### PR TITLE
Add CI and unsigned DMG release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Build and test
+    runs-on: macos-26
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Tuist
+        run: brew install tuist
+
+      - name: Lint shell scripts
+        run: |
+          bash -n scripts/create-unsigned-dmg.sh
+          bash -n scripts/prepare-unsigned-release.sh
+          bash -n scripts/validate-preview.sh
+
+      - name: Generate Xcode project
+        run: TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
+
+      - name: Build Debug app
+        run: |
+          xcodebuild \
+            -project Baseline.xcodeproj \
+            -scheme Baseline \
+            -configuration Debug \
+            -destination "platform=macOS" \
+            -derivedDataPath .DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY= \
+            DEVELOPMENT_TEAM= \
+            build
+
+      - name: Run unit tests
+        run: |
+          xcodebuild \
+            -project Baseline.xcodeproj \
+            -scheme Baseline \
+            -destination "platform=macOS" \
+            -derivedDataPath .DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY= \
+            DEVELOPMENT_TEAM= \
+            test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release unsigned DMG
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  unsigned-dmg:
+    name: Build and publish unsigned DMG
+    runs-on: macos-26
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Derive version from tag
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+
+          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
+            echo "Tag must look like v0.1.0 or v0.1.0-beta.1"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install Tuist
+        run: brew install tuist
+
+      - name: Prepare unsigned release artifacts
+        run: scripts/prepare-unsigned-release.sh "${{ steps.version.outputs.version }}"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            "dist/Baseline-${VERSION}-unsigned.dmg" \
+            "dist/Baseline-${VERSION}-unsigned.dmg.sha256" \
+            --title "Baseline ${VERSION} unsigned preview" \
+            --notes-file "dist/Baseline-${VERSION}-unsigned-release-notes.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ This project follows a lightweight changelog format inspired by Keep a Changelog
 - Initial open-source repository preparation.
 - Added a local diagnostics report from Settings for support and troubleshooting.
 - Added preview validation and unsigned release preparation scripts.
+- Added GitHub Actions CI and unsigned DMG release publishing.
 - Documented the preview validation checklist.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Unsigned builds are not notarized by Apple. macOS Gatekeeper may warn when openi
 
 ## Download
 
-Downloadable preview builds, when available, are published on the GitHub Releases page as unsigned DMGs.
+Preview builds are published on the GitHub Releases page as unsigned DMGs.
 
 For each release:
 - Download `Baseline-<version>-unsigned.dmg`.
-- Verify the published SHA-256 checksum if one is provided.
+- Verify the published SHA-256 checksum.
 - Drag `Baseline.app` to `/Applications`.
 
 Because the app is unsigned, macOS may show an unidentified-developer warning. This is expected for preview builds without an Apple Developer account.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,10 +1,19 @@
 # Continuous Integration
 
-This repository intentionally does not include a GitHub Actions workflow yet.
+This repository uses GitHub Actions for pull request and `main` branch validation.
 
-Baseline currently targets macOS 26. CI should be added once the public macOS runner image and Xcode version can reliably build and test that deployment target.
+Baseline targets macOS 26, so CI runs on GitHub's `macos-26` hosted runner.
 
-Until then, validate changes locally:
+The CI workflow:
+- Installs Tuist with Homebrew.
+- Lints release scripts with `bash -n`.
+- Generates the Xcode project.
+- Builds the Debug app with code signing disabled.
+- Runs unit tests on `platform=macOS`.
+
+CI intentionally does not launch the menubar app. Installed-app smoke validation still requires the local desktop session.
+
+The local equivalent for build and test validation is:
 
 ```bash
 TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
@@ -12,17 +21,12 @@ TUIST_SKIP_UPDATE_CHECK=1 tuist xcodebuild -project Baseline.xcodeproj -scheme B
 xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test
 ```
 
-When CI is added, it should:
-- Install or bootstrap Tuist.
-- Generate the Xcode project.
-- Build `Baseline`.
-- Run unit tests on `platform=macOS`.
-- Avoid committing generated project files.
-
-The closest local equivalent is:
+For full preview validation, run:
 
 ```bash
 scripts/validate-preview.sh 0.0.0-preview
 ```
 
