### PR TITLE
Fix Homebrew placeholder icon appearance updates

### DIFF
--- a/Sources/Models/IconAppearance.swift
+++ b/Sources/Models/IconAppearance.swift
@@ -1,0 +1,25 @@
+import AppKit
+import SwiftUI
+
+enum IconAppearance: String, Sendable {
+    case light
+    case dark
+
+    init(colorScheme: ColorScheme) {
+        switch colorScheme {
+        case .dark:
+            self = .dark
+        default:
+            self = .light
+        }
+    }
+
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .light:
+            NSAppearance(named: .aqua)
+        case .dark:
+            NSAppearance(named: .darkAqua)
+        }
+    }
+}

--- a/Sources/Store/UpdateStore.swift
+++ b/Sources/Store/UpdateStore.swift
@@ -1876,10 +1876,9 @@ final class UpdateStore {
     }
 
     func icon(for item: HomebrewManagedItem, appearance: IconAppearance) -> NSImage {
-        let usesFallbackIcon = item.kind != .cask || matchingApp(for: item) == nil
         let cacheKey = HomebrewIconCacheKey(
             itemID: item.id,
-            appearance: usesFallbackIcon ? appearance : nil
+            appearance: appearance
         )
 
         if let cached = homebrewIconCache[cacheKey] {

--- a/Sources/Store/UpdateStore.swift
+++ b/Sources/Store/UpdateStore.swift
@@ -588,6 +588,11 @@ private struct HomebrewLookupCacheKey: Hashable {
     let localVersion: Version
 }
 
+private struct HomebrewIconCacheKey: Hashable {
+    let itemID: String
+    let appearance: IconAppearance?
+}
+
 private struct RefreshCacheState {
     var homebrewIndex: TimedCacheEntry<HomebrewCaskIndex>?
     var homebrewFormulaIndex: TimedCacheEntry<HomebrewFormulaIndex>?
@@ -786,7 +791,7 @@ final class UpdateStore {
     @ObservationIgnored private var pendingExternalUpdateRefreshTasks: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var hasStarted = false
     @ObservationIgnored private var iconCache: [String: NSImage] = [:]
-    @ObservationIgnored private var homebrewIconCache: [String: NSImage] = [:]
+    @ObservationIgnored private var homebrewIconCache: [HomebrewIconCacheKey: NSImage] = [:]
     @ObservationIgnored private var appReleaseDateCache: [String: Date] = [:]
     @ObservationIgnored private var refreshCacheState = RefreshCacheState()
     @ObservationIgnored private var isHydratingPersistedSnapshot = false
@@ -1867,7 +1872,17 @@ final class UpdateStore {
     }
 
     func icon(for item: HomebrewManagedItem) -> NSImage {
-        if let cached = homebrewIconCache[item.id] {
+        icon(for: item, appearance: .light)
+    }
+
+    func icon(for item: HomebrewManagedItem, appearance: IconAppearance) -> NSImage {
+        let usesFallbackIcon = item.kind != .cask || matchingApp(for: item) == nil
+        let cacheKey = HomebrewIconCacheKey(
+            itemID: item.id,
+            appearance: usesFallbackIcon ? appearance : nil
+        )
+
+        if let cached = homebrewIconCache[cacheKey] {
             return cached
         }
 
@@ -1875,7 +1890,7 @@ final class UpdateStore {
         if item.kind == .cask, let app = matchingApp(for: item) {
             baseIcon = appIcon(for: app)
         } else {
-            baseIcon = fallbackIcon(for: item.kind)
+            baseIcon = fallbackIcon(for: item.kind, appearance: appearance)
         }
 
         let resolvedIcon = (baseIcon.copy() as? NSImage) ?? baseIcon
@@ -1883,12 +1898,16 @@ final class UpdateStore {
             width: MenuPresentationMetrics.rowIconSize,
             height: MenuPresentationMetrics.rowIconSize
         )
-        homebrewIconCache[item.id] = resolvedIcon
+        homebrewIconCache[cacheKey] = resolvedIcon
         return resolvedIcon
     }
 
     func icon(for item: HomebrewCaskDiscoveryItem) -> NSImage {
-        fallbackIcon(for: item.kind)
+        icon(for: item, appearance: .light)
+    }
+
+    func icon(for item: HomebrewCaskDiscoveryItem, appearance: IconAppearance) -> NSImage {
+        fallbackIcon(for: item.kind, appearance: appearance)
     }
 
     func releaseDate(for app: AppRecord) -> Date {
@@ -2377,18 +2396,18 @@ final class UpdateStore {
         appReleaseDateCache = appReleaseDateCache.filter { validIDs.contains($0.key) }
 
         let validHomebrewIDs = Set(homebrewItems.map(\.id))
-        homebrewIconCache = homebrewIconCache.filter { validHomebrewIDs.contains($0.key) }
+        homebrewIconCache = homebrewIconCache.filter { validHomebrewIDs.contains($0.key.itemID) }
     }
 
-    private func fallbackIcon(for kind: HomebrewManagedItemKind) -> NSImage {
+    private func fallbackIcon(for kind: HomebrewManagedItemKind, appearance: IconAppearance) -> NSImage {
         let symbolName = kind == .formula ? "terminal" : "shippingbox"
-        if let placeholder = placeholderIcon(symbolName: symbolName) {
+        if let placeholder = placeholderIcon(symbolName: symbolName, appearance: appearance) {
             return placeholder
         }
         return NSWorkspace.shared.icon(for: .application)
     }
 
-    private func placeholderIcon(symbolName: String) -> NSImage? {
+    private func placeholderIcon(symbolName: String, appearance: IconAppearance) -> NSImage? {
         guard let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) else {
             return nil
         }
@@ -2402,44 +2421,52 @@ final class UpdateStore {
             weight: .medium
         )
         let configuredSymbol = symbol.withSymbolConfiguration(symbolConfig) ?? symbol
-        let colorConfig = NSImage.SymbolConfiguration(
-            hierarchicalColor: NSColor.labelColor.withAlphaComponent(MenuPresentationMetrics.homebrewPlaceholderGlyphAlpha)
-        )
-        let tintedSymbol = configuredSymbol.withSymbolConfiguration(colorConfig) ?? configuredSymbol
 
         let image = NSImage(size: canvasSize)
-        image.lockFocus()
+        let drawPlaceholder = {
+            image.lockFocus()
 
-        let backgroundRect = NSRect(
-            x: (canvasSize.width - placeholderSizeValue) * 0.5,
-            y: (canvasSize.height - placeholderSizeValue) * 0.5,
-            width: placeholderSizeValue,
-            height: placeholderSizeValue
-        )
-        let backgroundPath = NSBezierPath(
-            roundedRect: backgroundRect,
-            xRadius: MenuPresentationMetrics.rowIconCornerRadius * MenuPresentationMetrics.homebrewPlaceholderBoxScale,
-            yRadius: MenuPresentationMetrics.rowIconCornerRadius * MenuPresentationMetrics.homebrewPlaceholderBoxScale
-        )
-        NSColor.tertiaryLabelColor.withAlphaComponent(0.18).setFill()
-        backgroundPath.fill()
+            let backgroundRect = NSRect(
+                x: (canvasSize.width - placeholderSizeValue) * 0.5,
+                y: (canvasSize.height - placeholderSizeValue) * 0.5,
+                width: placeholderSizeValue,
+                height: placeholderSizeValue
+            )
+            let backgroundPath = NSBezierPath(
+                roundedRect: backgroundRect,
+                xRadius: MenuPresentationMetrics.rowIconCornerRadius * MenuPresentationMetrics.homebrewPlaceholderBoxScale,
+                yRadius: MenuPresentationMetrics.rowIconCornerRadius * MenuPresentationMetrics.homebrewPlaceholderBoxScale
+            )
+            NSColor.tertiaryLabelColor.withAlphaComponent(0.18).setFill()
+            backgroundPath.fill()
 
-        let glyphRect = NSRect(
-            x: (canvasSize.width - glyphSizeValue) * 0.5,
-            y: (canvasSize.height - glyphSizeValue) * 0.5,
-            width: glyphSizeValue,
-            height: glyphSizeValue
-        )
-        tintedSymbol.draw(
-            in: glyphRect,
-            from: .zero,
-            operation: .sourceOver,
-            fraction: 1,
-            respectFlipped: true,
-            hints: nil
-        )
+            let colorConfig = NSImage.SymbolConfiguration(
+                hierarchicalColor: NSColor.labelColor.withAlphaComponent(MenuPresentationMetrics.homebrewPlaceholderGlyphAlpha)
+            )
+            let tintedSymbol = configuredSymbol.withSymbolConfiguration(colorConfig) ?? configuredSymbol
+            let glyphRect = NSRect(
+                x: (canvasSize.width - glyphSizeValue) * 0.5,
+                y: (canvasSize.height - glyphSizeValue) * 0.5,
+                width: glyphSizeValue,
+                height: glyphSizeValue
+            )
+            tintedSymbol.draw(
+                in: glyphRect,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1,
+                respectFlipped: true,
+                hints: nil
+            )
 
-        image.unlockFocus()
+            image.unlockFocus()
+        }
+
+        if let nsAppearance = appearance.nsAppearance {
+            nsAppearance.performAsCurrentDrawingAppearance(drawPlaceholder)
+        } else {
+            drawPlaceholder()
+        }
         return image
     }
 

--- a/Sources/Views/MenuRootView.swift
+++ b/Sources/Views/MenuRootView.swift
@@ -52,6 +52,7 @@ private enum MenuActionConfirmation: Identifiable {
 struct MenuRootView: View {
     @Bindable var store: UpdateStore
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.colorScheme) private var colorScheme
     @State private var selectedTab: MenuTab
     @State private var renderedTab: MenuTab
     @State private var isSearchPresented = false
@@ -132,7 +133,8 @@ struct MenuRootView: View {
                             isUninstallingHomebrewItem: store.isUninstallingHomebrewItem(_:),
                             isHomebrewItemUpdatedPendingRefresh: store.isHomebrewItemUpdatedPendingRefresh(_:),
                             onUpdateAllHomebrew: updateAllHomebrew,
-                            iconForItem: store.icon(for:),
+                            iconAppearance: IconAppearance(colorScheme: colorScheme),
+                            iconForItem: store.icon(for:appearance:),
                             canOpenFromIcon: store.canOpenHomebrewItem(_:),
                             onOpenFromIcon: store.openHomebrewItem(_:),
                             releaseDateForItem: store.releaseDate(for:),
@@ -141,7 +143,7 @@ struct MenuRootView: View {
                             onUpdate: store.performHomebrewUpdate(for:),
                             onRequestUninstall: requestUninstallConfirmation(for:),
                             onRequestInstall: requestInstallConfirmation(for:),
-                            iconForDiscoverItem: store.icon(for:),
+                            iconForDiscoverItem: store.icon(for:appearance:),
                             canOpenDiscoverFromIcon: store.canOpenHomebrewDiscoverItem(_:),
                             onOpenDiscoverFromIcon: store.openHomebrewDiscoverItem(_:),
                             isInstallingDiscoverItem: store.isInstallingHomebrewDiscoverItem(_:),
@@ -906,7 +908,8 @@ private struct HomebrewContentCard: View {
     let isUninstallingHomebrewItem: (HomebrewManagedItem) -> Bool
     let isHomebrewItemUpdatedPendingRefresh: (HomebrewManagedItem) -> Bool
     let onUpdateAllHomebrew: () -> Void
-    let iconForItem: (HomebrewManagedItem) -> NSImage
+    let iconAppearance: IconAppearance
+    let iconForItem: (HomebrewManagedItem, IconAppearance) -> NSImage
     let canOpenFromIcon: (HomebrewManagedItem) -> Bool
     let onOpenFromIcon: (HomebrewManagedItem) -> Void
     let releaseDateForItem: (HomebrewManagedItem) -> Date
@@ -915,7 +918,7 @@ private struct HomebrewContentCard: View {
     let onUpdate: (HomebrewManagedItem) -> Void
     let onRequestUninstall: (HomebrewManagedItem) -> Void
     let onRequestInstall: (HomebrewCaskDiscoveryItem) -> Void
-    let iconForDiscoverItem: (HomebrewCaskDiscoveryItem) -> NSImage
+    let iconForDiscoverItem: (HomebrewCaskDiscoveryItem, IconAppearance) -> NSImage
     let canOpenDiscoverFromIcon: (HomebrewCaskDiscoveryItem) -> Bool
     let onOpenDiscoverFromIcon: (HomebrewCaskDiscoveryItem) -> Void
     let isInstallingDiscoverItem: (HomebrewCaskDiscoveryItem) -> Bool
@@ -946,7 +949,7 @@ private struct HomebrewContentCard: View {
                     } else {
                         ForEach(Array(discoverItems.enumerated()), id: \.element.id) { index, item in
                             HomebrewDiscoverRowView(
-                                icon: Image(nsImage: iconForDiscoverItem(item)),
+                                icon: Image(nsImage: iconForDiscoverItem(item, iconAppearance)),
                                 item: item,
                                 canOpenFromIcon: canOpenDiscoverFromIcon(item),
                                 isInstalling: isInstallingDiscoverItem(item),
@@ -1002,7 +1005,7 @@ private struct HomebrewContentCard: View {
                         } else {
                             ForEach(visibleItems, id: \.element.id) { index, item in
                                 HomebrewRowView(
-                                    icon: Image(nsImage: iconForItem(item)),
+                                    icon: Image(nsImage: iconForItem(item, iconAppearance)),
                                     item: item,
                                     releaseDate: releaseDateForItem(item),
                                     recentlyUpdatedDate: section.showsUpdatedOnDate ? recentlyUpdatedDateForItem(item) : nil,

--- a/Tests/UpdateStoreTests.swift
+++ b/Tests/UpdateStoreTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import XCTest
 @testable import Baseline
@@ -116,6 +117,20 @@ final class UpdateStoreTests: XCTestCase {
         let homebrewIndexStartedAt: Date?
         let homebrewFormulaIndexStartedAt: Date?
         let homebrewInventoryStartedAt: Date?
+    }
+
+    private func renderedBitmapBytes(for image: NSImage) -> [UInt8] {
+        guard
+            let tiffRepresentation = image.tiffRepresentation,
+            let representation = NSBitmapImageRep(data: tiffRepresentation),
+            let bitmapData = representation.bitmapData
+        else {
+            XCTFail("Expected image to produce a bitmap representation")
+            return []
+        }
+
+        let byteCount = representation.bytesPerRow * representation.pixelsHigh
+        return Array(UnsafeBufferPointer(start: bitmapData, count: byteCount))
     }
 
     actor RefreshTimelineBox {
@@ -3750,6 +3765,77 @@ final class UpdateStoreTests: XCTestCase {
         XCTAssertFalse(store.canOpenHomebrewDiscoverItem(entry))
         store.openHomebrewDiscoverItem(entry)
         XCTAssertTrue(externalOpenCalls.snapshot().isEmpty)
+    }
+
+    func testHomebrewFormulaPlaceholderIconDiffersByAppearance() {
+        let store = UpdateStore(
+            dependencies: .live,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard
+        )
+        let item = HomebrewManagedItem(
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: .formula,
+            installedVersion: Version("14.1.0"),
+            latestVersion: nil,
+            isOutdated: false
+        )
+
+        let lightIcon = store.icon(for: item, appearance: .light)
+        let darkIcon = store.icon(for: item, appearance: .dark)
+
+        XCTAssertNotEqual(
+            renderedBitmapBytes(for: lightIcon),
+            renderedBitmapBytes(for: darkIcon)
+        )
+    }
+
+    func testHomebrewPlaceholderIconCacheSeparatesAppearances() {
+        let store = UpdateStore(
+            dependencies: .live,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard
+        )
+        let item = HomebrewManagedItem(
+            token: "wget",
+            name: "wget",
+            kind: .formula,
+            installedVersion: Version("1.25.0"),
+            latestVersion: nil,
+            isOutdated: false
+        )
+
+        let firstLightIcon = store.icon(for: item, appearance: .light)
+        let secondLightIcon = store.icon(for: item, appearance: .light)
+        let darkIcon = store.icon(for: item, appearance: .dark)
+
+        XCTAssertTrue(firstLightIcon === secondLightIcon)
+        XCTAssertFalse(firstLightIcon === darkIcon)
+        XCTAssertNotEqual(
+            renderedBitmapBytes(for: firstLightIcon),
+            renderedBitmapBytes(for: darkIcon)
+        )
+    }
+
+    func testHomebrewDiscoveryPlaceholderIconDiffersByAppearance() {
+        let store = UpdateStore(
+            dependencies: .live,
+            defaults: UserDefaults(suiteName: "UpdateStoreTests-\(UUID().uuidString)") ?? .standard
+        )
+        let entry = HomebrewCaskDiscoveryItem(
+            kind: .cask,
+            token: "notion",
+            displayName: "notion",
+            version: Version("7.9.0"),
+            homepageURL: nil
+        )
+
+        let lightIcon = store.icon(for: entry, appearance: .light)
+        let darkIcon = store.icon(for: entry, appearance: .dark)
+
+        XCTAssertNotEqual(
+            renderedBitmapBytes(for: lightIcon),
+            renderedBitmapBytes(for: darkIcon)
+        )
     }
 
     func testInstalledFormulaRemainsNonOpenableFromIconAction() async {


### PR DESCRIPTION
## Summary
- render Homebrew placeholder icons with an explicit light/dark appearance
- include appearance in placeholder-backed Homebrew icon cache keys
- pass SwiftUI color scheme through the Homebrew menu icon path
- add bitmap-level regression tests for light/dark placeholder rendering

Fixes #15

## Validation
- TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
- xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test
- bash -n ./run-menubar.sh
- bash -n ./stop-menubar.sh
- ./run-menubar.sh
