### PR TITLE
Fix Homebrew retry failure state

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -325,6 +325,65 @@ describe("update store helpers", () => {
     expect(runBrewCommand).not.toHaveBeenCalled();
     expect(store.getSnapshot().refreshErrorMessage).toContain("Blocked unsafe Homebrew token");
   });
+
+  it("clears Homebrew failed marker after a successful retry", async () => {
+    const itemID = "formula:libgpg-error";
+    const runBrewCommand = vi.fn(
+      async (_args: string[], onOutputLine: (line: string) => void = () => undefined) => {
+        if (runBrewCommand.mock.calls.length === 1) {
+          onOutputLine("Error: libgpg-error failed");
+          return { success: false, status: 1, output: "Error: libgpg-error failed" };
+        }
+        onOutputLine("Pouring libgpg-error--1.61.arm64_tahoe.bottle.tar.gz");
+        onOutputLine("🍺  /opt/homebrew/Cellar/libgpg-error/1.61: 50 files, 1.9MB");
+        return { success: true, status: 0, output: "" };
+      }
+    );
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: itemID,
+            token: "libgpg-error",
+            name: "libgpg-error",
+            kind: "formula",
+            installedVersion: version("1.60"),
+            latestVersion: version("1.61"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand,
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: itemID,
+                token: "libgpg-error",
+                name: "libgpg-error",
+                kind: "formula",
+                installedVersion: version("1.60"),
+                latestVersion: version("1.61"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.performHomebrewUpdate(itemID);
+    expect(store.getSnapshot().homebrewBatchFailedItemIDs).toContain(itemID);
+
+    await store.performHomebrewUpdate(itemID);
+    const snapshot = store.getSnapshot();
+    expect(snapshot.homebrewBatchFailedItemIDs).not.toContain(itemID);
+    expect(snapshot.refreshErrorMessage).toBeUndefined();
+  });
 });
 
 async function makeStore({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -312,6 +312,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       });
       if (result) {
         this.patch({
+          refreshErrorMessage: undefined,
+          homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID),
           homebrewUpdatedPendingRefreshItemIDs: addToArray(
             this.state.homebrewUpdatedPendingRefreshItemIDs,
             itemID
@@ -392,6 +394,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       homebrewUpdatingItemIDs: this.state.homebrewUpdatingItemIDs.filter(
         (id) => !affectedIDs.includes(id)
       ),
+      homebrewBatchFailedItemIDs: success
+        ? this.state.homebrewBatchFailedItemIDs.filter((id) => !affectedIDs.includes(id))
+        : this.state.homebrewBatchFailedItemIDs,
       homebrewUpdatedPendingRefreshItemIDs: success
         ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...affectedIDs])]
         : this.state.homebrewUpdatedPendingRefreshItemIDs,


### PR DESCRIPTION
## Summary

- Clear the Homebrew batch failure marker when a single-item retry succeeds.
- Clear failed markers for affected items after a successful Homebrew maintenance cycle.
- Add a regression test for retrying a failed formula update successfully.

## Why

A Homebrew item could remain marked as failed after a subsequent successful retry, leaving stale failure state in the snapshot even though the update command completed.

## Validation
- `npm test -- ElectronTests/updateStore.test.ts`
- `npm run typecheck`
