### PR TITLE
Update XML parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "fast-xml-parser": "^5.7.2",
+        "fast-xml-parser": "^5.7.3",
         "lucide-react": "^1.12.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -5122,9 +5122,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -5133,13 +5133,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -5149,7 +5150,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -10385,6 +10386,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "forge": "./forge.config.ts"
   },
   "dependencies": {
-    "fast-xml-parser": "^5.7.2",
+    "fast-xml-parser": "^5.7.3",
     "lucide-react": "^1.12.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"


### PR DESCRIPTION
## Summary

- update `fast-xml-parser` to `^5.7.3`
- refresh the lockfile so production installs use `fast-xml-builder@1.2.0`
- clear the production dependency audit finding for the transitive XML builder package

## Validation
- `npm test -- ElectronTests/clients.test.ts ElectronTests/security.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm audit --omit=dev --audit-level=high`
