### PR TITLE
Refresh docs for Electron main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,5 @@
 .DS_Store
 
-# Tuist/Xcode generated artifacts
-.DerivedData/
-Derived/
-Baseline.xcodeproj/
-Baseline.xcworkspace/
-
-# Swift/Xcode local build output
-.build/
-DerivedData/
-*.xcuserstate
-xcuserdata/
-
 # Release packaging output
 dist/
 *.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ This project follows a lightweight changelog format inspired by Keep a Changelog
 ## Unreleased
 
 - Initial open-source repository preparation.
+- Migrated Baseline from Swift/Tuist to Electron, Vite, React, TypeScript, and Tailwind.
+- Added a full app window alongside the compact menu bar tray window.
+- Added Electron tests and Playwright Electron smoke coverage.
+- Added Homebrew cask/formula inventory, update, install, discovery, and uninstall flows.
+- Preserved public update detection through App Store lookup, Sparkle/DevMate appcasts, and Homebrew metadata.
 - Added a local diagnostics report from Settings for support and troubleshooting.
 - Added preview validation and unsigned release preparation scripts.
 - Added GitHub Actions CI and unsigned DMG release publishing.
 - Documented the preview validation checklist.
+- Removed the legacy Swift/Tuist source from `main`; the previous implementation is archived at branch `legacy/swift-tuist` and tag `swift-tuist-final`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,27 @@
 # Contributing to Baseline
 
-Thanks for helping improve Baseline. This project is a macOS menubar app built with SwiftUI and Tuist.
+Thanks for helping improve Baseline. This project is a macOS Electron app built
+with Vite, React, TypeScript, and Tailwind.
 
 ## Development Setup
 
 Requirements:
-- macOS 26 or newer
-- Xcode with Swift 6 support
-- Tuist
 
-Install Tuist:
+- macOS
+- Node.js 25 or newer
+- npm
 
-```bash
-brew install tuist
-```
-
-Generate the project:
+Install dependencies:
 
 ```bash
-TUIST_SKIP_UPDATE_CHECK=1 tuist generate
+npm ci
 ```
 
-Open `Baseline.xcworkspace` in Xcode and run the `Baseline` scheme.
+Run the app during development:
+
+```bash
+npm start
+```
 
 ## Branches And Pull Requests
 
@@ -29,30 +29,45 @@ Open `Baseline.xcworkspace` in Xcode and run the `Baseline` scheme.
 - Keep pull requests small enough to review.
 - Include tests for behavior changes.
 - Update docs when user-facing behavior, setup, or release steps change.
-- Do not commit generated Xcode/Tuist artifacts.
+- Do not commit generated outputs such as `node_modules/`, `out/`, `.vite/`,
+  `dist/`, `coverage/`, `test-results/`, or `playwright-report/`.
 
 ## Architecture Guidelines
 
 Baseline is intentionally layered:
 
-- Models define stable domain contracts.
-- Clients perform source-specific IO and mapping.
-- Store code coordinates refresh lifecycle, policy, persistence, and actions.
-- SwiftUI views render state and dispatch intents only.
+- `src/shared` defines stable domain contracts, IPC types, security policy,
+  version logic, and shared parsers.
+- `src/main` owns Electron lifecycle, windows/tray, persistence, filesystem
+  access, network clients, subprocess execution, and update policy.
+- `src/main/preload.ts` exposes the narrow typed `window.baseline` API.
+- `src/renderer` renders React state and dispatches user intents only.
+- `ElectronTests` and `e2e` cover unit and Electron smoke behavior.
 
-Avoid adding networking, filesystem scanning, subprocess execution, or business-policy decisions directly inside SwiftUI view bodies.
+Avoid adding networking, filesystem scanning, subprocess execution, shell access,
+or update-source policy directly inside React components.
 
 ## Validation
 
 Run these before opening a pull request:
 
 ```bash
-TUIST_SKIP_UPDATE_CHECK=1 tuist generate --no-open
-TUIST_SKIP_UPDATE_CHECK=1 tuist xcodebuild -project Baseline.xcodeproj -scheme Baseline -configuration Debug -destination 'platform=macOS' -derivedDataPath .DerivedData build
-xcodebuild -project Baseline.xcodeproj -scheme Baseline -destination 'platform=macOS' -derivedDataPath .DerivedData test
+npm run typecheck
+npm test
+npm run lint
+npm run format
+npm run build
+npm run test:electron
 ```
 
-If a command cannot run in your environment, mention that in the PR and include the failure output.
+Production dependency audit:
+
+```bash
+npm audit --omit=dev --audit-level=high
+```
+
+If a command cannot run in your environment, mention that in the PR and include
+the failure output.
 
 For preview or release-candidate handoff, run:
 
@@ -60,14 +75,15 @@ For preview or release-candidate handoff, run:
 scripts/validate-preview.sh 0.0.0-preview
 ```
 
-Generated Tuist/Xcode artifacts, DerivedData, DMGs, and `dist/` output are intentionally ignored and should not be committed.
-
 ## Security-Sensitive Changes
 
 Be careful with code that:
+
 - Runs `brew`, `mas`, or other local executables.
 - Parses remote update metadata.
 - Opens external URLs.
 - Writes persisted app state.
+- Expands the preload/IPC API.
 
-Prefer typed inputs, allowlisted executable resolution, and conservative fallback behavior.
+Prefer typed inputs, validated executable resolution, argument arrays,
+allowlisted external URLs, and conservative fallback behavior.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,8 +10,9 @@ Use GitHub Issues for:
 
 Before opening an issue, include:
 - macOS version.
-- Xcode version.
-- Tuist version.
+- Install path or build path used to run Baseline.
+- Whether Homebrew and/or `mas` is installed, if the issue involves updates.
+- Node.js and npm versions, if the issue involves building from source.
 - Baseline version or commit.
 - Relevant logs or screenshots.
 


### PR DESCRIPTION
## Summary

- Updates public contributor guidance from the old Swift/Tuist flow to the Electron/Vite/React/TypeScript stack.
- Updates support issue guidance to ask for Electron/source-build details instead of Xcode/Tuist versions.
- Expands the changelog with the Electron migration, full app window, Homebrew inventory/discovery work, and legacy archive note.
- Removes stale Xcode/Tuist generated artifact ignore rules from `.gitignore`.

Local-only cleanup also completed outside this PR:

- Updated ignored `AGENTS.md` and `agent-docs/*.md` for the Electron architecture and workflow.
- Deleted old ignored local Xcode/Tuist generated directories and legacy helper scripts from this checkout.

## Validation
- Not run; documentation-only change.
