### PR TITLE
Preserve cached updates on transient lookup failures

### DIFF
--- a/Sources/Store/UpdateStore.swift
+++ b/Sources/Store/UpdateStore.swift
@@ -729,6 +729,7 @@ final class UpdateStore {
     private(set) var isRefreshing: Bool = false
     private(set) var lastRefreshDate: Date?
     private(set) var refreshErrorMessage: String?
+    private(set) var lastRefreshNoticeMessage: String?
     private(set) var isMasInstalled: Bool = false
     private(set) var isHomebrewInstalledForMasInstall: Bool = false
     private(set) var isCheckingMas: Bool = false
@@ -966,7 +967,7 @@ final class UpdateStore {
             useMasForAppStoreUpdates: useMasForAppStoreUpdates,
             isMasInstalled: isMasInstalled,
             isHomebrewInstalled: isHomebrewInstalledForMasInstall,
-            lastRefreshMessage: refreshErrorMessage
+            lastRefreshMessage: refreshErrorMessage ?? lastRefreshNoticeMessage
         )
     }
 
@@ -992,6 +993,7 @@ final class UpdateStore {
 
         isRefreshing = true
         refreshErrorMessage = nil
+        lastRefreshNoticeMessage = nil
         activeRefreshMode = mode
 
         refreshTask = Task {
@@ -1056,6 +1058,7 @@ final class UpdateStore {
         )
         lastRefreshDate = result.lastRefreshDate
         refreshErrorMessage = result.errorMessage
+        lastRefreshNoticeMessage = result.noticeMessage
         isRefreshing = false
         appUpdatedPendingRefreshIDs.removeAll()
         homebrewUpdatedPendingRefreshItemIDs.removeAll()
@@ -2693,6 +2696,7 @@ final class UpdateStore {
         var homebrewLookupMemo: [HomebrewLookupCacheKey: LookupOutcome<HomebrewLookupResult>] = [:]
 
         var updates: [String: UpdateRecord] = [:]
+        var transientLookupFailureCount = 0
 
         func cachedAppStoreLookup(
             bundleIdentifier: String,
@@ -2719,7 +2723,12 @@ final class UpdateStore {
             case .completed(let value):
                 cacheState.appStoreLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
-                cacheState.appStoreLookup.removeValue(forKey: key)
+                transientLookupFailureCount += 1
+                if let cached = cacheState.appStoreLookup[key] {
+                    let cachedOutcome = LookupOutcome<AppStoreLookupResult>.completed(value: cached.value)
+                    appStoreLookupMemo[key] = cachedOutcome
+                    return cachedOutcome
+                }
             }
             appStoreLookupMemo[key] = fetchedOutcome
             return fetchedOutcome
@@ -2750,7 +2759,12 @@ final class UpdateStore {
             case .completed(let value):
                 cacheState.sparkleLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
-                cacheState.sparkleLookup.removeValue(forKey: key)
+                transientLookupFailureCount += 1
+                if let cached = cacheState.sparkleLookup[key] {
+                    let cachedOutcome = LookupOutcome<SparkleLookupResult>.completed(value: cached.value)
+                    sparkleLookupMemo[key] = cachedOutcome
+                    return cachedOutcome
+                }
             }
             sparkleLookupMemo[key] = fetchedOutcome
             return fetchedOutcome
@@ -2788,7 +2802,12 @@ final class UpdateStore {
             case .completed(let value):
                 cacheState.homebrewLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
-                cacheState.homebrewLookup.removeValue(forKey: key)
+                transientLookupFailureCount += 1
+                if let cached = cacheState.homebrewLookup[key] {
+                    let cachedOutcome = LookupOutcome<HomebrewLookupResult>.completed(value: cached.value)
+                    homebrewLookupMemo[key] = cachedOutcome
+                    return cachedOutcome
+                }
             }
             homebrewLookupMemo[key] = fetchedOutcome
             return fetchedOutcome
@@ -2897,6 +2916,9 @@ final class UpdateStore {
             inferredHomebrewRecentlyUpdatedTransitions: sanitizedHomebrewInventory.inferredRecentlyUpdatedTransitions,
             lastRefreshDate: now,
             errorMessage: nil,
+            noticeMessage: transientLookupFailureCount > 0
+                ? "Some update checks could not be reached. Baseline kept available cached results where possible."
+                : nil,
             cacheState: cacheState
         )
     }
@@ -3095,6 +3117,7 @@ private struct RefreshResult {
     let inferredHomebrewRecentlyUpdatedTransitions: [InferredHomebrewRecentlyUpdatedTransition]
     let lastRefreshDate: Date
     let errorMessage: String?
+    let noticeMessage: String?
     let cacheState: RefreshCacheState
 }
 

--- a/Sources/Store/UpdateStore.swift
+++ b/Sources/Store/UpdateStore.swift
@@ -800,6 +800,7 @@ final class UpdateStore {
     private static let recentlyUpdatedLimit = 40
     private static let defaultExternalUpdateRefreshDelaySeconds: [UInt64] = [5, 15, 30, 60]
     private static let refreshCacheTTL: TimeInterval = 15 * 60
+    private static let staleRefreshCacheFallbackTTL: TimeInterval = 24 * 60 * 60
     private static let snapshotPersistDebounceNanoseconds: UInt64 = 140_000_000
 
     init(
@@ -2640,8 +2641,9 @@ final class UpdateStore {
         var cacheState = cacheState
         let shouldUseCache = mode.usesCachedValues
         let cacheTTL = refreshCacheTTL
+        let staleFallbackTTL = staleRefreshCacheFallbackTTL
 
-        cacheState.pruneExpired(now: now, ttl: cacheTTL)
+        cacheState.pruneExpired(now: now, ttl: staleFallbackTTL)
 
         let canUseCachedHomebrewIndex = shouldUseCache
             && (cacheState.homebrewIndex?.isFresh(at: now, ttl: cacheTTL) ?? false)
@@ -2687,9 +2689,6 @@ final class UpdateStore {
         cacheState.homebrewIndex = homebrewIndexEntry
         cacheState.homebrewFormulaIndex = homebrewFormulaIndexEntry
         cacheState.homebrewInventory = homebrewInventoryEntry
-        if !canUseCachedHomebrewIndex {
-            cacheState.homebrewLookup.removeAll()
-        }
 
         var appStoreLookupMemo: [AppStoreLookupCacheKey: LookupOutcome<AppStoreLookupResult>] = [:]
         var sparkleLookupMemo: [SparkleLookupCacheKey: LookupOutcome<SparkleLookupResult>] = [:]
@@ -2724,7 +2723,8 @@ final class UpdateStore {
                 cacheState.appStoreLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
                 transientLookupFailureCount += 1
-                if let cached = cacheState.appStoreLookup[key] {
+                if let cached = cacheState.appStoreLookup[key],
+                   cached.isFresh(at: now, ttl: staleFallbackTTL) {
                     let cachedOutcome = LookupOutcome<AppStoreLookupResult>.completed(value: cached.value)
                     appStoreLookupMemo[key] = cachedOutcome
                     return cachedOutcome
@@ -2760,7 +2760,8 @@ final class UpdateStore {
                 cacheState.sparkleLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
                 transientLookupFailureCount += 1
-                if let cached = cacheState.sparkleLookup[key] {
+                if let cached = cacheState.sparkleLookup[key],
+                   cached.isFresh(at: now, ttl: staleFallbackTTL) {
                     let cachedOutcome = LookupOutcome<SparkleLookupResult>.completed(value: cached.value)
                     sparkleLookupMemo[key] = cachedOutcome
                     return cachedOutcome
@@ -2803,7 +2804,8 @@ final class UpdateStore {
                 cacheState.homebrewLookup[key] = TimedCacheEntry(value: value, fetchedAt: now)
             case .transientFailure:
                 transientLookupFailureCount += 1
-                if let cached = cacheState.homebrewLookup[key] {
+                if let cached = cacheState.homebrewLookup[key],
+                   cached.isFresh(at: now, ttl: staleFallbackTTL) {
                     let cachedOutcome = LookupOutcome<HomebrewLookupResult>.completed(value: cached.value)
                     homebrewLookupMemo[key] = cachedOutcome
                     return cachedOutcome

--- a/Tests/UpdateStoreTests.swift
+++ b/Tests/UpdateStoreTests.swift
@@ -4461,7 +4461,7 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertEqual(homebrewCalls, 4)
     }
 
-    func testFullRefreshKeepsCachedLookupResultAfterTransientFailure() async {
+    func testFullRefreshKeepsStaleCachedLookupResultAfterTransientFailure() async {
         let phase = PhaseBox()
         let now = DateBox(Date(timeIntervalSince1970: 1_700_075_000))
         let appStoreLookupCalls = CounterBox()
@@ -4514,7 +4514,7 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertNil(store.lastRefreshNoticeMessage)
 
         phase.value = 1
-        now.value = now.value.addingTimeInterval(60)
+        now.value = now.value.addingTimeInterval((15 * 60) + 1)
         store.refreshNow()
         await waitUntilRefreshFinishes(store)
 
@@ -4523,6 +4523,131 @@ final class UpdateStoreTests: XCTestCase {
 
         let appStoreCalls = await appStoreLookupCalls.snapshot()
         XCTAssertEqual(appStoreCalls, 2)
+    }
+
+    func testFullRefreshDropsStaleCachedLookupResultAfterFallbackWindow() async {
+        let phase = PhaseBox()
+        let now = DateBox(Date(timeIntervalSince1970: 1_700_076_000))
+        let appStoreLookupCalls = CounterBox()
+
+        let app = AppRecord(
+            bundleURL: URL(fileURLWithPath: "/Applications/Store.app"),
+            displayName: "Store",
+            bundleIdentifier: "com.example.store",
+            localVersion: Version("1.0"),
+            sourceHint: .appStore,
+            sparkleFeedURL: nil
+        )
+
+        let deps = UpdateStoreDependencies(
+            scanApplications: { _ in [app] },
+            lookupAppStore: { _, _ in nil },
+            lookupAppStoreOutcome: { _, _ in
+                await appStoreLookupCalls.increment()
+                guard phase.value > 0 else {
+                    return .completed(value: AppStoreLookupResult(
+                        remoteVersion: Version("2.0"),
+                        updateURL: URL(string: "https://apps.apple.com/app/id-store"),
+                        releaseNotesSummary: nil,
+                        releaseDate: nil
+                    ))
+                }
+                return .transientFailure
+            },
+            lookupSparkle: { _, _ in nil },
+            fetchHomebrewIndex: { .empty },
+            fetchHomebrewFormulaIndex: { .empty },
+            lookupHomebrew: { _, _, _, _ in nil },
+            fetchHomebrewInventory: { [] },
+            runHomebrewUpgrade: { _ in true },
+            runHomebrewItemUpgrade: { _, _ in true },
+            runHomebrewMaintenanceCycle: { true }
+        )
+
+        let store = UpdateStore(
+            dependencies: deps,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard,
+            nowProvider: { now.value }
+        )
+
+        phase.value = 0
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.remoteVersion, Version("2.0"))
+
+        phase.value = 1
+        now.value = now.value.addingTimeInterval((24 * 60 * 60) + 1)
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertNil(store.updatesByAppID[app.id])
+        XCTAssertTrue(store.lastRefreshNoticeMessage?.contains("could not be reached") == true)
+
+        let appStoreCalls = await appStoreLookupCalls.snapshot()
+        XCTAssertEqual(appStoreCalls, 2)
+    }
+
+    func testFullRefreshKeepsStaleHomebrewLookupResultAfterIndexRefetch() async {
+        let phase = PhaseBox()
+        let now = DateBox(Date(timeIntervalSince1970: 1_700_077_000))
+        let homebrewLookupCalls = CounterBox()
+
+        let app = AppRecord(
+            bundleURL: URL(fileURLWithPath: "/Applications/BrewTool.app"),
+            displayName: "BrewTool",
+            bundleIdentifier: nil,
+            localVersion: Version("1.0"),
+            sourceHint: .unknown,
+            sparkleFeedURL: nil
+        )
+
+        let deps = UpdateStoreDependencies(
+            scanApplications: { _ in [app] },
+            lookupAppStore: { _, _ in nil },
+            lookupSparkle: { _, _ in nil },
+            fetchHomebrewIndex: { .empty },
+            fetchHomebrewFormulaIndex: { .empty },
+            lookupHomebrew: { _, _, _, _ in nil },
+            lookupHomebrewOutcome: { _, _, _, _ in
+                await homebrewLookupCalls.increment()
+                guard phase.value > 0 else {
+                    return .completed(value: HomebrewLookupResult(
+                        remoteVersion: Version("2.0"),
+                        token: "brew-tool",
+                        homepageURL: URL(string: "https://formulae.brew.sh/cask/brew-tool")
+                    ))
+                }
+                return .transientFailure
+            },
+            fetchHomebrewInventory: { [] },
+            runHomebrewUpgrade: { _ in true },
+            runHomebrewItemUpgrade: { _, _ in true },
+            runHomebrewMaintenanceCycle: { true }
+        )
+
+        let store = UpdateStore(
+            dependencies: deps,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard,
+            nowProvider: { now.value }
+        )
+
+        phase.value = 0
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.source, .homebrew)
+
+        phase.value = 1
+        now.value = now.value.addingTimeInterval((15 * 60) + 1)
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.source, .homebrew)
+        XCTAssertTrue(store.lastRefreshNoticeMessage?.contains("kept available cached results") == true)
+
+        let homebrewCalls = await homebrewLookupCalls.snapshot()
+        XCTAssertEqual(homebrewCalls, 2)
     }
 
     func testFullRefreshBypassesFreshCachesAndRefetchesAllSources() async {

--- a/Tests/UpdateStoreTests.swift
+++ b/Tests/UpdateStoreTests.swift
@@ -4433,6 +4433,7 @@ final class UpdateStoreTests: XCTestCase {
         store.refreshNow()
         await waitUntilRefreshFinishes(store)
         XCTAssertTrue(store.availableApps.isEmpty)
+        XCTAssertTrue(store.lastRefreshNoticeMessage?.contains("could not be reached") == true)
 
         let appStoreCallsAfterFailure = await appStoreLookupCalls.snapshot()
         let sparkleCallsAfterFailure = await sparkleLookupCalls.snapshot()
@@ -4450,6 +4451,7 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertEqual(store.updatesByAppID[sparkleApp.id]?.source, .sparkle)
         XCTAssertEqual(store.updatesByAppID[homebrewApp.id]?.source, .homebrew)
         XCTAssertEqual(Set(store.availableApps.map(\.displayName)), Set(["Store", "Sparkle", "BrewTool"]))
+        XCTAssertNil(store.lastRefreshNoticeMessage)
 
         let appStoreCalls = await appStoreLookupCalls.snapshot()
         let sparkleCalls = await sparkleLookupCalls.snapshot()
@@ -4457,6 +4459,70 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertEqual(appStoreCalls, 2)
         XCTAssertEqual(sparkleCalls, 2)
         XCTAssertEqual(homebrewCalls, 4)
+    }
+
+    func testFullRefreshKeepsCachedLookupResultAfterTransientFailure() async {
+        let phase = PhaseBox()
+        let now = DateBox(Date(timeIntervalSince1970: 1_700_075_000))
+        let appStoreLookupCalls = CounterBox()
+
+        let app = AppRecord(
+            bundleURL: URL(fileURLWithPath: "/Applications/Store.app"),
+            displayName: "Store",
+            bundleIdentifier: "com.example.store",
+            localVersion: Version("1.0"),
+            sourceHint: .appStore,
+            sparkleFeedURL: nil
+        )
+
+        let deps = UpdateStoreDependencies(
+            scanApplications: { _ in [app] },
+            lookupAppStore: { _, _ in nil },
+            lookupAppStoreOutcome: { _, _ in
+                await appStoreLookupCalls.increment()
+                guard phase.value > 0 else {
+                    return .completed(value: AppStoreLookupResult(
+                        remoteVersion: Version("2.0"),
+                        updateURL: URL(string: "https://apps.apple.com/app/id-store"),
+                        releaseNotesSummary: nil,
+                        releaseDate: nil
+                    ))
+                }
+                return .transientFailure
+            },
+            lookupSparkle: { _, _ in nil },
+            fetchHomebrewIndex: { .empty },
+            fetchHomebrewFormulaIndex: { .empty },
+            lookupHomebrew: { _, _, _, _ in nil },
+            fetchHomebrewInventory: { [] },
+            runHomebrewUpgrade: { _ in true },
+            runHomebrewItemUpgrade: { _, _ in true },
+            runHomebrewMaintenanceCycle: { true }
+        )
+
+        let store = UpdateStore(
+            dependencies: deps,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard,
+            nowProvider: { now.value }
+        )
+
+        phase.value = 0
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.remoteVersion, Version("2.0"))
+        XCTAssertNil(store.lastRefreshNoticeMessage)
+
+        phase.value = 1
+        now.value = now.value.addingTimeInterval(60)
+        store.refreshNow()
+        await waitUntilRefreshFinishes(store)
+
+        XCTAssertEqual(store.updatesByAppID[app.id]?.remoteVersion, Version("2.0"))
+        XCTAssertTrue(store.lastRefreshNoticeMessage?.contains("kept available cached results") == true)
+
+        let appStoreCalls = await appStoreLookupCalls.snapshot()
+        XCTAssertEqual(appStoreCalls, 2)
     }
 
     func testFullRefreshBypassesFreshCachesAndRefetchesAllSources() async {


### PR DESCRIPTION
## Summary
- preserve cached update results when lightweight refresh lookups fail transiently
- add coverage for retrying transient failures without caching nil results

## Validation
- Not run; validation not recorded before merge.
