### PR TITLE
Fix duplicate recently updated casks

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -652,13 +652,7 @@ describe("renderer button parity", () => {
   });
 
   it("clears compact menu bar control focus", async () => {
-    render(
-      <Dashboard
-        compact
-        onOpenSettings={() => undefined}
-        snapshot={snapshot()}
-      />
-    );
+    render(<Dashboard compact onOpenSettings={() => undefined} snapshot={snapshot()} />);
 
     await waitFor(() => expect(document.activeElement).toBe(document.body));
     expect(screen.getByRole("button", { name: "Search" })).toHaveAttribute("tabindex", "-1");
@@ -670,13 +664,7 @@ describe("renderer button parity", () => {
   });
 
   it("keeps compact menu bar row actions clickable while clearing focus", async () => {
-    render(
-      <Dashboard
-        compact
-        onOpenSettings={() => undefined}
-        snapshot={snapshot()}
-      />
-    );
+    render(<Dashboard compact onOpenSettings={() => undefined} snapshot={snapshot()} />);
 
     fireEvent.mouseDown(screen.getByRole("button", { name: "Actions" }));
     fireEvent.click(screen.getByRole("button", { name: "Actions" }));
@@ -697,9 +685,26 @@ describe("renderer button parity", () => {
     await waitFor(() => expect(screen.getByPlaceholderText("Search")).toHaveFocus());
   });
 
-  it("unifies app and Homebrew recently updated rows in the All tab", () => {
+  it("unifies app and Homebrew recently updated rows in the All tab without duplicating cask-backed apps", () => {
     const currentCask: HomebrewManagedItem = {
       ...cask,
+      latestVersion: version("2.0.0"),
+      isOutdated: false
+    };
+    const standaloneCask: HomebrewManagedItem = {
+      ...cask,
+      id: "cask:standalone",
+      token: "standalone",
+      name: "Standalone",
+      latestVersion: version("2.0.0"),
+      isOutdated: false
+    };
+    const formula: HomebrewManagedItem = {
+      ...cask,
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
       latestVersion: version("2.0.0"),
       isOutdated: false
     };
@@ -711,7 +716,7 @@ describe("renderer button parity", () => {
         snapshot={snapshot({
           selectedTab: "all",
           updates: [],
-          homebrewItems: [currentCask],
+          homebrewItems: [currentCask, standaloneCask, formula],
           recentlyUpdated: [
             {
               id: "recent:app",
@@ -724,11 +729,31 @@ describe("renderer button parity", () => {
           ],
           homebrewRecentlyUpdated: [
             {
-              id: "recent:cask",
+              id: "recent:cask:example",
               itemID: currentCask.id,
               token: currentCask.token,
               kind: currentCask.kind,
               displayName: currentCask.name,
+              fromVersion: version("1.0.0"),
+              toVersion: version("2.0.0"),
+              updatedAt: "2026-04-30T12:00:00.000Z"
+            },
+            {
+              id: "recent:cask:standalone",
+              itemID: standaloneCask.id,
+              token: standaloneCask.token,
+              kind: standaloneCask.kind,
+              displayName: standaloneCask.name,
+              fromVersion: version("1.0.0"),
+              toVersion: version("2.0.0"),
+              updatedAt: "2026-04-30T12:00:00.000Z"
+            },
+            {
+              id: "recent:formula:ripgrep",
+              itemID: formula.id,
+              token: formula.token,
+              kind: formula.kind,
+              displayName: formula.name,
               fromVersion: version("1.0.0"),
               toVersion: version("2.0.0"),
               updatedAt: "2026-04-30T12:00:00.000Z"
@@ -745,7 +770,9 @@ describe("renderer button parity", () => {
     expect(
       screen.queryByRole("heading", { name: "Recently Updated Homebrew" })
     ).not.toBeInTheDocument();
-    expect(screen.getAllByText("Example")).toHaveLength(2);
+    expect(screen.getAllByText("Example")).toHaveLength(1);
+    expect(screen.getByText("Standalone")).toBeInTheDocument();
+    expect(screen.getByText("ripgrep")).toBeInTheDocument();
   });
 
   it("search includes installed items and hides empty result sections", () => {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -582,23 +582,27 @@ function AllRecentlyUpdatedSection({
   const homebrewUpdatedAt = new Map(
     snapshot.homebrewRecentlyUpdated.map((record) => [record.itemID, record.updatedAt])
   );
+  const recentlyUpdatedApps = snapshot.showRecentlyUpdatedAppsSection
+    ? derived.recentlyUpdatedApps
+    : [];
+  const homebrewRecentlyUpdated = snapshot.showRecentlyUpdatedHomebrewSection
+    ? derived.homebrewRecentlyUpdated.filter(
+        (item) => !homebrewItemMatchesApp(item, recentlyUpdatedApps)
+      )
+    : [];
   const rows = [
-    ...(snapshot.showRecentlyUpdatedAppsSection
-      ? derived.recentlyUpdatedApps.map((app) => ({
-          type: "app" as const,
-          id: app.id,
-          updatedAt: appUpdatedAt.get(app.id) ?? "",
-          item: app
-        }))
-      : []),
-    ...(snapshot.showRecentlyUpdatedHomebrewSection
-      ? derived.homebrewRecentlyUpdated.map((item) => ({
-          type: "homebrew" as const,
-          id: item.id,
-          updatedAt: homebrewUpdatedAt.get(item.id) ?? "",
-          item
-        }))
-      : [])
+    ...recentlyUpdatedApps.map((app) => ({
+      type: "app" as const,
+      id: app.id,
+      updatedAt: appUpdatedAt.get(app.id) ?? "",
+      item: app
+    })),
+    ...homebrewRecentlyUpdated.map((item) => ({
+      type: "homebrew" as const,
+      id: item.id,
+      updatedAt: homebrewUpdatedAt.get(item.id) ?? "",
+      item
+    }))
   ].sort((lhs, rhs) => compareRecentRows(lhs, rhs));
 
   const collapsed = snapshot.collapsedAppSectionIDs.includes("recentlyUpdated");
@@ -1782,6 +1786,17 @@ function homebrewItemHasAppUpdate(
     }
     return normalizedAppCandidates(app).has(normalizedName(item.token));
   });
+}
+
+function homebrewItemMatchesApp(item: HomebrewManagedItem, apps: AppRecord[]): boolean {
+  if (!isCask(item.kind)) {
+    return false;
+  }
+
+  const identifiers = homebrewItemIdentifiers(item);
+  return apps.some((app) =>
+    [...identifiers].some((identifier) => normalizedAppCandidates(app).has(identifier))
+  );
 }
 
 function matchingAppForHomebrewItem(


### PR DESCRIPTION
## Summary
- de-dupe cask-backed app rows in the All tab Recently Updated section
- keep standalone Homebrew recent rows visible
- add renderer regression coverage for matching casks, standalone casks, and formulas

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
