### PR TITLE
Fix stale self-updated cask state

### DIFF
--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -28,6 +28,7 @@ describe("ported clients", () => {
   it("parses Homebrew cask schema drift fixtures", () => {
     const data = readFileSync(path.join(fixtures, "homebrew_cask_drift.json"));
     const index = new HomebrewCaskClient().parseIndex(data);
+    expect(index.byToken["example-app"]?.token).toBe("example-app");
     expect(index.byBundleIdentifier["com.example.app"]?.token).toBe("example-app");
     expect(index.byAppBundleName["example.app"]?.[0]?.token).toBe("example-app");
   });

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -13,7 +13,12 @@ import {
   preservePreviousHomebrewOutdatedState,
   UpdateStore
 } from "../src/main/updateStore";
-import type { HomebrewManagedItem, PersistedSnapshot } from "../src/shared/domain";
+import type {
+  AppRecord,
+  HomebrewCaskIndex,
+  HomebrewManagedItem,
+  PersistedSnapshot
+} from "../src/shared/domain";
 import { version } from "../src/shared/version";
 
 let tempDirs: string[] = [];
@@ -31,6 +36,30 @@ function homebrewItem(
     installedVersion: version("1.0.0"),
     isOutdated: false,
     ...patch
+  };
+}
+
+function appRecord(
+  patch: Pick<AppRecord, "bundlePath" | "displayName" | "localVersion"> & Partial<AppRecord>
+): AppRecord {
+  return {
+    id: patch.bundlePath,
+    sourceHint: "unknown",
+    ...patch
+  };
+}
+
+function caskIndexForSelfUpdatingApp(latestVersion: ReturnType<typeof version>): HomebrewCaskIndex {
+  const entry = {
+    token: "self-updating-app",
+    version: latestVersion,
+    bundleIdentifiers: ["com.example.selfupdating"],
+    appBundleNames: ["self updating app.app"]
+  };
+  return {
+    byToken: { "self-updating-app": entry },
+    byBundleIdentifier: { "com.example.selfupdating": entry },
+    byAppBundleName: { "self updating app.app": [entry] }
   };
 }
 
@@ -258,6 +287,245 @@ describe("update store helpers", () => {
       isOutdated: true
     });
     expect(snapshot.lastRefreshNoticeMessage).toContain("could not be read reliably");
+  });
+
+  it("clears stale cask updates when the installed app self-updated to the latest version", async () => {
+    const selfUpdatingApp = appRecord({
+      bundlePath: "/Applications/Self Updating App.app",
+      displayName: "Self Updating App",
+      bundleIdentifier: "com.example.selfupdating",
+      localVersion: version("1.2026.119.1")
+    });
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [selfUpdatingApp] },
+        homebrew: {
+          fetchIndex: async () => caskIndexForSelfUpdatingApp(version("1.2026.119.1")),
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:self-updating-app",
+                token: "self-updating-app",
+                name: "self-updating-app",
+                kind: "cask",
+                installedVersion: version("1.2026.98.2"),
+                latestVersion: version("1.2026.119.1"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:self-updating-app");
+    expect(item).toMatchObject({
+      installedVersion: version("1.2026.119.1"),
+      isOutdated: false
+    });
+    expect(item?.latestVersion).toBeUndefined();
+  });
+
+  it("uses the app bundle version for self-updated casks that still have a newer cask release", async () => {
+    const selfUpdatingApp = appRecord({
+      bundlePath: "/Applications/Self Updating App.app",
+      displayName: "Self Updating App",
+      bundleIdentifier: "com.example.selfupdating",
+      localVersion: version("1.2026.119.1")
+    });
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [selfUpdatingApp] },
+        homebrew: {
+          fetchIndex: async () => caskIndexForSelfUpdatingApp(version("1.2026.130.1")),
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:self-updating-app",
+                token: "self-updating-app",
+                name: "self-updating-app",
+                kind: "cask",
+                installedVersion: version("1.2026.98.2"),
+                latestVersion: version("1.2026.130.1"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:self-updating-app");
+    expect(item).toMatchObject({
+      installedVersion: version("1.2026.119.1"),
+      latestVersion: version("1.2026.130.1"),
+      isOutdated: true
+    });
+  });
+
+  it("does not use loose name matches to change cask installed versions", async () => {
+    const sameNameApp = appRecord({
+      bundlePath: "/Applications/Self Updating App.app",
+      displayName: "Self Updating App",
+      bundleIdentifier: "com.example.unrelated",
+      localVersion: version("1.2026.119.1"),
+      iconDataURL: "data:image/png;base64,icon"
+    });
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [sameNameApp] },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:self-updating-app",
+                token: "self-updating-app",
+                name: "self-updating-app",
+                kind: "cask",
+                installedVersion: version("1.2026.98.2"),
+                latestVersion: version("1.2026.119.1"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:self-updating-app");
+    expect(item).toMatchObject({
+      installedVersion: version("1.2026.98.2"),
+      latestVersion: version("1.2026.119.1"),
+      isOutdated: true,
+      iconDataURL: "data:image/png;base64,icon"
+    });
+  });
+
+  it("does not use app bundle-name matches when cask and app bundle identifiers conflict", async () => {
+    const sameNameApp = appRecord({
+      bundlePath: "/Applications/Self Updating App.app",
+      displayName: "Self Updating App",
+      bundleIdentifier: "com.example.unrelated",
+      localVersion: version("1.2026.119.1"),
+      iconDataURL: "data:image/png;base64,icon"
+    });
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [sameNameApp] },
+        homebrew: {
+          fetchIndex: async () => caskIndexForSelfUpdatingApp(version("1.2026.119.1")),
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:self-updating-app",
+                token: "self-updating-app",
+                name: "self-updating-app",
+                kind: "cask",
+                installedVersion: version("1.2026.98.2"),
+                latestVersion: version("1.2026.119.1"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:self-updating-app");
+    expect(item).toMatchObject({
+      installedVersion: version("1.2026.98.2"),
+      latestVersion: version("1.2026.119.1"),
+      isOutdated: true,
+      iconDataURL: "data:image/png;base64,icon"
+    });
+  });
+
+  it("validates update-matched apps against cask metadata before changing cask versions", async () => {
+    const sameNameApp = appRecord({
+      bundlePath: "/Applications/Self Updating App.app",
+      displayName: "Self Updating App",
+      bundleIdentifier: "com.example.unrelated",
+      localVersion: version("1.2026.119.1"),
+      iconDataURL: "data:image/png;base64,icon"
+    });
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [sameNameApp] },
+        homebrew: {
+          fetchIndex: async () => caskIndexForSelfUpdatingApp(version("1.2026.119.1")),
+          lookupUpdate: () => ({
+            remoteVersion: version("1.2026.119.1"),
+            token: "self-updating-app"
+          }),
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:self-updating-app",
+                token: "self-updating-app",
+                name: "self-updating-app",
+                kind: "cask",
+                installedVersion: version("1.2026.98.2"),
+                latestVersion: version("1.2026.119.1"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:self-updating-app");
+    expect(item).toMatchObject({
+      installedVersion: version("1.2026.98.2"),
+      latestVersion: version("1.2026.119.1"),
+      isOutdated: true,
+      iconDataURL: "data:image/png;base64,icon"
+    });
   });
 
   it("suppresses duplicate Homebrew cask uninstall dispatches while running", async () => {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -86,6 +86,7 @@ export class HomebrewCaskClient {
     }
 
     const raw = JSON.parse(data.toString("utf8")) as any[];
+    const byToken: Record<string, HomebrewCaskEntry> = {};
     const byBundleIdentifier: Record<string, HomebrewCaskEntry> = {};
     const byAppBundleName: Record<string, HomebrewCaskEntry[]> = {};
 
@@ -102,6 +103,7 @@ export class HomebrewCaskClient {
         bundleIdentifiers: extractBundleIdentifiers(item),
         appBundleNames: extractAppBundleNames(item)
       };
+      byToken[token.toLowerCase()] = entry;
 
       for (const identifier of entry.bundleIdentifiers) {
         const key = identifier.toLowerCase();
@@ -124,7 +126,7 @@ export class HomebrewCaskClient {
       byAppBundleName[key] = [...deduped.values()].sort(compareEntries);
     }
 
-    return { byBundleIdentifier, byAppBundleName };
+    return { byToken, byBundleIdentifier, byAppBundleName };
   }
 
   private lookupResult(entry: HomebrewCaskEntry): HomebrewLookupResult {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -5,6 +5,7 @@ import type {
   AppRecord,
   BaselineSnapshot,
   HomebrewCaskDiscoveryItem,
+  HomebrewCaskEntry,
   HomebrewCaskIndex,
   HomebrewFormulaIndex,
   HomebrewManagedItem,
@@ -27,7 +28,7 @@ import {
 } from "../shared/homebrewProgress";
 import type { PreferencePatch } from "../shared/ipc";
 import { isAllowedExternalURL, isValidHomebrewToken } from "../shared/security";
-import { compareVersions, isVersionGreater } from "../shared/version";
+import { compareVersions, isVersionEmpty, isVersionGreater } from "../shared/version";
 import { AppStoreLookupClient } from "./appStoreLookupClient";
 import { BundleScannerClient } from "./bundleScanner";
 import {
@@ -583,7 +584,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           homebrewInventory.outdatedDetectionSucceededByKind
         ),
         updates,
-        apps
+        apps,
+        homebrewIndex
       );
       const recentlyUpdated = this.mergeRecentlyUpdated(apps, updates, previousUpdates, now);
       const homebrewRecentlyUpdated = mergeHomebrewRecentlyUpdatedRecords(
@@ -606,7 +608,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         homebrewDiscoverInstallingItemIDs: [],
         homebrewDiscoverInstalledPendingRefreshItemIDs: [],
         homebrewDiscoverProgressByItemID: {},
-        laggingHomebrewCaskTokens: detectLaggingHomebrewCaskTokens(homebrewItems, updates)
+        laggingHomebrewCaskTokens: detectLaggingHomebrewCaskTokens(
+          homebrewItems,
+          updates,
+          apps,
+          homebrewIndex
+        )
       });
       await this.refreshHomebrewDiscoverItems();
       await this.persist();
@@ -981,7 +988,8 @@ export function preservePreviousHomebrewOutdatedState(
 function reconcileHomebrewInventory(
   items: HomebrewManagedItem[],
   updates: UpdateRecord[],
-  apps: AppRecord[] = []
+  apps: AppRecord[] = [],
+  caskIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex
 ): HomebrewManagedItem[] {
   const updatesByToken = new Map<string, UpdateRecord>();
   for (const update of updates) {
@@ -998,15 +1006,32 @@ function reconcileHomebrewInventory(
     if (item.kind !== "cask") {
       return item;
     }
-    const iconDataURL = matchingHomebrewAppIcon(item, updatesByToken, appsByID, apps);
+    const caskEntry = caskIndex.byToken[item.token.toLowerCase()];
+    const matchingApp = matchingHomebrewApp(updatesByToken, appsByID, apps, item, caskEntry);
+    const iconDataURL =
+      matchingApp?.iconDataURL ?? matchingHomebrewAppIcon(item, updatesByToken, appsByID, apps);
     const update = updatesByToken.get(item.token.toLowerCase());
-    if (!update || !isVersionGreater(update.remoteVersion, item.installedVersion)) {
-      return iconDataURL ? { ...item, iconDataURL } : item;
+    const installedVersion =
+      matchingApp && isVersionGreater(matchingApp.localVersion, item.installedVersion)
+        ? matchingApp.localVersion
+        : item.installedVersion;
+    const latestVersion = bestHomebrewCaskLatestVersion(item, update, caskEntry);
+
+    if (!latestVersion || !isVersionGreater(latestVersion, installedVersion)) {
+      return {
+        ...item,
+        iconDataURL: iconDataURL ?? item.iconDataURL,
+        installedVersion,
+        latestVersion: undefined,
+        isOutdated: false,
+        releaseDate: undefined
+      };
     }
     return {
       ...item,
-      iconDataURL,
-      latestVersion: update.remoteVersion,
+      iconDataURL: iconDataURL ?? item.iconDataURL,
+      installedVersion,
+      latestVersion,
       isOutdated: true
     };
   });
@@ -1052,6 +1077,66 @@ export function mergeHomebrewRecentlyUpdatedRecords(
   return [...deduped.values()].slice(0, 40);
 }
 
+function bestHomebrewCaskLatestVersion(
+  item: HomebrewManagedItem,
+  update: UpdateRecord | undefined,
+  caskEntry: HomebrewCaskEntry | undefined
+): HomebrewManagedItem["latestVersion"] {
+  const caskIndexVersion = item.isOutdated ? caskEntry?.version : undefined;
+  const candidates = [item.latestVersion, update?.remoteVersion, caskIndexVersion].filter(
+    (candidate): candidate is NonNullable<HomebrewManagedItem["latestVersion"]> =>
+      Boolean(candidate) && !isVersionEmpty(candidate)
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  return candidates.reduce((latest, candidate) =>
+    compareVersions(candidate, latest) > 0 ? candidate : latest
+  );
+}
+
+function matchingHomebrewApp(
+  updatesByToken: Map<string, UpdateRecord>,
+  appsByID: Map<string, AppRecord>,
+  apps: AppRecord[],
+  item: HomebrewManagedItem,
+  caskEntry: HomebrewCaskEntry | undefined
+): AppRecord | undefined {
+  const update = updatesByToken.get(item.token.toLowerCase());
+  const appFromUpdate = update ? appsByID.get(update.appID) : undefined;
+  if (appFromUpdate && appMatchesCaskEntry(appFromUpdate, caskEntry)) {
+    return appFromUpdate;
+  }
+
+  if (caskEntry) {
+    const byCaskMetadata = apps.find((app) => appMatchesCaskEntry(app, caskEntry));
+    if (byCaskMetadata) {
+      return byCaskMetadata;
+    }
+  }
+
+  return undefined;
+}
+
+function appMatchesCaskEntry(
+  app: AppRecord,
+  caskEntry: HomebrewCaskEntry | undefined
+): boolean {
+  if (!caskEntry) {
+    return true;
+  }
+
+  const bundleIdentifiers = new Set(
+    caskEntry.bundleIdentifiers.map((identifier) => identifier.toLowerCase())
+  );
+  const bundleIdentifier = app.bundleIdentifier?.toLowerCase();
+  if (bundleIdentifier && bundleIdentifiers.size > 0) {
+    return bundleIdentifiers.has(bundleIdentifier);
+  }
+
+  return new Set(caskEntry.appBundleNames).has(normalizedAppBundleName(app.bundlePath));
+}
+
 function matchingHomebrewAppIcon(
   item: HomebrewManagedItem,
   updatesByToken: Map<string, UpdateRecord>,
@@ -1072,6 +1157,13 @@ function matchingHomebrewAppIcon(
   })?.iconDataURL;
 }
 
+function normalizedAppBundleName(bundlePath: string): string {
+  const fileName = bundlePath.split("/").pop() ?? bundlePath;
+  return fileName.toLowerCase().endsWith(".app")
+    ? fileName.toLowerCase()
+    : `${fileName.toLowerCase()}.app`;
+}
+
 function normalizedAppCandidates(app: AppRecord): Set<string> {
   const fileName = app.bundlePath
     .split("/")
@@ -1089,9 +1181,11 @@ function normalizedName(value: string): string {
 
 function detectLaggingHomebrewCaskTokens(
   items: HomebrewManagedItem[],
-  updates: UpdateRecord[]
+  updates: UpdateRecord[],
+  apps: AppRecord[] = [],
+  caskIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex
 ): string[] {
-  const reconciled = reconcileHomebrewInventory(items, updates);
+  const reconciled = reconcileHomebrewInventory(items, updates, apps, caskIndex);
   return reconciled
     .filter((item, index) => item.kind === "cask" && item.isOutdated && !items[index]?.isOutdated)
     .map((item) => item.token.toLowerCase());

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -55,6 +55,7 @@ export type HomebrewCaskDiscoveryItem = {
 };
 
 export type HomebrewCaskIndex = {
+  byToken: Record<string, HomebrewCaskEntry>;
   byBundleIdentifier: Record<string, HomebrewCaskEntry>;
   byAppBundleName: Record<string, HomebrewCaskEntry[]>;
 };
@@ -180,6 +181,7 @@ export type BaselineSnapshot = PersistedSnapshot &
   };
 
 export const emptyHomebrewCaskIndex: HomebrewCaskIndex = {
+  byToken: {},
   byBundleIdentifier: {},
   byAppBundleName: {}
 };


### PR DESCRIPTION
## Summary
- reconcile Homebrew cask rows against scanned app bundle versions when cask metadata proves the app match
- add token lookup to the cask index so installed casks can be matched directly to metadata
- prevent same-name apps with conflicting bundle IDs from changing cask installed-version state

## Root Cause
Homebrew can keep an older cask receipt version after an app self-updates through its own GUI. Baseline previously trusted that receipt for Homebrew rows, so any self-updated cask-backed app could continue to appear outdated even when its installed app bundle was already current.

## Validation
- npm run typecheck
- npm test
- npm run lint
