### PR TITLE
Collapse toolbar search on outside click

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -252,6 +252,45 @@ describe("renderer button parity", () => {
     expect(window.baseline.setSearchText).toHaveBeenCalledWith("");
   });
 
+  it("opens toolbar search and collapses it on outside click without clearing text", () => {
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ searchText: "obsidian" })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close Search" }));
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(window.baseline.setSearchText).not.toHaveBeenCalled();
+  });
+
+  it("keeps toolbar search open for clicks inside the search controls", () => {
+    render(
+      <Dashboard
+        compact
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ searchText: "raycast" })}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByPlaceholderText("Search"));
+    expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear Search" }));
+
+    expect(window.baseline.setSearchText).toHaveBeenCalledWith("");
+    expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
+  });
+
   it("does not render an app open action button when no update exists", () => {
     render(
       <AppRow

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -144,6 +144,7 @@ export function Dashboard({
               open={toolbarSearchOpen}
               snapshot={snapshot}
               onToggle={() => setToolbarSearchOpen((open) => !open)}
+              onClose={() => setToolbarSearchOpen(false)}
             />
             <button
               className="toolbar-button refresh-button"
@@ -177,6 +178,7 @@ export function Dashboard({
                 open={toolbarSearchOpen}
                 snapshot={snapshot}
                 onToggle={() => setToolbarSearchOpen((open) => !open)}
+                onClose={() => setToolbarSearchOpen(false)}
               />
               <button
                 className="toolbar-button refresh-button"
@@ -300,12 +302,15 @@ function Sidebar({
 function ToolbarSearch({
   open,
   snapshot,
-  onToggle
+  onToggle,
+  onClose
 }: {
   open: boolean;
   snapshot: BaselineSnapshot;
   onToggle: () => void;
+  onClose: () => void;
 }) {
+  const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -315,13 +320,29 @@ function ToolbarSearch({
     }
   }, [open]);
 
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && !rootRef.current?.contains(target)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [onClose, open]);
+
   const clearSearch = () => {
     void window.baseline.setSearchText("");
     inputRef.current?.focus();
   };
 
   return (
-    <div className={open ? "toolbar-search open" : "toolbar-search"}>
+    <div ref={rootRef} className={open ? "toolbar-search open" : "toolbar-search"}>
       <div className="toolbar-search-field">
         <input
           ref={inputRef}


### PR DESCRIPTION
## Summary
- Collapse the toolbar search field when clicking outside the open search control.
- Preserve the current search text so active filtering remains until cleared.
- Cover outside-click and inside-control behavior in renderer tests.

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
