### PR TITLE
Add automatic issue labeling workflow

### DIFF
--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -1,0 +1,87 @@
+name: Auto-label issues
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label issue by content
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const text = `${issue.title || ""}\n\n${issue.body || ""}`.toLowerCase();
+
+            const desired = new Set();
+
+            // Bug indicators.
+            if (
+              /\bbug\b|\berror\b|\bcrash\b|\bfail(?:ed|ing)?\b|\bregression\b/.test(text) ||
+              text.includes("steps to reproduce") ||
+              text.includes("actual behavior")
+            ) {
+              desired.add("bug");
+            }
+
+            // Feature request indicators.
+            if (
+              /\bfeature\b|\benhancement\b|\bproposal\b|\brequest\b/.test(text) ||
+              text.includes("proposed solution") ||
+              text.includes("alternatives considered")
+            ) {
+              desired.add("enhancement");
+            }
+
+            // Question indicators.
+            if (
+              /\bquestion\b|\bhow do i\b|\bhow to\b/.test(text) ||
+              (issue.title || "").trim().endsWith("?")
+            ) {
+              desired.add("question");
+            }
+
+            // Documentation indicators.
+            if (
+              /\bdocs?\b|\bdocumentation\b|\breadme\b/.test(text)
+            ) {
+              desired.add("documentation");
+            }
+
+            if (desired.size === 0) {
+              desired.add("needs-triage");
+            }
+
+            const repoLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              }
+            );
+
+            const available = new Set(repoLabels.map((label) => label.name));
+            const existing = new Set(issue.labels.map((label) => label.name));
+            const toAdd = [...desired].filter(
+              (label) => available.has(label) && !existing.has(label)
+            );
+
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: toAdd
+              });
+              core.info(`Added labels: ${toAdd.join(", ")}`);
+            } else {
+              core.info("No matching labels available to add.");
+            }
+

--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -20,6 +20,7 @@ jobs:
             const text = `${issue.title || ""}\n\n${issue.body || ""}`.toLowerCase();
 
             const desired = new Set();
+            const escapeRegex = (value) => value.replace(/[.*+?^\${}()|[\]\\]/g, "\\$&");
 
             // Bug indicators.
             if (
@@ -48,14 +49,16 @@ jobs:
             }
 
             // Documentation indicators.
-            if (
-              /\bdocs?\b|\bdocumentation\b|\breadme\b/.test(text)
-            ) {
+            if (/\bdocs?\b|\bdocumentation\b|\breadme\b/.test(text)) {
               desired.add("documentation");
             }
 
-            if (desired.size === 0) {
-              desired.add("needs-triage");
+            // UI/theme indicators for common frontend issue tags.
+            if (/\bui\b|\bux\b|\binterface\b|\blayout\b/.test(text)) {
+              desired.add("ui");
+            }
+            if (/\btheme\b|\btheming\b|\bdark mode\b|\blight mode\b/.test(text)) {
+              desired.add("theme");
             }
 
             const repoLabels = await github.paginate(
@@ -66,6 +69,31 @@ jobs:
                 per_page: 100
               }
             );
+
+            // Add labels when issue text explicitly mentions the label name.
+            const skipAutoByName = new Set([
+              "duplicate",
+              "invalid",
+              "wontfix",
+              "good first issue",
+              "help wanted"
+            ]);
+
+            for (const label of repoLabels) {
+              const name = label.name.toLowerCase();
+              if (skipAutoByName.has(name)) {
+                continue;
+              }
+
+              const mentionPattern = new RegExp(`(^|\\W)${escapeRegex(name)}($|\\W)`, "i");
+              if (mentionPattern.test(text)) {
+                desired.add(label.name);
+              }
+            }
+
+            if (desired.size === 0) {
+              desired.add("needs-triage");
+            }
 
             const available = new Set(repoLabels.map((label) => label.name));
             const existing = new Set(issue.labels.map((label) => label.name));


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that auto-labels issues on open/edit/reopen
- classify issue title/body content into core labels: `bug`, `enhancement`, `question`, and `documentation`
- differentiate `ui` and `theme` with separate keyword detection
- dynamically match additional existing repo labels when the issue text explicitly mentions label names
- avoid auto-adding triage/closure labels such as `duplicate`, `invalid`, `wontfix`, `good first issue`, and `help wanted`
- use fallback `needs-triage` only when nothing else matches and that label exists

## Notes
- current repo labels include: bug, enhancement, question, documentation, ui, theme
- workflow only adds labels that already exist in the repository, preventing failures on missing labels