-That command also creates an unsigned DMG and smoke-launches the installed `/Applications/Baseline.app` copy, so it remains a local-only validation step until CI has a macOS desktop session capable of launching the app.
+That command also creates an unsigned DMG and smoke-launches the installed `/Applications/Baseline.app` copy.
+
+Unsigned DMG release publishing is handled by `.github/workflows/release.yml` when a `vX.Y.Z` tag is pushed.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,7 +8,7 @@ Unsigned DMGs are not notarized by Apple. macOS Gatekeeper may warn users before
 
 1. Choose a version, for example `0.1.0`.
 2. Update `CHANGELOG.md`.
-3. Run validation:
+3. Run local validation:
 
 ```bash
 TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
@@ -16,15 +16,28 @@ TUIST_SKIP_UPDATE_CHECK=1 tuist xcodebuild -project Baseline.xcodeproj -scheme B
 xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test
 ```
 
-4. Build the unsigned DMG and release-note checksum text:
+4. Optionally preview the unsigned release artifacts locally:
 
 ```bash
 scripts/prepare-unsigned-release.sh 0.1.0
 ```
 
-5. Upload `dist/Baseline-0.1.0-unsigned.dmg` to GitHub Releases.
-6. Use `dist/Baseline-0.1.0-unsigned-release-notes.md` as the release-note starting point.
-7. Clearly label the artifact as unsigned.
+5. Commit the release prep changes.
+6. Push `main`.
+7. Create and push the release tag:
+
+```bash
+git tag v0.1.0
+git push baseline v0.1.0
+```
+
+8. The GitHub Actions release workflow builds the unsigned DMG, writes `dist/Baseline-0.1.0-unsigned.dmg.sha256`, creates the GitHub Release, and uploads both files.
+9. Verify the GitHub Release contains:
+   - `Baseline-0.1.0-unsigned.dmg`
+   - `Baseline-0.1.0-unsigned.dmg.sha256`
+   - release notes that clearly label the artifact as unsigned.
+
+The release workflow accepts tags like `v0.1.0` and `v0.1.0-beta.1`.
 
 ## Future Signed Release Path
 

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -10,6 +10,7 @@ VERSION="$1"
 APP_NAME="Baseline"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DMG_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned.dmg"
+CHECKSUM_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned.dmg.sha256"
 NOTES_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned-release-notes.md"
 
 if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
@@ -33,6 +34,8 @@ fi
 
 CHECKSUM="$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
 
+echo "${CHECKSUM}  ${APP_NAME}-${VERSION}-unsigned.dmg" > "$CHECKSUM_PATH"
+
 cat > "$NOTES_PATH" <<NOTES
 # Baseline ${VERSION} unsigned preview
 
@@ -55,6 +58,9 @@ NOTES
 
 echo "Prepared unsigned release artifact:"
 echo "$DMG_PATH"
+echo
+echo "Prepared checksum:"
+echo "$CHECKSUM_PATH"
 echo
 echo "Prepared release notes:"
 echo "$NOTES_PATH"


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI for Baseline and tag-driven unsigned DMG release publishing.

## Changes

- Add CI workflow on PRs and pushes to `main` using `macos-26`.
- Add release workflow for `vX.Y.Z` tags that builds unsigned DMGs and publishes GitHub Releases.
- Add `.sha256` sidecar generation to `scripts/prepare-unsigned-release.sh`.
- Update README, CI docs, release docs, and changelog to describe the automated path.

## Validation
- `bash -n scripts/create-unsigned-dmg.sh scripts/prepare-unsigned-release.sh scripts/validate-preview.sh`
- YAML parse check for both workflow files
- `TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open`
- `xcodebuild ... test` passed: 122 tests
- `scripts/prepare-unsigned-release.sh 0.0.0-preview` produced DMG, release notes, and `.sha256`; checksum matched
