### PR TITLE
Fix Electron migration review findings

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BundleScannerClient } from "../src/main/bundleScanner";
+
+vi.mock("electron", () => ({
+  app: {
+    getFileIcon: vi.fn(async () => ({
+      isEmpty: () => true,
+      resize: () => ({ toDataURL: () => "" })
+    }))
+  },
+  nativeImage: {
+    createFromPath: vi.fn(() => ({
+      isEmpty: () => true,
+      resize: () => ({ toDataURL: () => "" })
+    }))
+  }
+}));
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+describe("bundle scanner", () => {
+  it("recursively finds apps without descending into app bundles", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    await writeAppPlist(path.join(root, "Direct.app"), {
+      displayName: "Direct",
+      bundleIdentifier: "com.example.direct",
+      version: "1.0.0"
+    });
+    await writeAppPlist(path.join(root, "Vendor", "Nested.app"), {
+      displayName: "Nested",
+      bundleIdentifier: "com.example.nested",
+      version: "2.0.0"
+    });
+    await writeAppPlist(
+      path.join(root, "Vendor", "Nested.app", "Contents", "PlugIns", "Hidden.app"),
+      {
+        displayName: "Hidden",
+        bundleIdentifier: "com.example.hidden",
+        version: "3.0.0"
+      }
+    );
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records.map((record) => record.displayName)).toEqual(["Direct", "Nested"]);
+    expect(records.map((record) => record.bundleIdentifier)).toEqual([
+      "com.example.direct",
+      "com.example.nested"
+    ]);
+  });
+});
+
+async function writeAppPlist(
+  appPath: string,
+  {
+    displayName,
+    bundleIdentifier,
+    version
+  }: { displayName: string; bundleIdentifier: string; version: string }
+): Promise<void> {
+  await mkdir(path.join(appPath, "Contents"), { recursive: true });
+  await writeFile(
+    path.join(appPath, "Contents", "Info.plist"),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>${displayName}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${bundleIdentifier}</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${version}</string>
+</dict>
+</plist>
+`
+  );
+}

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -7,7 +7,8 @@ import {
   Dashboard,
   DiscoverRow,
   HomebrewRow,
-  HomebrewSection
+  HomebrewSection,
+  SettingsView
 } from "../src/renderer/main";
 import type {
   AppRecord,
@@ -85,6 +86,7 @@ function installBaselineMock() {
     getSnapshot: vi.fn(),
     getDiagnostics: vi.fn(),
     getToolStatus: vi.fn(),
+    refreshToolStatus: vi.fn(),
     refresh: vi.fn(),
     setSearchText: vi.fn(),
     setSelectedTab: vi.fn(),
@@ -762,5 +764,14 @@ describe("renderer button parity", () => {
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
       collapsedAppSectionIDs: []
     });
+  });
+
+  it("rechecks tool readiness from settings without running a refresh", () => {
+    render(<SettingsView snapshot={snapshot()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Check Again" }));
+
+    expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);
+    expect(window.baseline.refresh).not.toHaveBeenCalled();
   });
 });

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -39,9 +39,19 @@ export class BundleScannerClient {
   private async findApps(directory: string): Promise<string[]> {
     try {
       const entries = await readdir(directory, { withFileTypes: true });
-      return entries
-        .filter((entry) => entry.isDirectory() && entry.name.endsWith(".app"))
-        .map((entry) => path.join(directory, entry.name));
+      const apps: string[] = [];
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const entryPath = path.join(directory, entry.name);
+        if (entry.name.endsWith(".app")) {
+          apps.push(entryPath);
+          continue;
+        }
+        apps.push(...(await this.findApps(entryPath)));
+      }
+      return apps;
     } catch {
       return [];
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -331,6 +331,7 @@ function wireIpc(): void {
       masTestSucceeded: snapshot.masTestSucceeded
     };
   });
+  ipcMain.handle(ipcChannels.refreshToolStatus, () => store.refreshToolStatus());
   ipcMain.handle(ipcChannels.refresh, (_event, lightweight?: boolean) =>
     store.refresh(Boolean(lightweight))
   );

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -7,6 +7,7 @@ const api: BaselineAPI = {
   getSnapshot: () => ipcRenderer.invoke(ipcChannels.getSnapshot),
   getDiagnostics: () => ipcRenderer.invoke(ipcChannels.getDiagnostics),
   getToolStatus: () => ipcRenderer.invoke(ipcChannels.getToolStatus),
+  refreshToolStatus: () => ipcRenderer.invoke(ipcChannels.refreshToolStatus),
   refresh: (lightweight?: boolean) => ipcRenderer.invoke(ipcChannels.refresh, lightweight),
   setSearchText: (searchText: string) => ipcRenderer.invoke(ipcChannels.setSearchText, searchText),
   setSelectedTab: (tab) => ipcRenderer.invoke(ipcChannels.setSelectedTab, tab),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1295,7 +1295,7 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
   return "Update failed";
 }
 
-function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
+export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
   const [diagnosticsCopied, setDiagnosticsCopied] = useState(false);
   const derived = useMemo(() => deriveSections(snapshot), [snapshot]);
 
@@ -1324,7 +1324,7 @@ function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
             <div className="settings-action">
               <button
                 className="ghost-button wide"
-                onClick={() => void window.baseline.refresh(true)}
+                onClick={() => void window.baseline.refreshToolStatus()}
               >
                 Check Again
               </button>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -11,6 +11,7 @@ export const ipcChannels = {
   getSnapshot: "baseline:getSnapshot",
   getDiagnostics: "baseline:getDiagnostics",
   getToolStatus: "baseline:getToolStatus",
+  refreshToolStatus: "baseline:refreshToolStatus",
   refresh: "baseline:refresh",
   setSearchText: "baseline:setSearchText",
   setSelectedTab: "baseline:setSelectedTab",
@@ -54,6 +55,7 @@ export type BaselineAPI = {
   getSnapshot(): Promise<BaselineSnapshot>;
   getDiagnostics(): Promise<string>;
   getToolStatus(): Promise<ToolStatus>;
+  refreshToolStatus(): Promise<void>;
   refresh(lightweight?: boolean): Promise<void>;
   setSearchText(searchText: string): Promise<void>;
   setSelectedTab(tab: MenuTab): Promise<void>;


### PR DESCRIPTION
## Summary

- Recursively scan configured app directories while stopping at discovered `.app` bundles.
- Add a typed `refreshToolStatus` IPC/preload API for rechecking Homebrew and `mas` readiness.
- Wire the Settings “Check Again” button to recheck tool readiness instead of running a lightweight refresh.
- Add regression coverage for nested app scanning and the Settings readiness button.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:electron`
- `npm audit --omit=dev --audit-level=high`
