### PR TITLE
Fix menu bar window positioning

### DIFF
--- a/ElectronTests/trayWindowPosition.test.ts
+++ b/ElectronTests/trayWindowPosition.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { calculateTrayWindowPosition } from "../src/main/trayWindowPosition";
+
+describe("tray window positioning", () => {
+  it("centers the compact window under the tray item without a vertical gap", () => {
+    expect(
+      calculateTrayWindowPosition(
+        { x: 900, y: 0, width: 24, height: 24 },
+        { x: 0, y: 0, width: 440, height: 560 },
+        { workArea: { x: 0, y: 24, width: 1440, height: 876 } }
+      )
+    ).toEqual({ x: 692, y: 24 });
+  });
+
+  it("clamps the compact window to the left edge of the matched display work area", () => {
+    expect(
+      calculateTrayWindowPosition(
+        { x: 10, y: 0, width: 24, height: 24 },
+        { x: 0, y: 0, width: 440, height: 560 },
+        { workArea: { x: 0, y: 24, width: 1440, height: 876 } }
+      )
+    ).toEqual({ x: 0, y: 24 });
+  });
+
+  it("clamps the compact window to the right edge of the matched display work area", () => {
+    expect(
+      calculateTrayWindowPosition(
+        { x: 1420, y: 0, width: 24, height: 24 },
+        { x: 0, y: 0, width: 440, height: 560 },
+        { workArea: { x: 0, y: 24, width: 1440, height: 876 } }
+      )
+    ).toEqual({ x: 1000, y: 24 });
+  });
+
+  it("uses the matched display work area when clamping multi-display positions", () => {
+    expect(
+      calculateTrayWindowPosition(
+        { x: -1180, y: 0, width: 24, height: 24 },
+        { x: 0, y: 0, width: 440, height: 560 },
+        { workArea: { x: -1280, y: 24, width: 1280, height: 776 } }
+      )
+    ).toEqual({ x: -1280, y: 24 });
+  });
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,10 +1,21 @@
-import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeImage, shell, Tray } from "electron";
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  ipcMain,
+  nativeImage,
+  screen,
+  shell,
+  Tray
+} from "electron";
 import path from "node:path";
 import { renderDiagnostics } from "../shared/diagnostics";
 import type { BaselineSnapshot, HomebrewCaskDiscoveryItem, MenuTab } from "../shared/domain";
 import { ipcChannels, type PreferencePatch } from "../shared/ipc";
 import { isAllowedExternalURL } from "../shared/security";
 import { SnapshotPersistence } from "./persistence";
+import { calculateTrayWindowPosition } from "./trayWindowPosition";
 import { UpdateStore } from "./updateStore";
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -83,6 +94,7 @@ app.on("window-all-closed", () => undefined);
 app.on("before-quit", () => {
   isQuitting = true;
 });
+app.on("did-resign-active", hideMenuWindowForNativeDismissal);
 
 function createMainWindow(route: "main" | "settings"): BrowserWindow {
   mainWindow =
@@ -145,11 +157,7 @@ function createMenuWindow(): BrowserWindow {
       }
     });
 
-  menuWindow.on("blur", () => {
-    if (!isDevelopment) {
-      menuWindow?.hide();
-    }
-  });
+  menuWindow.on("blur", hideMenuWindowForNativeDismissal);
 
   void loadRenderer(menuWindow, "menubar");
   return menuWindow;
@@ -192,14 +200,18 @@ function toggleMenuWindow(): void {
   if (tray) {
     const bounds = tray.getBounds();
     const windowBounds = window.getBounds();
-    window.setPosition(
-      Math.round(bounds.x + bounds.width / 2 - windowBounds.width / 2),
-      Math.round(bounds.y + bounds.height + 6),
-      false
-    );
+    const display = screen.getDisplayMatching(bounds);
+    const position = calculateTrayWindowPosition(bounds, windowBounds, display);
+    window.setPosition(position.x, position.y, false);
   }
   window.setAlwaysOnTop(true, "pop-up-menu");
-  window.showInactive();
+  window.show();
+}
+
+function hideMenuWindowForNativeDismissal(): void {
+  if (!isDevelopment) {
+    menuWindow?.hide();
+  }
 }
 
 function showMainWindow(route: "main" | "settings"): void {

--- a/src/main/trayWindowPosition.ts
+++ b/src/main/trayWindowPosition.ts
@@ -1,0 +1,24 @@
+import type { Display, Rectangle } from "electron";
+
+type TrayDisplay = Pick<Display, "workArea">;
+
+export function calculateTrayWindowPosition(
+  trayBounds: Rectangle,
+  windowBounds: Rectangle,
+  display: TrayDisplay
+): { x: number; y: number } {
+  const proposedX = trayBounds.x + trayBounds.width / 2 - windowBounds.width / 2;
+  const minX = display.workArea.x;
+  const maxX = display.workArea.x + display.workArea.width - windowBounds.width;
+  const x = clamp(proposedX, minX, Math.max(minX, maxX));
+  const y = trayBounds.y + trayBounds.height;
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y)
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -313,7 +313,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       if (result) {
         this.patch({
           refreshErrorMessage: undefined,
-          homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID),
+          homebrewBatchFailedItemIDs: removeFromArray(
+            this.state.homebrewBatchFailedItemIDs,
+            itemID
+          ),
           homebrewUpdatedPendingRefreshItemIDs: addToArray(
             this.state.homebrewUpdatedPendingRefreshItemIDs,
             itemID


### PR DESCRIPTION
## Summary
- Align the compact menu bar window to the tray item without the previous hard-coded vertical gap.
- Clamp the compact window horizontally within the matched display work area.
- Show the compact window as a focused popover so normal focus loss can dismiss it.
- Add unit coverage for the tray positioning helper.

Fixes #22

## Validation
- npm run typecheck
- npm test
- npm run lint
## Notes
The native macOS behavior where opening another menu bar extra dismisses Baseline still needs a separate follow-up approach; this PR keeps the focus-loss dismissal path and fixes the issue #22 positioning work.
