### PR TITLE
Add preview release validation tooling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ Describe the change and why it is needed.
 - [ ] `TUIST_SKIP_UPDATE_CHECK=1 tuist build Baseline --configuration Debug`
 - [ ] `TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open`
 - [ ] `xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test`
+- [ ] Preview handoff only: `scripts/validate-preview.sh 0.0.0-preview`
 
 If any validation was not run, explain why.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ This project follows a lightweight changelog format inspired by Keep a Changelog
 ## Unreleased
 
 - Initial open-source repository preparation.
+- Added a local diagnostics report from Settings for support and troubleshooting.
+- Added preview validation and unsigned release preparation scripts.
+- Documented the preview validation checklist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,14 @@ xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=m
 
 If a command cannot run in your environment, mention that in the PR and include the failure output.
 
+For preview or release-candidate handoff, run:
+
+```bash
+scripts/validate-preview.sh 0.0.0-preview
+```
+
+Generated Tuist/Xcode artifacts, DerivedData, DMGs, and `dist/` output are intentionally ignored and should not be committed.
+
 ## Security-Sensitive Changes
 
 Be careful with code that:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ TUIST_SKIP_UPDATE_CHECK=1 tuist xcodebuild -project Baseline.xcodeproj -scheme B
 xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test
 ```
 
+For a fuller preview handoff, run:
+
+```bash
+scripts/validate-preview.sh 0.0.0-preview
+```
+
+This builds, tests, packages an unsigned DMG, installs `/Applications/Baseline.app`, and smoke-launches the installed copy.
+
 ## Package An Unsigned DMG
 
 ```bash
@@ -87,6 +95,12 @@ scripts/create-unsigned-dmg.sh 0.1.0
 ```
 
 The script builds a Release app, creates `dist/Baseline-0.1.0-unsigned.dmg`, and prints a SHA-256 checksum. See [docs/RELEASING.md](docs/RELEASING.md) for release steps and limitations.
+
+To create the unsigned DMG plus release-note checksum text:
+
+```bash
+scripts/prepare-unsigned-release.sh 0.1.0
+```
 
 ## Optional Local Tooling
 
@@ -104,6 +118,7 @@ Baseline keeps update logic outside SwiftUI views:
 - `Tests` covers parsers, version logic, store policy, security checks, and fixtures.
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for more detail.
+See [docs/VALIDATION.md](docs/VALIDATION.md) for preview validation.
 
 ## Privacy And Security
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -18,3 +18,11 @@ When CI is added, it should:
 - Build `Baseline`.
 - Run unit tests on `platform=macOS`.
 - Avoid committing generated project files.
+
+The closest local equivalent is:
+
+```bash
+scripts/validate-preview.sh 0.0.0-preview
+```
+
+That command also creates an unsigned DMG and smoke-launches the installed `/Applications/Baseline.app` copy, so it remains a local-only validation step until CI has a macOS desktop session capable of launching the app.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,14 +16,14 @@ TUIST_SKIP_UPDATE_CHECK=1 tuist xcodebuild -project Baseline.xcodeproj -scheme B
 xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test
 ```
 
-4. Build the unsigned DMG:
+4. Build the unsigned DMG and release-note checksum text:
 
 ```bash
-scripts/create-unsigned-dmg.sh 0.1.0
+scripts/prepare-unsigned-release.sh 0.1.0
 ```
 
 5. Upload `dist/Baseline-0.1.0-unsigned.dmg` to GitHub Releases.
-6. Include the printed SHA-256 checksum in the release notes.
+6. Use `dist/Baseline-0.1.0-unsigned-release-notes.md` as the release-note starting point.
 7. Clearly label the artifact as unsigned.
 
 ## Future Signed Release Path

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,40 @@
+# Validation
+
+Use this checklist before handing off a preview build or opening a release PR.
+
+## Known-Good Preview
+
+```bash
+scripts/validate-preview.sh 0.0.0-preview
+```
+
+The script checks ignored generated artifacts, lints release scripts, generates the project, builds Debug, runs unit tests, creates an unsigned DMG, installs the Debug app to `/Applications/Baseline.app`, and smoke-launches the installed app.
+
+## Manual Smoke Matrix
+
+Validate at least one item in each category when possible:
+
+- App Store app with an available update.
+- Sparkle or DevMate app with a valid appcast.
+- Homebrew cask app with an available update.
+- Homebrew formula with an available update.
+- Current app with no update.
+- Ignored app and ignored Homebrew item.
+- Unsupported app with only an external fallback.
+- App with malformed or missing update metadata.
+- Missing `mas` fallback path.
+- Missing Homebrew fallback path.
+
+## Release Artifact Check
+
+```bash
+scripts/prepare-unsigned-release.sh 0.1.0
+```
+
+Confirm:
+
+- `dist/Baseline-<version>-unsigned.dmg` exists.
+- `dist/Baseline-<version>-unsigned-release-notes.md` includes the SHA-256 checksum.
+- The release notes clearly describe the artifact as unsigned and not notarized.
+- The DMG opens and `Baseline.app` can be copied to `/Applications`.
+

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -37,4 +37,3 @@ Confirm:
 - `dist/Baseline-<version>-unsigned-release-notes.md` includes the SHA-256 checksum.
 - The release notes clearly describe the artifact as unsigned and not notarized.
 - The DMG opens and `Baseline.app` can be copied to `/Applications`.
