### PR TITLE
Use Server icon for All sidebar tab

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -11,11 +11,11 @@ import {
   EyeOff,
   ExternalLink,
   FolderPlus,
-  LayoutGrid,
   MoreHorizontal,
   Package,
   RefreshCcw,
   Search,
+  Server,
   Settings,
   Terminal,
   Trash2,
@@ -326,7 +326,7 @@ function Sidebar({
             void window.baseline.setSelectedTab("all");
           }}
         >
-          <LayoutGrid size={16} strokeWidth={sidebarIconStrokeWidth} />
+          <Server size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>All</span>
           <strong>{combinedAvailableCount(derived)}</strong>
         </button>


### PR DESCRIPTION
## Summary
- replace the sidebar icon for the All tab from LayoutGrid to Server
- keep all tab behavior and counts unchanged

## Validation
- npm run -s typecheck