### PR TITLE
Clear compact menubar initial focus

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -665,9 +665,12 @@ describe("renderer button parity", () => {
     );
 
     await waitFor(() => expect(document.activeElement).toBe(document.body));
-    expect(screen.getByRole("button", { name: "Search" })).toHaveAttribute("tabindex", "-1");
-    expect(screen.getByRole("button", { name: "Refresh" })).toHaveAttribute("tabindex", "-1");
-    expect(screen.getByRole("button", { name: "Settings" })).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Search" })).not.toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Refresh" })).not.toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Settings" })).not.toHaveAttribute("tabindex", "-1");
+
+    screen.getByRole("button", { name: "Search" }).focus();
+    expect(screen.getByRole("button", { name: "Search" })).toHaveFocus();
 
     screen.getByRole("button", { name: "Open app" }).focus();
     expect(screen.getByRole("button", { name: "Open app" })).toHaveFocus();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -651,7 +651,7 @@ describe("renderer button parity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("clears compact menu bar initial focus without blocking keyboard focus", async () => {
+  it("clears compact menu bar control focus", async () => {
     const focusTarget = document.createElement("button");
     document.body.append(focusTarget);
     focusTarget.focus();
@@ -665,15 +665,12 @@ describe("renderer button parity", () => {
     );
 
     await waitFor(() => expect(document.activeElement).toBe(document.body));
-    expect(screen.getByRole("button", { name: "Search" })).not.toHaveAttribute("tabindex", "-1");
-    expect(screen.getByRole("button", { name: "Refresh" })).not.toHaveAttribute("tabindex", "-1");
-    expect(screen.getByRole("button", { name: "Settings" })).not.toHaveAttribute("tabindex", "-1");
-
-    screen.getByRole("button", { name: "Search" }).focus();
-    expect(screen.getByRole("button", { name: "Search" })).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Search" })).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Refresh" })).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Settings" })).toHaveAttribute("tabindex", "-1");
 
     screen.getByRole("button", { name: "Open app" }).focus();
-    expect(screen.getByRole("button", { name: "Open app" })).toHaveFocus();
+    await waitFor(() => expect(document.activeElement).toBe(document.body));
 
     focusTarget.remove();
   });

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -652,10 +652,6 @@ describe("renderer button parity", () => {
   });
 
   it("clears compact menu bar control focus", async () => {
-    const focusTarget = document.createElement("button");
-    document.body.append(focusTarget);
-    focusTarget.focus();
-
     render(
       <Dashboard
         compact
@@ -671,8 +667,22 @@ describe("renderer button parity", () => {
 
     screen.getByRole("button", { name: "Open app" }).focus();
     await waitFor(() => expect(document.activeElement).toBe(document.body));
+  });
 
-    focusTarget.remove();
+  it("keeps compact menu bar row actions clickable while clearing focus", async () => {
+    render(
+      <Dashboard
+        compact
+        onOpenSettings={() => undefined}
+        snapshot={snapshot()}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Ignore" })).toBeInTheDocument();
+    await waitFor(() => expect(document.activeElement).toBe(document.body));
   });
 
   it("keeps compact menu bar search input focused when search is already open", async () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -651,6 +651,30 @@ describe("renderer button parity", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("clears compact menu bar initial focus without blocking keyboard focus", async () => {
+    const focusTarget = document.createElement("button");
+    document.body.append(focusTarget);
+    focusTarget.focus();
+
+    render(
+      <Dashboard
+        compact
+        onOpenSettings={() => undefined}
+        snapshot={snapshot()}
+      />
+    );
+
+    await waitFor(() => expect(document.activeElement).toBe(document.body));
+    expect(screen.getByRole("button", { name: "Search" })).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Refresh" })).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Settings" })).toHaveAttribute("tabindex", "-1");
+
+    screen.getByRole("button", { name: "Open app" }).focus();
+    expect(screen.getByRole("button", { name: "Open app" })).toHaveFocus();
+
+    focusTarget.remove();
+  });
+
   it("unifies app and Homebrew recently updated rows in the All tab", () => {
     const currentCask: HomebrewManagedItem = {
       ...cask,

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -675,6 +675,18 @@ describe("renderer button parity", () => {
     focusTarget.remove();
   });
 
+  it("keeps compact menu bar search input focused when search is already open", async () => {
+    render(
+      <Dashboard
+        compact
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ searchText: "raycast" })}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByPlaceholderText("Search")).toHaveFocus());
+  });
+
   it("unifies app and Homebrew recently updated rows in the All tab", () => {
     const currentCask: HomebrewManagedItem = {
       ...cask,

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -123,9 +123,7 @@ export function Dashboard({
       return;
     }
 
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-    }
+    blurCompactControl(document.activeElement);
   }, [compact, toolbarSearchOpen]);
 
   const confirmAction = () => {
@@ -144,7 +142,10 @@ export function Dashboard({
   let shell: React.ReactNode;
   if (compact) {
     shell = (
-      <main className="app-shell compact">
+      <main
+        className="app-shell compact"
+        onFocusCapture={(event) => blurCompactControl(event.target)}
+      >
         <header className="popover-titlebar">
           <div className="popover-title">
             <h1>Baseline</h1>
@@ -155,11 +156,13 @@ export function Dashboard({
               snapshot={snapshot}
               onToggle={() => setToolbarSearchOpen((open) => !open)}
               onClose={() => setToolbarSearchOpen(false)}
+              toolbarButtonTabIndex={-1}
             />
             <button
               className="toolbar-button refresh-button"
               onClick={() => void window.baseline.refresh(false)}
               title="Refresh"
+              tabIndex={-1}
             >
               <RefreshCcw className={snapshot.isRefreshing ? "spin" : undefined} size={16} />
             </button>
@@ -167,6 +170,7 @@ export function Dashboard({
               className="toolbar-button"
               onClick={onOpenSettings}
               title="Settings"
+              tabIndex={-1}
             >
               <Settings size={16} />
             </button>
@@ -244,6 +248,16 @@ export function Dashboard({
   );
 }
 
+function blurCompactControl(target: EventTarget | Element | null): void {
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  if (target.matches("input, textarea, [contenteditable='true']")) {
+    return;
+  }
+  target.blur();
+}
+
 function Sidebar({
   snapshot,
   derived,
@@ -317,12 +331,14 @@ function ToolbarSearch({
   open,
   snapshot,
   onToggle,
-  onClose
+  onClose,
+  toolbarButtonTabIndex
 }: {
   open: boolean;
   snapshot: BaselineSnapshot;
   onToggle: () => void;
   onClose: () => void;
+  toolbarButtonTabIndex?: number;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -387,6 +403,7 @@ function ToolbarSearch({
         className="toolbar-button"
         onClick={onToggle}
         title={open ? "Close Search" : "Search"}
+        tabIndex={toolbarButtonTabIndex}
       >
         <Search size={16} />
       </button>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -119,14 +119,14 @@ export function Dashboard({
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
 
   useEffect(() => {
-    if (!compact) {
+    if (!compact || toolbarSearchOpen) {
       return;
     }
 
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur();
     }
-  }, [compact]);
+  }, [compact, toolbarSearchOpen]);
 
   const confirmAction = () => {
     if (!actionConfirmation) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -155,13 +155,11 @@ export function Dashboard({
               snapshot={snapshot}
               onToggle={() => setToolbarSearchOpen((open) => !open)}
               onClose={() => setToolbarSearchOpen(false)}
-              toolbarButtonTabIndex={-1}
             />
             <button
               className="toolbar-button refresh-button"
               onClick={() => void window.baseline.refresh(false)}
               title="Refresh"
-              tabIndex={-1}
             >
               <RefreshCcw className={snapshot.isRefreshing ? "spin" : undefined} size={16} />
             </button>
@@ -169,7 +167,6 @@ export function Dashboard({
               className="toolbar-button"
               onClick={onOpenSettings}
               title="Settings"
-              tabIndex={-1}
             >
               <Settings size={16} />
             </button>
@@ -320,14 +317,12 @@ function ToolbarSearch({
   open,
   snapshot,
   onToggle,
-  onClose,
-  toolbarButtonTabIndex
+  onClose
 }: {
   open: boolean;
   snapshot: BaselineSnapshot;
   onToggle: () => void;
   onClose: () => void;
-  toolbarButtonTabIndex?: number;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -392,7 +387,6 @@ function ToolbarSearch({
         className="toolbar-button"
         onClick={onToggle}
         title={open ? "Close Search" : "Search"}
-        tabIndex={toolbarButtonTabIndex}
       >
         <Search size={16} />
       </button>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -117,13 +117,14 @@ export function Dashboard({
   const selectedTab = snapshot.selectedTab;
   const [toolbarSearchOpen, setToolbarSearchOpen] = useState(Boolean(snapshot.searchText));
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
+  const compactShellRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (!compact || toolbarSearchOpen) {
       return;
     }
 
-    blurCompactControl(document.activeElement);
+    clearCompactPopoverControlFocus(document.activeElement, compactShellRef.current);
   }, [compact, toolbarSearchOpen]);
 
   const confirmAction = () => {
@@ -143,8 +144,14 @@ export function Dashboard({
   if (compact) {
     shell = (
       <main
+        ref={compactShellRef}
         className="app-shell compact"
-        onFocusCapture={(event) => blurCompactControl(event.target)}
+        onFocusCapture={(event) =>
+          clearCompactPopoverControlFocus(event.target, compactShellRef.current)
+        }
+        onMouseDownCapture={(event) =>
+          suppressCompactPopoverControlFocus(event.target, compactShellRef.current, event)
+        }
       >
         <header className="popover-titlebar">
           <div className="popover-title">
@@ -248,14 +255,45 @@ export function Dashboard({
   );
 }
 
-function blurCompactControl(target: EventTarget | Element | null): void {
-  if (!(target instanceof HTMLElement)) {
+function clearCompactPopoverControlFocus(
+  target: EventTarget | Element | null,
+  compactShell: HTMLElement | null
+): void {
+  const focusTarget = compactPopoverControlFocusTarget(target, compactShell);
+  if (!focusTarget) {
     return;
   }
-  if (target.matches("input, textarea, [contenteditable='true']")) {
-    return;
+  focusTarget.blur();
+}
+
+function suppressCompactPopoverControlFocus(
+  target: EventTarget | Element | null,
+  compactShell: HTMLElement | null,
+  event: React.MouseEvent
+): void {
+  if (compactPopoverControlFocusTarget(target, compactShell)) {
+    event.preventDefault();
   }
-  target.blur();
+}
+
+function compactPopoverControlFocusTarget(
+  target: EventTarget | Element | null,
+  compactShell: HTMLElement | null
+): HTMLElement | undefined {
+  if (!(target instanceof Element)) {
+    return undefined;
+  }
+  const focusTarget = target.closest("button, input, textarea, [contenteditable='true']");
+  if (!(focusTarget instanceof HTMLElement)) {
+    return undefined;
+  }
+  if (compactShell && !compactShell.contains(focusTarget)) {
+    return undefined;
+  }
+  if (focusTarget.matches("input, textarea, [contenteditable='true']")) {
+    return undefined;
+  }
+  return focusTarget;
 }
 
 function Sidebar({

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -118,6 +118,16 @@ export function Dashboard({
   const [toolbarSearchOpen, setToolbarSearchOpen] = useState(Boolean(snapshot.searchText));
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
 
+  useEffect(() => {
+    if (!compact) {
+      return;
+    }
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  }, [compact]);
+
   const confirmAction = () => {
     if (!actionConfirmation) {
       return;
@@ -145,15 +155,22 @@ export function Dashboard({
               snapshot={snapshot}
               onToggle={() => setToolbarSearchOpen((open) => !open)}
               onClose={() => setToolbarSearchOpen(false)}
+              toolbarButtonTabIndex={-1}
             />
             <button
               className="toolbar-button refresh-button"
               onClick={() => void window.baseline.refresh(false)}
               title="Refresh"
+              tabIndex={-1}
             >
               <RefreshCcw className={snapshot.isRefreshing ? "spin" : undefined} size={16} />
             </button>
-            <button className="toolbar-button" onClick={onOpenSettings} title="Settings">
+            <button
+              className="toolbar-button"
+              onClick={onOpenSettings}
+              title="Settings"
+              tabIndex={-1}
+            >
               <Settings size={16} />
             </button>
           </div>
@@ -303,12 +320,14 @@ function ToolbarSearch({
   open,
   snapshot,
   onToggle,
-  onClose
+  onClose,
+  toolbarButtonTabIndex
 }: {
   open: boolean;
   snapshot: BaselineSnapshot;
   onToggle: () => void;
   onClose: () => void;
+  toolbarButtonTabIndex?: number;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -373,6 +392,7 @@ function ToolbarSearch({
         className="toolbar-button"
         onClick={onToggle}
         title={open ? "Close Search" : "Search"}
+        tabIndex={toolbarButtonTabIndex}
       >
         <Search size={16} />
       </button>


### PR DESCRIPTION
## Summary
- Clear any initially focused element when the compact menubar dashboard mounts.
- Remove the compact toolbar buttons from the tab order so Search is not preselected on first tray open.
- Cover the compact initial-focus behavior in renderer tests while preserving later keyboard focus for row actions.

## Validation
- npm test -- ElectronTests/rendererButtons.test.tsx
- npm run typecheck
- npm run lint
