### PR TITLE
Defer toolbar search collapse until after clicks

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -252,7 +252,7 @@ describe("renderer button parity", () => {
     expect(window.baseline.setSearchText).toHaveBeenCalledWith("");
   });
 
-  it("opens toolbar search and collapses it on outside click without clearing text", () => {
+  it("opens toolbar search and collapses it on outside click without clearing text", async () => {
     render(
       <Dashboard
         compact={false}
@@ -267,9 +267,9 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
     expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
 
-    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
 
-    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument());
     expect(window.baseline.setSearchText).not.toHaveBeenCalled();
   });
 
@@ -282,13 +282,28 @@ describe("renderer button parity", () => {
       />
     );
 
-    fireEvent.pointerDown(screen.getByPlaceholderText("Search"));
+    fireEvent.click(screen.getByPlaceholderText("Search"));
     expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Clear Search" }));
 
     expect(window.baseline.setSearchText).toHaveBeenCalledWith("");
     expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
+  });
+
+  it("runs adjacent toolbar actions before collapsing open search", async () => {
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ searchText: "raycast" })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(window.baseline.refresh).toHaveBeenCalledWith(false);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument());
   });
 
   it("does not render an app open action button when no update exists", () => {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -325,15 +325,15 @@ function ToolbarSearch({
       return undefined;
     }
 
-    const handlePointerDown = (event: PointerEvent) => {
+    const handleClick = (event: MouseEvent) => {
       const target = event.target;
       if (target instanceof Node && !rootRef.current?.contains(target)) {
-        onClose();
+        window.setTimeout(onClose, 0);
       }
     };
 
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => document.removeEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
   }, [onClose, open]);
 
   const clearSearch = () => {
@@ -342,7 +342,11 @@ function ToolbarSearch({
   };
 
   return (
-    <div ref={rootRef} className={open ? "toolbar-search open" : "toolbar-search"}>
+    <div
+      ref={rootRef}
+      className={open ? "toolbar-search open" : "toolbar-search"}
+      onClick={(event) => event.stopPropagation()}
+    >
       <div className="toolbar-search-field">
         <input
           ref={inputRef}


### PR DESCRIPTION
## Summary
- Address the P2 review from PR #27 by deferring outside-click search collapse until after click activation.
- Stop clicks inside the toolbar search root from reaching the document outside-click listener.
- Add regression coverage for adjacent toolbar actions firing before search collapses.

Fixes follow-up from https://github.com/arshiaghaf/baseline/pull/27#discussion_r3214407444

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
