### PR TITLE
Preserve cached updates on transient lookup failures

### DIFF
--- a/Sources/Store/UpdateStore.swift
+++ b/Sources/Store/UpdateStore.swift
@@ -729,6 +729,7 @@ final class UpdateStore {
     private(set) var isRefreshing: Bool = false
     private(set) var lastRefreshDate: Date?
     private(set) var refreshErrorMessage: String?
+    private(set) var lastRefreshNoticeMessage: String?
     private(set) var isMasInstalled: Bool = false
     private(set) var isHomebrewInstalledForMasInstall: Bool = false
     private(set) var isCheckingMas: Bool = false
@@ -966,7 +967,7 @@ final class UpdateStore {
             useMasForAppStoreUpdates: useMasForAppStoreUpdates,
             isMasInstalled: isMasInstalled,
             isHomebrewInstalled: isHomebrewInstalledForMasInstall,
-            lastRefreshMessage: refreshErrorMessage
+            lastRefreshMessage: refreshErrorMessage ?? lastRefreshNoticeMessage
         )
     }
 
@@ -992,6 +993,7 @@ final class UpdateStore {
 
         isRefreshing = true
         refreshErrorMessage = nil
+        lastRefreshNoticeMessage = nil
         activeRefreshMode = mode
 
         refreshTask = Task {
@@ -1056,6 +1058,7 @@ final class UpdateStore {
         )
         lastRefreshDate = result.lastRefreshDate
         refreshErrorMessage = result.errorMessage
+        lastRefreshNoticeMessage = result.noticeMessage
         isRefreshing = false
         appUpdatedPendingRefreshIDs.removeAll()
         homebrewUpdatedPendingRefreshItemIDs.removeAll()
@@ -2693,6 +2696,7 @@ final class UpdateStore {
         var homebrewLookupMemo: [HomebrewLookupCacheKey: LookupOutcome<HomebrewLookupResult>] = [:]
 
         var updates: [String: UpdateRecord] = [:]
+        var transientLookupFailureCount = 0
 
         func cachedAppStoreLookup(
             bundleIdentifier: String,
@@ -2719,7 +2723,12 @@ final class UpdateStore {
             case .completed(let value):
                 cacheState.appStoreLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
-                cacheState.appStoreLookup.removeValue(forKey: key)
+                transientLookupFailureCount += 1
+                if let cached = cacheState.appStoreLookup[key] {
+                    let cachedOutcome = LookupOutcome<AppStoreLookupResult>.completed(value: cached.value)
+                    appStoreLookupMemo[key] = cachedOutcome
+                    return cachedOutcome
+                }
             }
             appStoreLookupMemo[key] = fetchedOutcome
             return fetchedOutcome
@@ -2750,7 +2759,12 @@ final class UpdateStore {
             case .completed(let value):
                 cacheState.sparkleLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
-                cacheState.sparkleLookup.removeValue(forKey: key)
+                transientLookupFailureCount += 1
+                if let cached = cacheState.sparkleLookup[key] {
+                    let cachedOutcome = LookupOutcome<SparkleLookupResult>.completed(value: cached.value)
+                    sparkleLookupMemo[key] = cachedOutcome
+                    return cachedOutcome
+                }
             }
             sparkleLookupMemo[key] = fetchedOutcome
             return fetchedOutcome
@@ -2788,7 +2802,12 @@ final class UpdateStore {
             case .completed(let value):
                 cacheState.homebrewLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
-                cacheState.homebrewLookup.removeValue(forKey: key)
+                transientLookupFailureCount += 1
+                if let cached = cacheState.homebrewLookup[key] {
+                    let cachedOutcome = LookupOutcome<HomebrewLookupResult>.completed(value: cached.value)
+                    homebrewLookupMemo[key] = cachedOutcome
+                    return cachedOutcome
+                }
             }
             homebrewLookupMemo[key] = fetchedOutcome
             return fetchedOutcome
@@ -2897,6 +2916,9 @@ final class UpdateStore {
             inferredHomebrewRecentlyUpdatedTransitions: sanitizedHomebrewInventory.inferredRecentlyUpdatedTransitions,
             lastRefreshDate: now,
             errorMessage: nil,
+            noticeMessage: transientLookupFailureCount > 0
+                ? "Some update checks could not be reached. Baseline kept available cached results where possible."
+                : nil,
             cacheState: cacheState
         )
     }
@@ -3095,6 +3117,7 @@ private struct RefreshResult {
     let inferredHomebrewRecentlyUpdatedTransitions: [InferredHomebrewRecentlyUpdatedTransition]
     let lastRefreshDate: Date
     let errorMessage: String?
+    let noticeMessage: String?
     let cacheState: RefreshCacheState
 }
 

--- a/Tests/UpdateStoreTests.swift
+++ b/Tests/UpdateStoreTests.swift
@@ -4433,6 +4433,7 @@ final class UpdateStoreTests: XCTestCase {
         store.refreshNow()
         await waitUntilRefreshFinishes(store)
         XCTAssertTrue(store.availableApps.isEmpty)
+        XCTAssertTrue(store.lastRefreshNoticeMessage?.contains("could not be reached") == true)
 
         let appStoreCallsAfterFailure = await appStoreLookupCalls.snapshot()
         let sparkleCallsAfterFailure = await sparkleLookupCalls.snapshot()
@@ -4450,6 +4451,7 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertEqual(store.updatesByAppID[sparkleApp.id]?.source, .sparkle)
         XCTAssertEqual(store.updatesByAppID[homebrewApp.id]?.source, .homebrew)
         XCTAssertEqual(Set(store.availableApps.map(\.displayName)), Set(["Store", "Sparkle", "BrewTool"]))
+        XCTAssertNil(store.lastRefreshNoticeMessage)
 
         let appStoreCalls = await appStoreLookupCalls.snapshot()
         let sparkleCalls = await sparkleLookupCalls.snapshot()
@@ -4457,6 +4459,70 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertEqual(appStoreCalls, 2)
         XCTAssertEqual(sparkleCalls, 2)
         XCTAssertEqual(homebrewCalls, 4)
+    }
+
+    func testFullRefreshKeepsCachedLookupResultAfterTransientFailure() async {
+        let phase = PhaseBox()
+        let now = DateBox(Date(timeIntervalSince1970: 1_700_075_000))
+        let appStoreLookupCalls = CounterBox()
+
+        let app = AppRecord(
+            bundleURL: URL(fileURLWithPath: "/Applications/Store.app"),
+            displayName: "Store",
+            bundleIdentifier: "com.example.store",
+            localVersion: Version("1.0"),
+            sourceHint: .appStore,
+            sparkleFeedURL: nil
+        )
+
+        let deps = UpdateStoreDependencies(
+            scanApplications: { _ in [app] },
+            lookupAppStore: { _, _ in nil },
+            lookupAppStoreOutcome: { _, _ in
+                await appStoreLookupCalls.increment()
+                guard phase.value > 0 else {
+                    return .completed(value: AppStoreLookupResult(
+                        remoteVersion: Version("2.0"),
+                        updateURL: URL(string: "https://apps.apple.com/app/id-store"),
+                        releaseNotesSummary: nil,
+                        releaseDate: nil
+                    ))
+                }
+                return .transientFailure
+            },
+            lookupSparkle: { _, _ in nil },
+            fetchHomebrewIndex: { .empty },
+            fetchHomebrewFormulaIndex: { .empty },
+            lookupHomebrew: { _, _, _, _ in nil },
+            fetchHomebrewInventory: { [] },
+            runHomebrewUpgrade: { _ in true },
+            runHomebrewItemUpgrade: { _, _ in true },
+            runHomebrewMaintenanceCycle: { true }
+        )
+
+        let store = UpdateStore(
+            dependencies: deps,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard,
+            nowProvider: { now.value }
+        )
+
+        phase.value = 0
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.remoteVersion, Version("2.0"))
+        XCTAssertNil(store.lastRefreshNoticeMessage)
+
+        phase.value = 1
+        now.value = now.value.addingTimeInterval(60)
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.remoteVersion, Version("2.0"))
+        XCTAssertTrue(store.lastRefreshNoticeMessage?.contains("kept available cached results") == true)
+
+        let appStoreCalls = await appStoreLookupCalls.snapshot()
+        XCTAssertEqual(appStoreCalls, 2)
     }
 
     func testFullRefreshBypassesFreshCachesAndRefetchesAllSources() async {


### PR DESCRIPTION
## Summary
- keep available cached lookup results when a full refresh hits transient source failures
- add a non-error refresh notice for unreachable update checks
- cover retry and cache-preservation behavior in store tests

## Validation
- TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
- xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test