### PR TITLE
Add diagnostics report

### DIFF
--- a/Sources/Store/DiagnosticsReport.swift
+++ b/Sources/Store/DiagnosticsReport.swift
@@ -36,8 +36,8 @@ struct BaselineDiagnosticsReport: Sendable {
         lines.append("- Refreshing: \(Self.yesNo(isRefreshing))")
         lines.append("- Auto refresh: \(Self.yesNo(autoRefreshEnabled))")
         lines.append("- Refresh interval: \(refreshIntervalMinutes) minutes")
-        if let lastRefreshMessage, !lastRefreshMessage.isEmpty {
-            lines.append("- Last message: \(lastRefreshMessage)")
+        if let safeLastRefreshMessage {
+            lines.append("- Last message: \(safeLastRefreshMessage)")
         }
         lines.append("")
         lines.append("Apps")
@@ -77,6 +77,15 @@ struct BaselineDiagnosticsReport: Sendable {
             }
             .joined(separator: ", ")
             .nilIfEmpty ?? "None"
+    }
+
+    private var safeLastRefreshMessage: String? {
+        lastRefreshMessage?
+            .split(whereSeparator: \.isNewline)
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
     }
 
     private static func format(_ date: Date) -> String {

--- a/Sources/Store/DiagnosticsReport.swift
+++ b/Sources/Store/DiagnosticsReport.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+struct BaselineDiagnosticsReport: Sendable {
+    let generatedAt: Date
+    let lastRefreshDate: Date?
+    let isRefreshing: Bool
+    let appCount: Int
+    let availableAppCount: Int
+    let installedAppCount: Int
+    let ignoredAppCount: Int
+    let recentlyUpdatedAppCount: Int
+    let homebrewItemCount: Int
+    let homebrewOutdatedCount: Int
+    let homebrewInstalledCount: Int
+    let homebrewIgnoredCount: Int
+    let homebrewRecentlyUpdatedCount: Int
+    let updateSourceCounts: [UpdateSource: Int]
+    let scanDirectories: [URL]
+    let additionalDirectoryCount: Int
+    let autoRefreshEnabled: Bool
+    let refreshIntervalMinutes: Int
+    let useMasForAppStoreUpdates: Bool
+    let isMasInstalled: Bool
+    let isHomebrewInstalled: Bool
+    let lastRefreshMessage: String?
+
+    func render() -> String {
+        var lines: [String] = []
+        lines.append("Baseline Diagnostics")
+        lines.append("Generated: \(Self.format(generatedAt))")
+        lines.append("macOS: \(ProcessInfo.processInfo.operatingSystemVersionString)")
+        lines.append("App version: \(Self.bundleVersionDescription())")
+        lines.append("")
+        lines.append("Refresh")
+        lines.append("- Last refresh: \(lastRefreshDate.map(Self.format) ?? "Never")")
+        lines.append("- Refreshing: \(Self.yesNo(isRefreshing))")
+        lines.append("- Auto refresh: \(Self.yesNo(autoRefreshEnabled))")
+        lines.append("- Refresh interval: \(refreshIntervalMinutes) minutes")
+        if let lastRefreshMessage, !lastRefreshMessage.isEmpty {
+            lines.append("- Last message: \(lastRefreshMessage)")
+        }
+        lines.append("")
+        lines.append("Apps")
+        lines.append("- Scanned apps: \(appCount)")
+        lines.append("- Available updates: \(availableAppCount)")
+        lines.append("- Installed/current: \(installedAppCount)")
+        lines.append("- Recently updated: \(recentlyUpdatedAppCount)")
+        lines.append("- Ignored: \(ignoredAppCount)")
+        lines.append("- Sources: \(sourceCountsDescription)")
+        lines.append("")
+        lines.append("Homebrew")
+        lines.append("- Items: \(homebrewItemCount)")
+        lines.append("- Outdated: \(homebrewOutdatedCount)")
+        lines.append("- Installed/current: \(homebrewInstalledCount)")
+        lines.append("- Recently updated: \(homebrewRecentlyUpdatedCount)")
+        lines.append("- Ignored: \(homebrewIgnoredCount)")
+        lines.append("- Homebrew available for helper install: \(Self.yesNo(isHomebrewInstalled))")
+        lines.append("")
+        lines.append("Optional Tools")
+        lines.append("- mas installed: \(Self.yesNo(isMasInstalled))")
+        lines.append("- Use mas for App Store updates: \(Self.yesNo(useMasForAppStoreUpdates))")
+        lines.append("")
+        lines.append("Scan Directories")
+        lines.append("- Custom directories: \(additionalDirectoryCount)")
+        for directory in scanDirectories {
+            lines.append("- \(directory.path)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private var sourceCountsDescription: String {
+        UpdateSource.allCases
+            .compactMap { source in
+                let count = updateSourceCounts[source] ?? 0
+                guard count > 0 else { return nil }
+                return "\(source.displayName): \(count)"
+            }
+            .joined(separator: ", ")
+            .nilIfEmpty ?? "None"
+    }
+
+    private static func format(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private static func yesNo(_ value: Bool) -> String {
+        value ? "Yes" : "No"
+    }
+
+    private static func bundleVersionDescription() -> String {
+        let bundle = Bundle.main
+        let shortVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+
+        switch (shortVersion, build) {
+        case let (short?, build?) where !short.isEmpty && !build.isEmpty:
+            return "\(short) (\(build))"
+        case let (short?, _) where !short.isEmpty:
+            return short
+        case let (_, build?) where !build.isEmpty:
+            return build
+        default:
+            return "Unknown"
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Sources/Store/UpdateStore.swift
+++ b/Sources/Store/UpdateStore.swift
@@ -942,6 +942,34 @@ final class UpdateStore {
         refreshErrorMessage = nil
     }
 
+    func diagnosticsReport() -> BaselineDiagnosticsReport {
+        BaselineDiagnosticsReport(
+            generatedAt: nowProvider(),
+            lastRefreshDate: lastRefreshDate,
+            isRefreshing: isRefreshing,
+            appCount: apps.count,
+            availableAppCount: availableApps.count,
+            installedAppCount: installedApps.count,
+            ignoredAppCount: ignoredApps.count,
+            recentlyUpdatedAppCount: recentlyUpdatedApps.count,
+            homebrewItemCount: homebrewItems.count,
+            homebrewOutdatedCount: homebrewOutdatedItems.count,
+            homebrewInstalledCount: homebrewInstalledItems.count,
+            homebrewIgnoredCount: homebrewIgnoredItems.count,
+            homebrewRecentlyUpdatedCount: homebrewRecentlyUpdatedItems.count,
+            updateSourceCounts: Dictionary(grouping: updatesByAppID.values, by: \.source)
+                .mapValues(\.count),
+            scanDirectories: scanDirectories,
+            additionalDirectoryCount: additionalDirectories.count,
+            autoRefreshEnabled: autoRefreshEnabled,
+            refreshIntervalMinutes: refreshIntervalMinutes,
+            useMasForAppStoreUpdates: useMasForAppStoreUpdates,
+            isMasInstalled: isMasInstalled,
+            isHomebrewInstalled: isHomebrewInstalledForMasInstall,
+            lastRefreshMessage: refreshErrorMessage
+        )
+    }
+
     private func requestRefresh(mode: RefreshMode) {
         if isRefreshing {
             if mode == .lightweight {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -1,9 +1,11 @@
+import AppKit
 import SwiftUI
 
 struct SettingsView: View {
     @Bindable var store: UpdateStore
     @Environment(\.openURL) private var openURL
     @State private var showsMasInstallPrompt = false
+    @State private var diagnosticsCopyMessage: String?
 
     var body: some View {
         GlassEffectContainer(spacing: 12) {
@@ -41,6 +43,12 @@ struct SettingsView: View {
                         }
                     )
 
+                    SettingsOptionalToolsCard(
+                        isMasInstalled: store.isMasInstalled,
+                        isHomebrewInstalled: store.isHomebrewInstalledForMasInstall,
+                        useMasForAppStoreUpdates: store.useMasForAppStoreUpdates
+                    )
+
                     SettingsDirectoriesCard(
                         scanDirectories: store.scanDirectories,
                         additionalDirectories: store.additionalDirectories,
@@ -51,6 +59,11 @@ struct SettingsView: View {
                     SettingsRefreshIntervalCard(
                         refreshIntervalMinutes: $store.refreshIntervalMinutes,
                         autoRefreshEnabled: $store.autoRefreshEnabled
+                    )
+
+                    SettingsDiagnosticsCard(
+                        copyMessage: diagnosticsCopyMessage,
+                        onCopy: copyDiagnosticsReport
                     )
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -80,6 +93,14 @@ struct SettingsView: View {
         }
     }
 
+    private func copyDiagnosticsReport() {
+        let report = store.diagnosticsReport().render()
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(report, forType: .string)
+        diagnosticsCopyMessage = "Diagnostics copied. Review before sharing."
+    }
+
     private var messageColor: Color {
         if store.masTestSucceeded == true {
             return .green
@@ -88,6 +109,107 @@ struct SettingsView: View {
             return .orange
         }
         return .secondary
+    }
+}
+
+private struct SettingsOptionalToolsCard: View {
+    let isMasInstalled: Bool
+    let isHomebrewInstalled: Bool
+    let useMasForAppStoreUpdates: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Readiness")
+                    .font(.headline)
+                Text("Baseline works without optional tools, but direct update actions improve when they are available.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            SettingsReadinessRow(
+                title: "Homebrew",
+                value: isHomebrewInstalled ? "Available" : "Not detected",
+                isReady: isHomebrewInstalled,
+                detail: isHomebrewInstalled
+                    ? "Homebrew cask and formula actions can run locally."
+                    : "Baseline will use external Homebrew pages for install or update actions."
+            )
+
+            SettingsReadinessRow(
+                title: "mas",
+                value: isMasInstalled ? "Available" : "Not detected",
+                isReady: isMasInstalled,
+                detail: isMasInstalled && useMasForAppStoreUpdates
+                    ? "App Store updates can start through mas when an item ID is available."
+                    : "App Store updates fall back to opening the App Store page."
+            )
+        }
+        .menuCardStyle()
+    }
+}
+
+private struct SettingsReadinessRow: View {
+    let title: String
+    let value: String
+    let isReady: Bool
+    let detail: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Circle()
+                .fill(isReady ? Color.green : Color.gray)
+                .frame(width: 10, height: 10)
+                .padding(.top, 4)
+
+            VStack(alignment: .leading, spacing: 1) {
+                HStack {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                    Text(value)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+        }
+    }
+}
+
+private struct SettingsDiagnosticsCard: View {
+    let copyMessage: String?
+    let onCopy: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Diagnostics")
+                        .font(.headline)
+                    Text("Copy a local report with counts, tool status, scan paths, and the latest non-sensitive refresh message.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button("Copy Report", action: onCopy)
+                    .menuSecondaryButtonStyle()
+                    .controlSize(.small)
+            }
+
+            if let copyMessage {
+                Text(copyMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .menuCardStyle()
     }
 }
 

--- a/Tests/DiagnosticsReportTests.swift
+++ b/Tests/DiagnosticsReportTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+@testable import Baseline
+
+@MainActor
+final class DiagnosticsReportTests: XCTestCase {
+    func testDiagnosticsReportIncludesCountsSourcesAndToolStatus() async {
+        let app = AppRecord(
+            bundleURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            displayName: "Example",
+            bundleIdentifier: "com.example.app",
+            localVersion: Version("1.0.0"),
+            sourceHint: .appStore,
+            sparkleFeedURL: nil
+        )
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let store = UpdateStore(
+            dependencies: UpdateStoreDependencies(
+                scanApplications: { _ in [app] },
+                lookupAppStore: { _, _ in
+                    AppStoreLookupResult(
+                        remoteVersion: Version("1.1.0"),
+                        updateURL: URL(string: "https://apps.apple.com/app/id1"),
+                        releaseNotesSummary: nil,
+                        releaseDate: nil,
+                        appStoreItemID: 1
+                    )
+                },
+                lookupSparkle: { _, _ in nil },
+                fetchHomebrewIndex: { .empty },
+                lookupHomebrew: { _, _, _, _ in nil },
+                fetchHomebrewInventory: { [] },
+                checkMasInstalled: { true },
+                checkHomebrewInstalled: { true },
+                runHomebrewUpgrade: { _ in true },
+                runHomebrewItemUpgrade: { _, _ in true },
+                runHomebrewMaintenanceCycle: { true }
+            ),
+            defaults: UserDefaults(suiteName: "DiagnosticsReportTests-\(UUID().uuidString)") ?? .standard,
+            nowProvider: { now }
+        )
+
+        store.refreshNow()
+        await waitUntil { !store.isRefreshing }
+        store.refreshMasSetupStatus()
+        await waitUntil { !store.isCheckingMas }
+
+        let report = store.diagnosticsReport()
+        let rendered = report.render()
+
+        XCTAssertEqual(report.appCount, 1)
+        XCTAssertEqual(report.availableAppCount, 1)
+        XCTAssertEqual(report.updateSourceCounts[.appStore], 1)
+        XCTAssertTrue(rendered.contains("Baseline Diagnostics"))
+        XCTAssertTrue(rendered.contains("App Store: 1"))
+        XCTAssertTrue(rendered.contains("mas installed: Yes"))
+        XCTAssertTrue(rendered.contains("Homebrew available for helper install: Yes"))
+    }
+
+    private func waitUntil(
+        _ predicate: @escaping @MainActor () -> Bool,
+        timeout: TimeInterval = 2.0
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertTrue(predicate())
+    }
+}

--- a/Tests/DiagnosticsReportTests.swift
+++ b/Tests/DiagnosticsReportTests.swift
@@ -57,6 +57,39 @@ final class DiagnosticsReportTests: XCTestCase {
         XCTAssertTrue(rendered.contains("Homebrew available for helper install: Yes"))
     }
 
+    func testDiagnosticsReportOmitsRawRefreshOutput() {
+        let report = BaselineDiagnosticsReport(
+            generatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            lastRefreshDate: nil,
+            isRefreshing: false,
+            appCount: 0,
+            availableAppCount: 0,
+            installedAppCount: 0,
+            ignoredAppCount: 0,
+            recentlyUpdatedAppCount: 0,
+            homebrewItemCount: 0,
+            homebrewOutdatedCount: 0,
+            homebrewInstalledCount: 0,
+            homebrewIgnoredCount: 0,
+            homebrewRecentlyUpdatedCount: 0,
+            updateSourceCounts: [:],
+            scanDirectories: [],
+            additionalDirectoryCount: 0,
+            autoRefreshEnabled: true,
+            refreshIntervalMinutes: 60,
+            useMasForAppStoreUpdates: true,
+            isMasInstalled: false,
+            isHomebrewInstalled: false,
+            lastRefreshMessage: "Homebrew uninstall failed for ProtonVPN.\n\nError: existing app at /Users/example/Applications/ProtonVPN.app"
+        )
+
+        let rendered = report.render()
+
+        XCTAssertTrue(rendered.contains("- Last message: Homebrew uninstall failed for ProtonVPN."))
+        XCTAssertFalse(rendered.contains("/Users/example"))
+        XCTAssertFalse(rendered.contains("existing app"))
+    }
+
     private func waitUntil(
         _ predicate: @escaping @MainActor () -> Bool,
         timeout: TimeInterval = 2.0


### PR DESCRIPTION
## Summary
- add a local Baseline diagnostics report renderer
- add a Settings card to copy the report for support/debugging
- cover report counts, source summaries, and optional tool status with tests

## Validation
- TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
- xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test