-

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: scripts/prepare-unsigned-release.sh <version>"
+  exit 1
+fi
+
+VERSION="$1"
+APP_NAME="Baseline"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DMG_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned.dmg"
+NOTES_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned-release-notes.md"
+
+if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
+  echo "Version must look like 0.1.0 or 0.1.0-beta.1"
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if ! grep -q "## Unreleased" CHANGELOG.md; then
+  echo "CHANGELOG.md must contain an Unreleased section before preparing a release."
+  exit 1
+fi
+
+scripts/create-unsigned-dmg.sh "$VERSION"
+
+if [[ ! -f "$DMG_PATH" ]]; then
+  echo "Expected DMG was not created at $DMG_PATH"
+  exit 1
+fi
+
+CHECKSUM="$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
+
+cat > "$NOTES_PATH" <<NOTES
+# Baseline ${VERSION} unsigned preview
+
+This is an unsigned preview build. It is not notarized by Apple, and macOS may show an unidentified-developer warning.
+
+## Download
+
+- ${APP_NAME}-${VERSION}-unsigned.dmg
+
+## SHA-256
+
+\`\`\`text
+${CHECKSUM}  ${APP_NAME}-${VERSION}-unsigned.dmg
+\`\`\`
+
+## Install
+
+Open the DMG and drag ${APP_NAME}.app to /Applications.
+NOTES
+
+echo "Prepared unsigned release artifact:"
+echo "$DMG_PATH"
+echo
+echo "Prepared release notes:"
+echo "$NOTES_PATH"
+echo
+echo "SHA-256:"
+echo "${CHECKSUM}  ${APP_NAME}-${VERSION}-unsigned.dmg"
+

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -61,4 +61,3 @@ echo "$NOTES_PATH"
 echo
 echo "SHA-256:"
 echo "${CHECKSUM}  ${APP_NAME}-${VERSION}-unsigned.dmg"
-

--- a/scripts/validate-preview.sh
+++ b/scripts/validate-preview.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="Baseline"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DERIVED_DATA_PATH="$ROOT_DIR/.DerivedData"
+INSTALL_PATH="/Applications/${APP_NAME}.app"
+VERSION="${1:-0.0.0-preview}"
+
+cd "$ROOT_DIR"
+
+stop_existing_app() {
+  if ! pgrep -x "$APP_NAME" >/dev/null; then
+    return
+  fi
+
+  echo "Stopping existing ${APP_NAME} process"
+  osascript -e "tell application \"${APP_NAME}\" to quit" >/dev/null 2>&1 || true
+
+  for _ in {1..20}; do
+    if ! pgrep -x "$APP_NAME" >/dev/null; then
+      return
+    fi
+    sleep 0.25
+  done
+
+  pkill -x "$APP_NAME" >/dev/null 2>&1 || true
+  for _ in {1..20}; do
+    if ! pgrep -x "$APP_NAME" >/dev/null; then
+      return
+    fi
+    sleep 0.25
+  done
+
+  echo "Could not stop existing ${APP_NAME} process before smoke launch."
+  exit 1
+}
+
+echo "Checking generated artifacts are ignored"
+for ignored_path in "${APP_NAME}.xcodeproj" "${APP_NAME}.xcworkspace" ".DerivedData" "Derived" "dist"; do
+  git check-ignore -q "$ignored_path" || {
+    echo "Expected $ignored_path to be ignored."
+    exit 1
+  }
+done
+
+echo "Linting scripts"
+bash -n scripts/create-unsigned-dmg.sh
+bash -n scripts/prepare-unsigned-release.sh
+bash -n scripts/validate-preview.sh
+
+echo "Generating Xcode project"
+TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
+
+echo "Building Debug app"
+TUIST_SKIP_UPDATE_CHECK=1 tuist xcodebuild \
+  -project "${APP_NAME}.xcodeproj" \
+  -scheme "$APP_NAME" \
+  -configuration Debug \
+  -destination "platform=macOS" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  build
+
+echo "Running unit tests"
+xcodebuild \
+  -project "${APP_NAME}.xcodeproj" \
+  -scheme "$APP_NAME" \
+  -destination "platform=macOS" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  test
+
+echo "Creating unsigned preview DMG"
+scripts/create-unsigned-dmg.sh "$VERSION"
+
+DEBUG_APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug/${APP_NAME}.app"
+if [[ ! -d "$DEBUG_APP_PATH" ]]; then
+  echo "Debug app bundle was not found at $DEBUG_APP_PATH"
+  exit 1
+fi
+
+echo "Installing Debug app to $INSTALL_PATH"
+stop_existing_app
+rm -rf "$INSTALL_PATH"
+ditto "$DEBUG_APP_PATH" "$INSTALL_PATH"
+
+echo "Launching installed app"
+open "$INSTALL_PATH"
+
+for _ in {1..20}; do
+  if pgrep -x "$APP_NAME" >/dev/null; then
+    echo "Smoke launch succeeded."
+    echo "Known-good preview validation completed."
+    exit 0
+  fi
+  sleep 0.25
+done
+
+echo "Smoke launch failed; ${APP_NAME} process was not detected."
+exit 1


### PR DESCRIPTION
## Summary
- add a preview validation script that builds, tests, packages, installs, and smoke-launches Baseline
- add unsigned release preparation with checksum release-note text
- document the preview/release validation flow without adding a public roadmap

## Validation
- bash -n scripts/create-unsigned-dmg.sh && bash -n scripts/prepare-unsigned-release.sh && bash -n scripts/validate-preview.sh
- scripts/validate-preview.sh 0.0.0-preview