### PR TITLE
Redesign update surfaces as card grids

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -89,6 +89,28 @@ describe("bundle scanner", () => {
 
     expect(records).toEqual([]);
   });
+
+  it("keeps normal app bundles that contain a generic manifest", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    await writeAppPlist(path.join(root, "Manifested.app"), {
+      displayName: "Manifested",
+      bundleIdentifier: "com.example.manifested",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>Manifest</key>",
+        "  <dict>",
+        "    <key>name</key>",
+        "    <string>Manifested</string>",
+        "  </dict>"
+      ].join("\n")
+    });
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records.map((record) => record.displayName)).toEqual(["Manifested"]);
+  });
 });
 
 async function writeAppPlist(

--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -58,6 +58,37 @@ describe("bundle scanner", () => {
       "com.example.nested"
     ]);
   });
+
+  it("ignores Safari web app bundles", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    await writeAppPlist(path.join(root, "GitHub.app"), {
+      displayName: "GitHub",
+      bundleIdentifier: "com.apple.Safari.WebApp.96B22158-BAD1-44DA-880D-913DB7E56FC7",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>LSTemplateApplication</key>",
+        "  <true/>",
+        "  <key>LSTemplateApplicationParameters</key>",
+        "  <dict>",
+        "    <key>CFBundleIdentifier</key>",
+        "    <string>com.apple.Safari.WebApp</string>",
+        "  </dict>",
+        "  <key>WKManifestURL</key>",
+        "  <string>https://github.com/manifest.json</string>",
+        "  <key>Manifest</key>",
+        "  <dict>",
+        "    <key>name</key>",
+        "    <string>GitHub</string>",
+        "  </dict>"
+      ].join("\n")
+    });
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records).toEqual([]);
+  });
 });
 
 async function writeAppPlist(
@@ -65,8 +96,9 @@ async function writeAppPlist(
   {
     displayName,
     bundleIdentifier,
-    version
-  }: { displayName: string; bundleIdentifier: string; version: string }
+    version,
+    extraKeys = ""
+  }: { displayName: string; bundleIdentifier: string; version: string; extraKeys?: string }
 ): Promise<void> {
   await mkdir(path.join(appPath, "Contents"), { recursive: true });
   await writeFile(
@@ -81,6 +113,7 @@ async function writeAppPlist(
   <string>${bundleIdentifier}</string>
   <key>CFBundleShortVersionString</key>
   <string>${version}</string>
+${extraKeys}
 </dict>
 </plist>
 `

--- a/ElectronTests/homebrewAppLinking.test.ts
+++ b/ElectronTests/homebrewAppLinking.test.ts
@@ -35,9 +35,9 @@ describe("Homebrew app linking", () => {
       checkedAt: "2026-04-30T12:00:00.000Z"
     };
 
-    expect(
-      homebrewItemHasAppRepresentation(codeCask, [app], new Map([[app.id, update]]))
-    ).toBe(true);
+    expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map([[app.id, update]]))).toBe(
+      true
+    );
   });
 
   it("matches casks to ignored apps by app bundle name", () => {

--- a/ElectronTests/homebrewAppLinking.test.ts
+++ b/ElectronTests/homebrewAppLinking.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { homebrewItemHasAppRepresentation } from "../src/shared/homebrewAppLinking";
+import type { AppRecord, HomebrewManagedItem, UpdateRecord } from "../src/shared/domain";
+import { version } from "../src/shared/version";
+
+const app: AppRecord = {
+  id: "app:code",
+  bundlePath: "/Applications/Visual Studio Code.app",
+  displayName: "Code",
+  bundleIdentifier: "com.microsoft.VSCode",
+  localVersion: version("1.0.0"),
+  sourceHint: "homebrew"
+};
+
+const codeCask: HomebrewManagedItem = {
+  id: "cask:visual-studio-code",
+  token: "visual-studio-code",
+  name: "Visual Studio Code",
+  kind: "cask",
+  installedVersion: version("1.0.0"),
+  latestVersion: version("2.0.0"),
+  isOutdated: true
+};
+
+describe("Homebrew app linking", () => {
+  it("matches casks to app updates by Homebrew token", () => {
+    const update: UpdateRecord = {
+      id: app.id,
+      appID: app.id,
+      source: "homebrew",
+      supportLevel: "supported",
+      localVersion: version("1.0.0"),
+      remoteVersion: version("2.0.0"),
+      homebrewToken: "visual-studio-code",
+      checkedAt: "2026-04-30T12:00:00.000Z"
+    };
+
+    expect(
+      homebrewItemHasAppRepresentation(codeCask, [app], new Map([[app.id, update]]))
+    ).toBe(true);
+  });
+
+  it("matches casks to ignored apps by app bundle name", () => {
+    expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map())).toBe(true);
+  });
+
+  it("does not treat formulae as app-backed items", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:visual-studio-code",
+      token: "visual-studio-code",
+      name: "visual-studio-code",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    };
+
+    expect(homebrewItemHasAppRepresentation(formula, [app], new Map())).toBe(false);
+  });
+});

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -591,21 +591,65 @@ describe("renderer button parity", () => {
   });
 
   it("renders the Homebrew tab outdated section as a card grid", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    };
     const { container } = render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}
-        snapshot={snapshot({ selectedTab: "homebrew" })}
+        snapshot={snapshot({ selectedTab: "homebrew", homebrewItems: [cask, formula] })}
       />
     );
 
     expect(container.querySelector(".update-grid")).toBeInTheDocument();
     expect(container.querySelector(".update-card")).toBeInTheDocument();
+    expect(container.querySelectorAll(".update-card")).toHaveLength(1);
     expect(container.querySelector(".rows .update-card")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
-    expect(screen.getByText("cask")).toBeInTheDocument();
-    expect(screen.getByText("1.0.0")).toBeInTheDocument();
-    expect(screen.getByText("2.0.0")).toBeInTheDocument();
+    expect(screen.getByText("formula")).toBeInTheDocument();
+    expect(screen.getByText("14.0.0")).toBeInTheDocument();
+    expect(screen.getByText("14.1.0")).toBeInTheDocument();
+    expect(screen.queryByText("cask")).not.toBeInTheDocument();
+    expect(screen.queryByText("1.0.0")).not.toBeInTheDocument();
+    expect(screen.queryByText("2.0.0")).not.toBeInTheDocument();
+  });
+
+  it("hides app-backed Homebrew casks from the Homebrew tab when the matching app is ignored", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    };
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "homebrew",
+          ignoredIDs: [app.id],
+          homebrewItems: [cask, formula]
+        })}
+      />
+    );
+
+    expect(container.querySelectorAll(".update-card")).toHaveLength(1);
+    expect(screen.getByText("formula")).toBeInTheDocument();
+    expect(screen.getByText("14.0.0")).toBeInTheDocument();
+    expect(screen.getByText("14.1.0")).toBeInTheDocument();
+    expect(screen.queryByText("cask")).not.toBeInTheDocument();
+    expect(screen.queryByText("1.0.0")).not.toBeInTheDocument();
+    expect(screen.queryByText("2.0.0")).not.toBeInTheDocument();
   });
 
   it("moves installed apps and Homebrew into the Installed sidebar item", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -509,7 +509,7 @@ describe("renderer button parity", () => {
     expect(window.baseline.installHomebrewItem).toHaveBeenCalledWith(item);
   });
 
-  it("shows Update All only for sections with more than one outdated item", () => {
+  it("shows Update Brews only for sections with more than one outdated item", () => {
     const second: HomebrewManagedItem = {
       ...cask,
       id: "formula:ripgrep",
@@ -527,7 +527,7 @@ describe("renderer button parity", () => {
         showUpdateAll
       />
     );
-    expect(screen.queryByRole("button", { name: "Update All" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update Brews" })).not.toBeInTheDocument();
 
     rerender(
       <HomebrewSection
@@ -539,7 +539,7 @@ describe("renderer button parity", () => {
         showUpdateAll
       />
     );
-    expect(screen.getByRole("button", { name: "Update All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update Brews" })).toBeInTheDocument();
   });
 
   it("renders full-window update sections as card grids with inline update actions", () => {
@@ -575,7 +575,7 @@ describe("renderer button parity", () => {
     expect(container.querySelectorAll(".update-grid")).toHaveLength(1);
     expect(container.querySelectorAll(".update-card")).toHaveLength(3);
     expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(3);
-    expect(screen.getByRole("button", { name: "Update All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update Brews" })).toBeInTheDocument();
     expect(
       Array.from(container.querySelectorAll(".update-card")).map((card) => card.textContent)
     ).toEqual(expect.arrayContaining([expect.stringContaining("Homebrew")]));

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1039,6 +1039,45 @@ describe("renderer button parity", () => {
     expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent("Discover");
   });
 
+  it("shows app-backed Homebrew updates in search when the app result does not match", () => {
+    const shortNamedApp: AppRecord = {
+      ...app,
+      id: "app:short-name",
+      bundlePath: "/Applications/Short Name.app",
+      displayName: "Short Name",
+      bundleIdentifier: "com.example.shortname"
+    };
+    const matchingUpdate: UpdateRecord = {
+      ...update,
+      id: shortNamedApp.id,
+      appID: shortNamedApp.id,
+      homebrewToken: "long-token-name"
+    };
+    const matchingCask: HomebrewManagedItem = {
+      ...cask,
+      id: "cask:long-token-name",
+      token: "long-token-name",
+      name: "Long Token Name"
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          searchText: "long-token-name",
+          apps: [shortNamedApp],
+          updates: [matchingUpdate],
+          homebrewItems: [matchingCask]
+        })}
+      />
+    );
+
+    expect(screen.queryByRole("heading", { name: "App Updates" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Homebrew Updates" })).toBeInTheDocument();
+    expect(screen.getByText("Long Token Name")).toBeInTheDocument();
+  });
+
   it("search hides cask-backed apps from Installed Apps", () => {
     const caskBackedApp: AppRecord = {
       ...app,

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -542,6 +542,39 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Update All" })).toBeInTheDocument();
   });
 
+  it("renders full-window update sections as card grids with inline update actions", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    };
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ homebrewItems: [cask, formula] })}
+      />
+    );
+
+    expect(container.querySelectorAll(".update-grid")).toHaveLength(2);
+    expect(container.querySelectorAll(".update-card")).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(2);
+    expect(
+      Array.from(container.querySelectorAll(".update-card")).map((card) => card.textContent)
+    ).toEqual(expect.arrayContaining([expect.stringContaining("Homebrew")]));
+    expect(
+      Array.from(container.querySelectorAll(".update-card")).map((card) => card.textContent)
+    ).toEqual(expect.arrayContaining([expect.stringContaining("formula")]));
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("2.0.0")).toBeInTheDocument();
+    expect(screen.getByText("14.0.0")).toBeInTheDocument();
+    expect(screen.getByText("14.1.0")).toBeInTheDocument();
+  });
+
   it("moves installed apps and Homebrew into the Installed sidebar item", () => {
     const installedApp: AppRecord = {
       ...app,
@@ -604,7 +637,7 @@ describe("renderer button parity", () => {
   });
 
   it("renders compact menu bar as all updates without tabs or recent sections", () => {
-    render(
+    const { container } = render(
       <Dashboard
         compact
         onOpenSettings={() => undefined}
@@ -637,6 +670,7 @@ describe("renderer button parity", () => {
     );
 
     expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+    expect(container.querySelector(".update-grid")).not.toBeInTheDocument();
     expect(screen.queryByText("2 available")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Refresh" })).toHaveClass("toolbar-button");

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -552,17 +552,30 @@ describe("renderer button parity", () => {
       latestVersion: version("14.1.0"),
       isOutdated: true
     };
+    const secondFormula: HomebrewManagedItem = {
+      id: "formula:fd",
+      token: "fd",
+      name: "fd",
+      kind: "formula",
+      installedVersion: version("9.0.0"),
+      latestVersion: version("10.0.0"),
+      isOutdated: true
+    };
     const { container } = render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}
-        snapshot={snapshot({ homebrewItems: [cask, formula] })}
+        snapshot={snapshot({ homebrewItems: [cask, formula, secondFormula] })}
       />
     );
 
-    expect(container.querySelectorAll(".update-grid")).toHaveLength(2);
-    expect(container.querySelectorAll(".update-card")).toHaveLength(2);
-    expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Updates" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "App Updates" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Homebrew Updates" })).not.toBeInTheDocument();
+    expect(container.querySelectorAll(".update-grid")).toHaveLength(1);
+    expect(container.querySelectorAll(".update-card")).toHaveLength(3);
+    expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "Update All" })).toBeInTheDocument();
     expect(
       Array.from(container.querySelectorAll(".update-card")).map((card) => card.textContent)
     ).toEqual(expect.arrayContaining([expect.stringContaining("Homebrew")]));
@@ -573,6 +586,26 @@ describe("renderer button parity", () => {
     expect(screen.getByText("2.0.0")).toBeInTheDocument();
     expect(screen.getByText("14.0.0")).toBeInTheDocument();
     expect(screen.getByText("14.1.0")).toBeInTheDocument();
+    expect(screen.getByText("9.0.0")).toBeInTheDocument();
+    expect(screen.getByText("10.0.0")).toBeInTheDocument();
+  });
+
+  it("renders the Homebrew tab outdated section as a card grid", () => {
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ selectedTab: "homebrew" })}
+      />
+    );
+
+    expect(container.querySelector(".update-grid")).toBeInTheDocument();
+    expect(container.querySelector(".update-card")).toBeInTheDocument();
+    expect(container.querySelector(".rows .update-card")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+    expect(screen.getByText("cask")).toBeInTheDocument();
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("2.0.0")).toBeInTheDocument();
   });
 
   it("moves installed apps and Homebrew into the Installed sidebar item", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -845,9 +845,17 @@ describe("renderer button parity", () => {
 
     expect(container.querySelector(".ignored-grid")).toBeInTheDocument();
     expect(container.querySelector(".ignored-card")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
     expect(screen.getByText("1.0.0")).toBeInTheDocument();
     expect(screen.getByText("2.0.0")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Update",
+      "Unignore",
+      "Uninstall"
+    ]);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Update" }));
+    expect(window.baseline.performAppUpdate).toHaveBeenCalledWith(app.id);
 
     rerender(
       <Dashboard
@@ -862,8 +870,16 @@ describe("renderer button parity", () => {
 
     expect(container.querySelector(".ignored-grid")).toBeInTheDocument();
     expect(container.querySelector(".ignored-card")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
     expect(screen.getByText("cask")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Update",
+      "Unignore",
+      "Uninstall"
+    ]);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Update" }));
+    expect(window.baseline.performHomebrewUpdate).toHaveBeenCalledWith(cask.id);
   });
 
   it("search includes installed items and hides empty result sections", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -685,7 +685,7 @@ describe("renderer button parity", () => {
     await waitFor(() => expect(screen.getByPlaceholderText("Search")).toHaveFocus());
   });
 
-  it("unifies app and Homebrew recently updated rows in the All tab without duplicating cask-backed apps", () => {
+  it("unifies app and Homebrew recently updated cards in the All tab without duplicating cask-backed apps", () => {
     const currentCask: HomebrewManagedItem = {
       ...cask,
       latestVersion: version("2.0.0"),
@@ -709,7 +709,7 @@ describe("renderer button parity", () => {
       isOutdated: false
     };
 
-    render(
+    const { container } = render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}
@@ -764,6 +764,9 @@ describe("renderer button parity", () => {
     );
 
     expect(screen.getByRole("button", { name: "Recently Updated" })).toBeInTheDocument();
+    const recentGrid = container.querySelector(".recent-grid");
+    expect(recentGrid).toBeInTheDocument();
+    expect(recentGrid?.querySelectorAll(".recent-card")).toHaveLength(3);
     expect(
       screen.queryByRole("heading", { name: "Recently Updated Apps" })
     ).not.toBeInTheDocument();
@@ -773,6 +776,94 @@ describe("renderer button parity", () => {
     expect(screen.getAllByText("Example")).toHaveLength(1);
     expect(screen.getByText("Standalone")).toBeInTheDocument();
     expect(screen.getByText("ripgrep")).toBeInTheDocument();
+  });
+
+  it("renders app and Homebrew recently updated sections as card grids outside compact mode", () => {
+    const recentApp = {
+      id: "recent:app",
+      appID: app.id,
+      displayName: app.displayName,
+      fromVersion: version("1.0.0"),
+      toVersion: version("2.0.0"),
+      updatedAt: "2026-04-29T12:00:00.000Z"
+    };
+    const recentCask = {
+      id: "recent:cask",
+      itemID: cask.id,
+      token: cask.token,
+      kind: cask.kind,
+      displayName: cask.name,
+      fromVersion: version("1.0.0"),
+      toVersion: version("2.0.0"),
+      updatedAt: "2026-04-30T12:00:00.000Z"
+    };
+
+    const { container, rerender } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "apps",
+          updates: [],
+          recentlyUpdated: [recentApp]
+        })}
+      />
+    );
+
+    expect(container.querySelector(".recent-grid")).toBeInTheDocument();
+    expect(container.querySelector(".recent-card")).toBeInTheDocument();
+    expect(container.querySelector(".rows .recent-card")).not.toBeInTheDocument();
+
+    rerender(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "homebrew",
+          homebrewItems: [{ ...cask, isOutdated: false }],
+          updates: [],
+          homebrewRecentlyUpdated: [recentCask]
+        })}
+      />
+    );
+
+    expect(container.querySelector(".recent-grid")).toBeInTheDocument();
+    expect(container.querySelector(".recent-card")).toBeInTheDocument();
+  });
+
+  it("renders ignored app and Homebrew sections as card grids with existing update details", () => {
+    const { container, rerender } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "apps",
+          ignoredIDs: [app.id]
+        })}
+      />
+    );
+
+    expect(container.querySelector(".ignored-grid")).toBeInTheDocument();
+    expect(container.querySelector(".ignored-card")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("2.0.0")).toBeInTheDocument();
+
+    rerender(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "homebrew",
+          ignoredHomebrewItemIDs: [cask.id]
+        })}
+      />
+    );
+
+    expect(container.querySelector(".ignored-grid")).toBeInTheDocument();
+    expect(container.querySelector(".ignored-card")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+    expect(screen.getByText("cask")).toBeInTheDocument();
   });
 
   it("search includes installed items and hides empty result sections", () => {

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -207,11 +207,13 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
 function isWebAppBundle(info: InfoPlist): boolean {
   const templateParameters = recordValue(info.LSTemplateApplicationParameters);
   const templateIdentifier = stringValue(templateParameters?.CFBundleIdentifier);
+  const bundleIdentifier = stringValue(info.CFBundleIdentifier);
   return (
-    stringValue(info.CFBundleIdentifier)?.startsWith("com.apple.Safari.WebApp.") === true ||
+    bundleIdentifier?.startsWith("com.apple.Safari.WebApp.") === true ||
     templateIdentifier === "com.apple.Safari.WebApp" ||
-    stringValue(info.WKManifestURL) !== undefined ||
-    recordValue(info.Manifest) !== undefined
+    (stringValue(info.WKManifestURL) !== undefined &&
+      (bundleIdentifier?.startsWith("com.apple.Safari.") === true ||
+        templateIdentifier?.startsWith("com.apple.Safari.") === true))
   );
 }
 

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -62,6 +62,9 @@ export class BundleScannerClient {
     if (!info) {
       return undefined;
     }
+    if (isWebAppBundle(info)) {
+      return undefined;
+    }
 
     const displayName =
       stringValue(info.CFBundleDisplayName) ??
@@ -199,6 +202,17 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function isWebAppBundle(info: InfoPlist): boolean {
+  const templateParameters = recordValue(info.LSTemplateApplicationParameters);
+  const templateIdentifier = stringValue(templateParameters?.CFBundleIdentifier);
+  return (
+    stringValue(info.CFBundleIdentifier)?.startsWith("com.apple.Safari.WebApp.") === true ||
+    templateIdentifier === "com.apple.Safari.WebApp" ||
+    stringValue(info.WKManifestURL) !== undefined ||
+    recordValue(info.Manifest) !== undefined
+  );
 }
 
 function resizedIconDataURL(image: NativeImage): string {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,7 @@ import {
 import path from "node:path";
 import { renderDiagnostics } from "../shared/diagnostics";
 import type { BaselineSnapshot, HomebrewCaskDiscoveryItem, MenuTab } from "../shared/domain";
+import { homebrewItemHasAppRepresentation } from "../shared/homebrewAppLinking";
 import { ipcChannels, type PreferencePatch } from "../shared/ipc";
 import { isAllowedExternalURL } from "../shared/security";
 import { SnapshotPersistence } from "./persistence";
@@ -277,55 +278,21 @@ function trayUpdateTitle(snapshot: BaselineSnapshot): string {
   const ignoredHomebrew = new Set(snapshot.ignoredHomebrewItemIDs);
   const visibleAppUpdates = snapshot.updates.filter((update) => !ignored.has(update.appID));
   const visibleAppUpdateIDs = new Set(visibleAppUpdates.map((update) => update.appID));
-  const visibleAppsWithUpdates = snapshot.apps.filter((app) => visibleAppUpdateIDs.has(app.id));
-  const updatesByAppID = new Map(visibleAppUpdates.map((update) => [update.appID, update]));
+  const appsRepresentedOutsideHomebrew = snapshot.apps.filter(
+    (app) => visibleAppUpdateIDs.has(app.id) || ignored.has(app.id)
+  );
+  const updatesByAppID = new Map(snapshot.updates.map((update) => [update.appID, update]));
   const visibleHomebrewUpdates = snapshot.homebrewItems.filter(
     (item) =>
       item.isOutdated &&
       !ignoredHomebrew.has(item.id) &&
-      !homebrewItemHasTrayAppUpdate(item, visibleAppsWithUpdates, updatesByAppID)
+      !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
   );
   const visibleUpdates = visibleAppUpdates.length + visibleHomebrewUpdates.length;
   if (visibleUpdates === 0) {
     return "✓";
   }
   return `${visibleUpdates}\u2009↓`;
-}
-
-function homebrewItemHasTrayAppUpdate(
-  item: BaselineSnapshot["homebrewItems"][number],
-  apps: BaselineSnapshot["apps"],
-  updatesByAppID: Map<string, BaselineSnapshot["updates"][number]>
-): boolean {
-  if (item.kind !== "cask") {
-    return false;
-  }
-
-  return apps.some((app) => {
-    const update = updatesByAppID.get(app.id);
-    if (
-      update?.homebrewToken &&
-      normalizedTrayName(update.homebrewToken) === normalizedTrayName(item.token)
-    ) {
-      return true;
-    }
-    return normalizedTrayAppCandidates(app).has(normalizedTrayName(item.token));
-  });
-}
-
-function normalizedTrayAppCandidates(app: BaselineSnapshot["apps"][number]): Set<string> {
-  const fileName = app.bundlePath
-    .split("/")
-    .pop()
-    ?.replace(/\.app$/iu, "");
-  const candidates = [app.displayName, app.bundleIdentifier, fileName]
-    .filter((value): value is string => Boolean(value))
-    .map(normalizedTrayName);
-  return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));
-}
-
-function normalizedTrayName(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
 }
 
 function wireIpc(): void {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2506,9 +2506,11 @@ function deriveSections(snapshot: BaselineSnapshot) {
     .filter((item) => item.isOutdated && !snapshot.ignoredHomebrewItemIDs.includes(item.id))
     .filter(homebrewFilter)
     .sort(sortHomebrewOutdated);
-  const appsRepresentedOutsideHomebrew = snapshot.apps.filter(
-    (app) => updatesByAppID.has(app.id) || snapshot.ignoredIDs.includes(app.id)
-  );
+  const appsRepresentedOutsideHomebrew = term
+    ? [...availableApps, ...ignoredApps]
+    : snapshot.apps.filter(
+        (app) => updatesByAppID.has(app.id) || snapshot.ignoredIDs.includes(app.id)
+      );
   const allHomebrewOutdated = homebrewOutdated.filter(
     (item) =>
       !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
@@ -2587,7 +2589,6 @@ function uninstallableHomebrewItemForApp(
     return [...identifiers].some((identifier) => appCandidates.has(identifier));
   });
 }
-
 
 function sortByName(lhs: AppRecord, rhs: AppRecord): number {
   return lhs.displayName.localeCompare(rhs.displayName, undefined, { sensitivity: "base" });

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -356,7 +356,7 @@ function Sidebar({
         >
           <Beer size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Homebrew</span>
-          <strong>{derived.homebrewOutdated.length}</strong>
+          <strong>{derived.allHomebrewOutdated.length}</strong>
         </button>
       </nav>
       <nav className="source-list secondary-source-list">
@@ -1265,8 +1265,8 @@ function HomebrewTab({
       {snapshot.searchText.trim() && <DiscoverSection snapshot={snapshot} />}
       <HomebrewSection
         sectionID="outdated"
-        title={`Outdated (${derived.homebrewOutdated.length})`}
-        items={derived.homebrewOutdated}
+        title={`Outdated (${derived.allHomebrewOutdated.length})`}
+        items={derived.allHomebrewOutdated}
         snapshot={snapshot}
         empty="All your Homebrew items are up to date."
         showUpdateAll
@@ -2498,8 +2498,11 @@ function deriveSections(snapshot: BaselineSnapshot) {
     .filter((item) => item.isOutdated && !snapshot.ignoredHomebrewItemIDs.includes(item.id))
     .filter(homebrewFilter)
     .sort(sortHomebrewOutdated);
+  const appsRepresentedOutsideHomebrew = snapshot.apps.filter(
+    (app) => updatesByAppID.has(app.id) || snapshot.ignoredIDs.includes(app.id)
+  );
   const allHomebrewOutdated = homebrewOutdated.filter(
-    (item) => !homebrewItemHasAppUpdate(item, availableApps, updatesByAppID)
+    (item) => !homebrewItemHasAppUpdate(item, appsRepresentedOutsideHomebrew, updatesByAppID)
   );
   const homebrewInstalled = snapshot.homebrewItems
     .filter((item) => !item.isOutdated && !snapshot.ignoredHomebrewItemIDs.includes(item.id))

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -32,6 +32,14 @@ import type {
   UpdateRecord
 } from "../shared/domain";
 import { defaultPersistedSnapshot } from "../shared/domain";
+import {
+  homebrewItemHasAppRepresentation,
+  homebrewItemIdentifiers,
+  homebrewItemMatchesApp,
+  isCask,
+  normalizedAppCandidates,
+  normalizedHomebrewAppName
+} from "../shared/homebrewAppLinking";
 import "./styles.css";
 
 type Route = "main" | "menubar" | "settings";
@@ -2502,7 +2510,8 @@ function deriveSections(snapshot: BaselineSnapshot) {
     (app) => updatesByAppID.has(app.id) || snapshot.ignoredIDs.includes(app.id)
   );
   const allHomebrewOutdated = homebrewOutdated.filter(
-    (item) => !homebrewItemHasAppUpdate(item, appsRepresentedOutsideHomebrew, updatesByAppID)
+    (item) =>
+      !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
   );
   const homebrewInstalled = snapshot.homebrewItems
     .filter((item) => !item.isOutdated && !snapshot.ignoredHomebrewItemIDs.includes(item.id))
@@ -2528,38 +2537,6 @@ function deriveSections(snapshot: BaselineSnapshot) {
   };
 }
 
-function homebrewItemHasAppUpdate(
-  item: HomebrewManagedItem,
-  apps: AppRecord[],
-  updatesByAppID: Map<string, UpdateRecord>
-): boolean {
-  if (!isCask(item.kind)) {
-    return false;
-  }
-
-  return apps.some((app) => {
-    const update = updatesByAppID.get(app.id);
-    if (
-      update?.homebrewToken &&
-      normalizedName(update.homebrewToken) === normalizedName(item.token)
-    ) {
-      return true;
-    }
-    return normalizedAppCandidates(app).has(normalizedName(item.token));
-  });
-}
-
-function homebrewItemMatchesApp(item: HomebrewManagedItem, apps: AppRecord[]): boolean {
-  if (!isCask(item.kind)) {
-    return false;
-  }
-
-  const identifiers = homebrewItemIdentifiers(item);
-  return apps.some((app) =>
-    [...identifiers].some((identifier) => normalizedAppCandidates(app).has(identifier))
-  );
-}
-
 function matchingAppForHomebrewItem(
   item: Pick<HomebrewManagedItem, "kind" | "token"> &
     Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>,
@@ -2571,7 +2548,8 @@ function matchingAppForHomebrewItem(
 
   const identifiers = homebrewItemIdentifiers(item);
   const matchingUpdate = snapshot.updates.find(
-    (update) => update.homebrewToken && identifiers.has(normalizedName(update.homebrewToken))
+    (update) =>
+      update.homebrewToken && identifiers.has(normalizedHomebrewAppName(update.homebrewToken))
   );
   const appFromUpdate = matchingUpdate
     ? snapshot.apps.find((app) => app.id === matchingUpdate.appID)
@@ -2591,9 +2569,9 @@ function uninstallableHomebrewItemForApp(
 ): HomebrewManagedItem | undefined {
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
   if (update?.homebrewToken) {
-    const token = normalizedName(update.homebrewToken);
+    const token = normalizedHomebrewAppName(update.homebrewToken);
     const matchedByUpdate = snapshot.homebrewItems.find(
-      (item) => item.kind === "cask" && normalizedName(item.token) === token
+      (item) => item.kind === "cask" && normalizedHomebrewAppName(item.token) === token
     );
     if (matchedByUpdate) {
       return matchedByUpdate;
@@ -2610,35 +2588,6 @@ function uninstallableHomebrewItemForApp(
   });
 }
 
-function homebrewItemIdentifiers(
-  item: Pick<HomebrewManagedItem, "token"> &
-    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>
-): Set<string> {
-  return new Set(
-    [item.token, item.name, item.displayName]
-      .filter((value): value is string => Boolean(value))
-      .map(normalizedName)
-  );
-}
-
-function normalizedAppCandidates(app: AppRecord): Set<string> {
-  const fileName = app.bundlePath
-    .split("/")
-    .pop()
-    ?.replace(/\.app$/iu, "");
-  const candidates = [app.displayName, app.bundleIdentifier, fileName]
-    .filter((value): value is string => Boolean(value))
-    .map(normalizedName);
-  return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));
-}
-
-function normalizedName(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
-}
-
-function isCask(kind: string): boolean {
-  return kind.toLowerCase() === "cask";
-}
 
 function sortByName(lhs: AppRecord, rhs: AppRecord): number {
   return lhs.displayName.localeCompare(rhs.displayName, undefined, { sensitivity: "base" });

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -568,27 +568,99 @@ function AllTab({
   derived: DerivedSections;
   compact?: boolean;
 }) {
+  if (compact) {
+    return (
+      <div className="stack">
+        <AppSection
+          sectionID="available"
+          title={`App Updates (${derived.availableApps.length})`}
+          apps={derived.availableApps}
+          snapshot={snapshot}
+          empty="All your apps are up to date."
+        />
+        <HomebrewSection
+          sectionID="outdated"
+          title={`Homebrew Updates (${derived.allHomebrewOutdated.length})`}
+          items={derived.allHomebrewOutdated}
+          snapshot={snapshot}
+          empty="All your Homebrew items are up to date."
+          showUpdateAll
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className="stack all-tab-stack">
-      <AppSection
-        sectionID="available"
-        title={`App Updates (${derived.availableApps.length})`}
-        apps={derived.availableApps}
-        snapshot={snapshot}
-        empty="All your apps are up to date."
-        cardLayout={!compact}
-      />
-      <HomebrewSection
-        sectionID="outdated"
-        title={`Homebrew Updates (${derived.allHomebrewOutdated.length})`}
-        items={derived.allHomebrewOutdated}
-        snapshot={snapshot}
-        empty="All your Homebrew items are up to date."
-        showUpdateAll
-        cardLayout={!compact}
-      />
-      {!compact && <AllRecentlyUpdatedSection snapshot={snapshot} derived={derived} />}
+    <div className="stack">
+      <AllUpdatesSection snapshot={snapshot} derived={derived} />
+      <AllRecentlyUpdatedSection snapshot={snapshot} derived={derived} />
     </div>
+  );
+}
+
+function AllUpdatesSection({
+  snapshot,
+  derived
+}: {
+  snapshot: BaselineSnapshot;
+  derived: DerivedSections;
+}) {
+  const items: RecentGridItem[] = [
+    ...derived.availableApps.map((app) => ({
+      type: "app" as const,
+      id: app.id,
+      updatedAt: "",
+      item: app
+    })),
+    ...derived.allHomebrewOutdated.map((item) => ({
+      type: "homebrew" as const,
+      id: item.id,
+      updatedAt: "",
+      item
+    }))
+  ];
+
+  return (
+    <section className="panel">
+      <PanelTitle
+        title={`Updates (${combinedAvailableCount(derived)})`}
+        action={
+          derived.allHomebrewOutdated.length > 1 ? (
+            <UpdateActionButton
+              state={
+                snapshot.isRunningHomebrewMaintenance
+                  ? { type: "updating" }
+                  : derived.allHomebrewOutdated.every((item) =>
+                        snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id)
+                      )
+                    ? { type: "done" }
+                    : { type: "ready" }
+              }
+              readyLabel="Update All"
+              readyVariant="outline"
+              onAction={() => void window.baseline.performHomebrewUpdateAll()}
+            />
+          ) : undefined
+        }
+      />
+      {items.length === 0 ? (
+        <Empty text="All your apps and Homebrew items are up to date." />
+      ) : (
+        <CardGrid sectionClassName="update-grid">
+          {items.map((item) =>
+            item.type === "app" ? (
+              <AppUpdateCard key={`app:${item.id}`} app={item.item} snapshot={snapshot} />
+            ) : (
+              <HomebrewUpdateCard
+                key={`homebrew:${item.id}`}
+                item={item.item}
+                snapshot={snapshot}
+              />
+            )
+          )}
+        </CardGrid>
+      )}
+    </section>
   );
 }
 
@@ -1198,6 +1270,7 @@ function HomebrewTab({
         snapshot={snapshot}
         empty="All your Homebrew items are up to date."
         showUpdateAll
+        cardLayout
       />
       {snapshot.showRecentlyUpdatedHomebrewSection && (
         <RecentlyUpdatedHomebrewSection

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -7,6 +7,7 @@ import {
   Check,
   CheckCircle2,
   ChevronRight,
+  Download,
   Eye,
   EyeOff,
   ExternalLink,
@@ -1918,7 +1919,7 @@ function RowMoreActionButton({
               disabled={updateAction.disabled || updateAction.state.type !== "ready"}
             >
               {updateAction.state.type === "ready" ? (
-                <RefreshCcw size={14} />
+                <Download size={14} />
               ) : updateAction.state.type === "updating" ? (
                 updateAction.state.progress === undefined ? (
                   <RefreshCcw className="spin" size={14} />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -521,6 +521,7 @@ function SearchResults({
           apps={derived.availableApps}
           snapshot={snapshot}
           empty="All your apps are up to date."
+          cardLayout
         />
       )}
       {derived.allHomebrewOutdated.length > 0 && (
@@ -531,6 +532,7 @@ function SearchResults({
           snapshot={snapshot}
           empty="All your Homebrew items are up to date."
           showUpdateAll
+          cardLayout
         />
       )}
       {searchInstalledApps.length > 0 && (
@@ -573,6 +575,7 @@ function AllTab({
         apps={derived.availableApps}
         snapshot={snapshot}
         empty="All your apps are up to date."
+        cardLayout={!compact}
       />
       <HomebrewSection
         sectionID="outdated"
@@ -581,6 +584,7 @@ function AllTab({
         snapshot={snapshot}
         empty="All your Homebrew items are up to date."
         showUpdateAll
+        cardLayout={!compact}
       />
       {!compact && <AllRecentlyUpdatedSection snapshot={snapshot} derived={derived} />}
     </div>
@@ -652,6 +656,7 @@ function AppsTab({ snapshot, derived }: { snapshot: BaselineSnapshot; derived: D
         apps={derived.availableApps}
         snapshot={snapshot}
         empty="All your apps are up to date."
+        cardLayout
       />
       {snapshot.showRecentlyUpdatedAppsSection && (
         <RecentlyUpdatedAppSection
@@ -682,7 +687,8 @@ function AppSection({
   snapshot,
   empty,
   recentlyUpdated = false,
-  collapsible = false
+  collapsible = false,
+  cardLayout = false
 }: {
   sectionID: string;
   title: string;
@@ -691,6 +697,7 @@ function AppSection({
   empty: string;
   recentlyUpdated?: boolean;
   collapsible?: boolean;
+  cardLayout?: boolean;
 }) {
   const collapsed = collapsible && snapshot.collapsedAppSectionIDs.includes(sectionID);
   return (
@@ -704,6 +711,12 @@ function AppSection({
       {!collapsed &&
         (apps.length === 0 ? (
           <Empty text={empty} />
+        ) : cardLayout ? (
+          <CardGrid sectionClassName="update-grid">
+            {apps.map((app) => (
+              <AppUpdateCard key={app.id} app={app} snapshot={snapshot} />
+            ))}
+          </CardGrid>
         ) : (
           <div className="rows">
             {apps.map((app) => (
@@ -717,6 +730,87 @@ function AppSection({
           </div>
         ))}
     </section>
+  );
+}
+
+function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
+  const requestActionConfirmation = React.useContext(ActionConfirmationContext);
+  const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
+  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
+  const isIgnored = snapshot.ignoredIDs.includes(app.id);
+  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
+  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
+  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
+  const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
+  const isUninstalling = uninstallableItem
+    ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
+    : false;
+  const actionState = actionStateFromFlags({
+    failed,
+    updating: isUpdating,
+    progress,
+    done
+  });
+
+  return (
+    <article className={isIgnored ? "item-card update-card ignored-row" : "item-card update-card"}>
+      <div className="item-card-top">
+        <button
+          className={
+            app.iconDataURL
+              ? "app-icon app-icon-image clickable-app-icon"
+              : "app-icon clickable-app-icon"
+          }
+          onClick={() => void window.baseline.openApp(app.id)}
+          title="Open app"
+          aria-label="Open app"
+        >
+          {app.iconDataURL ? (
+            <img src={app.iconDataURL} alt="" draggable={false} />
+          ) : (
+            app.displayName.slice(0, 1).toUpperCase()
+          )}
+        </button>
+        <div className="item-card-actions">
+          {update && (
+            <UpdateActionButton
+              state={actionState}
+              disabled={isUninstalling}
+              onAction={() => void window.baseline.performAppUpdate(app.id)}
+            />
+          )}
+          <RowMoreActionButton
+            isIgnored={isIgnored}
+            disabled={isUninstalling}
+            onToggleIgnore={() => void window.baseline.toggleIgnoredApp(app.id)}
+            uninstallLabel="Uninstall"
+            canUninstall={Boolean(uninstallableItem)}
+            uninstalling={isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling}
+            onUninstall={() =>
+              uninstallableItem &&
+              requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
+            }
+          />
+        </div>
+      </div>
+      <div className="item-card-main row-main">
+        <div className="row-title">
+          <strong>{app.displayName}</strong>
+          {update && <span>{sourceLabel(update)}</span>}
+        </div>
+        <p>
+          {update ? (
+            <VersionChange
+              from={app.localVersion.raw || "unknown"}
+              to={update.remoteVersion.raw || "unknown"}
+            />
+          ) : (
+            app.localVersion.raw || "unknown"
+          )}
+        </p>
+      </div>
+    </article>
   );
 }
 
@@ -1231,7 +1325,8 @@ export function HomebrewSection({
   empty,
   showUpdateAll = false,
   collapsible = false,
-  recentlyUpdated = false
+  recentlyUpdated = false,
+  cardLayout = false
 }: {
   sectionID: string;
   title: string;
@@ -1241,6 +1336,7 @@ export function HomebrewSection({
   showUpdateAll?: boolean;
   collapsible?: boolean;
   recentlyUpdated?: boolean;
+  cardLayout?: boolean;
 }) {
   const collapsed = collapsible && snapshot.collapsedHomebrewSectionIDs.includes(sectionID);
   return (
@@ -1272,6 +1368,12 @@ export function HomebrewSection({
       {!collapsed &&
         (items.length === 0 ? (
           <Empty text={empty} />
+        ) : cardLayout ? (
+          <CardGrid sectionClassName="update-grid">
+            {items.map((item) => (
+              <HomebrewUpdateCard key={item.id} item={item} snapshot={snapshot} />
+            ))}
+          </CardGrid>
         ) : (
           <div className="rows">
             {items.map((item) => (
@@ -1285,6 +1387,71 @@ export function HomebrewSection({
           </div>
         ))}
     </section>
+  );
+}
+
+function HomebrewUpdateCard({
+  item,
+  snapshot
+}: {
+  item: HomebrewManagedItem;
+  snapshot: BaselineSnapshot;
+}) {
+  const requestActionConfirmation = React.useContext(ActionConfirmationContext);
+  const isUpdating = snapshot.homebrewUpdatingItemIDs.includes(item.id);
+  const isUninstalling = snapshot.homebrewUninstallingItemIDs.includes(item.id);
+  const isIgnored = snapshot.ignoredHomebrewItemIDs.includes(item.id);
+  const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
+  const done = snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id);
+  const progress = snapshot.homebrewBatchProgressByItemID[item.id];
+  const updateState = actionStateFromFlags({
+    failed,
+    updating: isUpdating,
+    progress,
+    done
+  });
+
+  return (
+    <article className={isIgnored ? "item-card update-card ignored-row" : "item-card update-card"}>
+      <div className="item-card-top">
+        <HomebrewItemIcon item={item} snapshot={snapshot} />
+        <div className="item-card-actions">
+          {item.isOutdated && (
+            <UpdateActionButton
+              state={updateState}
+              disabled={isUninstalling}
+              onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
+            />
+          )}
+          <RowMoreActionButton
+            isIgnored={isIgnored}
+            disabled={isUninstalling}
+            onToggleIgnore={() => void window.baseline.toggleIgnoredHomebrew(item.id)}
+            uninstallLabel="Uninstall"
+            canUninstall={item.kind === "cask"}
+            uninstalling={isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling}
+            onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
+          />
+        </div>
+      </div>
+      <div className="item-card-main row-main">
+        <div className="row-title">
+          <strong>{item.name}</strong>
+          <span>{item.kind}</span>
+        </div>
+        <p>
+          {item.latestVersion ? (
+            <VersionChange
+              from={item.installedVersion.raw || "unknown"}
+              to={item.latestVersion.raw}
+            />
+          ) : (
+            item.installedVersion.raw || "unknown"
+          )}
+        </p>
+      </div>
+    </article>
   );
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -603,7 +603,7 @@ function AllRecentlyUpdatedSection({
         (item) => !homebrewItemMatchesApp(item, recentlyUpdatedApps)
       )
     : [];
-  const rows = [
+  const rows: RecentGridItem[] = [
     ...recentlyUpdatedApps.map((app) => ({
       type: "app" as const,
       id: app.id,
@@ -632,20 +632,7 @@ function AllRecentlyUpdatedSection({
         (rows.length === 0 ? (
           <Empty text="No recently updated items yet." />
         ) : (
-          <div className="rows">
-            {rows.map((row) =>
-              row.type === "app" ? (
-                <AppRow key={`app:${row.id}`} app={row.item} snapshot={snapshot} recentlyUpdated />
-              ) : (
-                <HomebrewRow
-                  key={`homebrew:${row.id}`}
-                  item={row.item}
-                  snapshot={snapshot}
-                  recentlyUpdated
-                />
-              )
-            )}
-          </div>
+          <RecentGrid items={rows} snapshot={snapshot} />
         ))}
     </section>
   );
@@ -662,20 +649,17 @@ function AppsTab({ snapshot, derived }: { snapshot: BaselineSnapshot; derived: D
         empty="All your apps are up to date."
       />
       {snapshot.showRecentlyUpdatedAppsSection && (
-        <AppSection
+        <RecentlyUpdatedAppSection
           sectionID="recentlyUpdated"
-          collapsible
           title="Recently Updated"
           apps={derived.recentlyUpdatedApps}
           snapshot={snapshot}
           empty="No recently updated apps yet."
-          recentlyUpdated
         />
       )}
       {snapshot.showIgnoredAppsSection && (
-        <AppSection
+        <IgnoredAppSection
           sectionID="ignored"
-          collapsible
           title={`Ignored (${derived.ignoredApps.length})`}
           apps={derived.ignoredApps}
           snapshot={snapshot}
@@ -728,6 +712,278 @@ function AppSection({
           </div>
         ))}
     </section>
+  );
+}
+
+function RecentlyUpdatedAppSection({
+  sectionID,
+  title,
+  apps,
+  snapshot,
+  empty
+}: {
+  sectionID: string;
+  title: string;
+  apps: AppRecord[];
+  snapshot: BaselineSnapshot;
+  empty: string;
+}) {
+  const collapsed = snapshot.collapsedAppSectionIDs.includes(sectionID);
+  const items: RecentGridItem[] = apps.map((app) => ({
+    type: "app",
+    id: app.id,
+    updatedAt: snapshot.recentlyUpdated.find((record) => record.appID === app.id)?.updatedAt ?? "",
+    item: app
+  }));
+
+  return (
+    <section className="panel">
+      <PanelTitle
+        title={title}
+        collapsed={collapsed}
+        canCollapse
+        onToggleCollapse={() => toggleCollapsedSection("app", sectionID, snapshot)}
+      />
+      {!collapsed &&
+        (items.length === 0 ? (
+          <Empty text={empty} />
+        ) : (
+          <RecentGrid items={items} snapshot={snapshot} />
+        ))}
+    </section>
+  );
+}
+
+function IgnoredAppSection({
+  sectionID,
+  title,
+  apps,
+  snapshot,
+  empty
+}: {
+  sectionID: string;
+  title: string;
+  apps: AppRecord[];
+  snapshot: BaselineSnapshot;
+  empty: string;
+}) {
+  const collapsed = snapshot.collapsedAppSectionIDs.includes(sectionID);
+
+  return (
+    <section className="panel">
+      <PanelTitle
+        title={title}
+        collapsed={collapsed}
+        canCollapse
+        onToggleCollapse={() => toggleCollapsedSection("app", sectionID, snapshot)}
+      />
+      {!collapsed &&
+        (apps.length === 0 ? (
+          <Empty text={empty} />
+        ) : (
+          <CardGrid sectionClassName="ignored-grid">
+            {apps.map((app) => (
+              <IgnoredAppCard key={app.id} app={app} snapshot={snapshot} />
+            ))}
+          </CardGrid>
+        ))}
+    </section>
+  );
+}
+
+type RecentGridItem =
+  | {
+      type: "app";
+      id: string;
+      updatedAt: string;
+      item: AppRecord;
+    }
+  | {
+      type: "homebrew";
+      id: string;
+      updatedAt: string;
+      item: HomebrewManagedItem;
+    };
+
+function RecentGrid({ items, snapshot }: { items: RecentGridItem[]; snapshot: BaselineSnapshot }) {
+  return (
+    <CardGrid sectionClassName="recent-grid">
+      {items.map((item) =>
+        item.type === "app" ? (
+          <RecentAppCard key={`app:${item.id}`} app={item.item} snapshot={snapshot} />
+        ) : (
+          <RecentHomebrewCard key={`homebrew:${item.id}`} item={item.item} snapshot={snapshot} />
+        )
+      )}
+    </CardGrid>
+  );
+}
+
+function CardGrid({
+  children,
+  sectionClassName
+}: {
+  children: React.ReactNode;
+  sectionClassName: string;
+}) {
+  return <div className={`card-grid ${sectionClassName}`}>{children}</div>;
+}
+
+function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
+  const requestActionConfirmation = React.useContext(ActionConfirmationContext);
+  const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
+  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
+  const isIgnored = snapshot.ignoredIDs.includes(app.id);
+  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
+  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
+  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
+  const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
+  const isUninstalling = uninstallableItem
+    ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
+    : false;
+  const actionState = actionStateFromFlags({
+    failed,
+    updating: isUpdating,
+    progress,
+    done
+  });
+  const recentlyUpdatedRecord = snapshot.recentlyUpdated.find((record) => record.appID === app.id);
+
+  return (
+    <article className={isIgnored ? "item-card recent-card ignored-row" : "item-card recent-card"}>
+      <div className="item-card-top">
+        <button
+          className={
+            app.iconDataURL
+              ? "app-icon app-icon-image clickable-app-icon"
+              : "app-icon clickable-app-icon"
+          }
+          onClick={() => void window.baseline.openApp(app.id)}
+          title="Open app"
+          aria-label="Open app"
+        >
+          {app.iconDataURL ? (
+            <img src={app.iconDataURL} alt="" draggable={false} />
+          ) : (
+            app.displayName.slice(0, 1).toUpperCase()
+          )}
+        </button>
+        <div className="item-card-actions">
+          {update && (
+            <UpdateActionButton
+              state={actionState}
+              disabled={isUninstalling}
+              onAction={() => void window.baseline.performAppUpdate(app.id)}
+            />
+          )}
+          <RowMoreActionButton
+            isIgnored={isIgnored}
+            disabled={isUninstalling}
+            onToggleIgnore={() => void window.baseline.toggleIgnoredApp(app.id)}
+            uninstallLabel="Uninstall"
+            canUninstall={Boolean(uninstallableItem)}
+            uninstalling={isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling}
+            onUninstall={() =>
+              uninstallableItem &&
+              requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
+            }
+          />
+        </div>
+      </div>
+      <div className="item-card-main row-main">
+        <div className="row-title">
+          <strong>{app.displayName}</strong>
+          {update && <span>{sourceLabel(update)}</span>}
+        </div>
+        <p>
+          {recentlyUpdatedRecord
+            ? updatedRelativeLabel(recentlyUpdatedRecord.updatedAt)
+            : "Updated recently"}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
+  const requestActionConfirmation = React.useContext(ActionConfirmationContext);
+  const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
+  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
+  const isIgnored = snapshot.ignoredIDs.includes(app.id);
+  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
+  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
+  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
+  const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
+  const isUninstalling = uninstallableItem
+    ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
+    : false;
+  const actionState = actionStateFromFlags({
+    failed,
+    updating: isUpdating,
+    progress,
+    done
+  });
+
+  return (
+    <article className="item-card ignored-card ignored-row">
+      <div className="item-card-top">
+        <button
+          className={
+            app.iconDataURL
+              ? "app-icon app-icon-image clickable-app-icon"
+              : "app-icon clickable-app-icon"
+          }
+          onClick={() => void window.baseline.openApp(app.id)}
+          title="Open app"
+          aria-label="Open app"
+        >
+          {app.iconDataURL ? (
+            <img src={app.iconDataURL} alt="" draggable={false} />
+          ) : (
+            app.displayName.slice(0, 1).toUpperCase()
+          )}
+        </button>
+        <div className="item-card-actions">
+          {update && (
+            <UpdateActionButton
+              state={actionState}
+              disabled={isUninstalling}
+              onAction={() => void window.baseline.performAppUpdate(app.id)}
+            />
+          )}
+          <RowMoreActionButton
+            isIgnored={isIgnored}
+            disabled={isUninstalling}
+            onToggleIgnore={() => void window.baseline.toggleIgnoredApp(app.id)}
+            uninstallLabel="Uninstall"
+            canUninstall={Boolean(uninstallableItem)}
+            uninstalling={isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling}
+            onUninstall={() =>
+              uninstallableItem &&
+              requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
+            }
+          />
+        </div>
+      </div>
+      <div className="item-card-main row-main">
+        <div className="row-title">
+          <strong>{app.displayName}</strong>
+          {update && <span>{sourceLabel(update)}</span>}
+        </div>
+        <p>
+          {update ? (
+            <VersionChange
+              from={app.localVersion.raw || "unknown"}
+              to={update.remoteVersion.raw || "unknown"}
+            />
+          ) : (
+            app.localVersion.raw || "unknown"
+          )}
+        </p>
+      </div>
+    </article>
   );
 }
 
@@ -842,20 +1098,17 @@ function HomebrewTab({
         showUpdateAll
       />
       {snapshot.showRecentlyUpdatedHomebrewSection && (
-        <HomebrewSection
+        <RecentlyUpdatedHomebrewSection
           sectionID="recentlyUpdated"
-          collapsible
           title="Recently Updated"
           items={derived.homebrewRecentlyUpdated}
           snapshot={snapshot}
           empty="No recently updated Homebrew items yet."
-          recentlyUpdated
         />
       )}
       {snapshot.showIgnoredHomebrewSection && (
-        <HomebrewSection
+        <IgnoredHomebrewSection
           sectionID="ignored"
-          collapsible
           title={`Ignored (${derived.homebrewIgnored.length})`}
           items={derived.homebrewIgnored}
           snapshot={snapshot}
@@ -1025,6 +1278,211 @@ export function HomebrewSection({
           </div>
         ))}
     </section>
+  );
+}
+
+function RecentlyUpdatedHomebrewSection({
+  sectionID,
+  title,
+  items,
+  snapshot,
+  empty
+}: {
+  sectionID: string;
+  title: string;
+  items: HomebrewManagedItem[];
+  snapshot: BaselineSnapshot;
+  empty: string;
+}) {
+  const collapsed = snapshot.collapsedHomebrewSectionIDs.includes(sectionID);
+  const gridItems: RecentGridItem[] = items.map((item) => ({
+    type: "homebrew",
+    id: item.id,
+    updatedAt:
+      snapshot.homebrewRecentlyUpdated.find((record) => record.itemID === item.id)?.updatedAt ?? "",
+    item
+  }));
+
+  return (
+    <section className="panel">
+      <PanelTitle
+        title={title}
+        collapsed={collapsed}
+        canCollapse
+        onToggleCollapse={() => toggleCollapsedSection("homebrew", sectionID, snapshot)}
+      />
+      {!collapsed &&
+        (gridItems.length === 0 ? (
+          <Empty text={empty} />
+        ) : (
+          <RecentGrid items={gridItems} snapshot={snapshot} />
+        ))}
+    </section>
+  );
+}
+
+function IgnoredHomebrewSection({
+  sectionID,
+  title,
+  items,
+  snapshot,
+  empty
+}: {
+  sectionID: string;
+  title: string;
+  items: HomebrewManagedItem[];
+  snapshot: BaselineSnapshot;
+  empty: string;
+}) {
+  const collapsed = snapshot.collapsedHomebrewSectionIDs.includes(sectionID);
+
+  return (
+    <section className="panel">
+      <PanelTitle
+        title={title}
+        collapsed={collapsed}
+        canCollapse
+        onToggleCollapse={() => toggleCollapsedSection("homebrew", sectionID, snapshot)}
+      />
+      {!collapsed &&
+        (items.length === 0 ? (
+          <Empty text={empty} />
+        ) : (
+          <CardGrid sectionClassName="ignored-grid">
+            {items.map((item) => (
+              <IgnoredHomebrewCard key={item.id} item={item} snapshot={snapshot} />
+            ))}
+          </CardGrid>
+        ))}
+    </section>
+  );
+}
+
+function RecentHomebrewCard({
+  item,
+  snapshot
+}: {
+  item: HomebrewManagedItem;
+  snapshot: BaselineSnapshot;
+}) {
+  const requestActionConfirmation = React.useContext(ActionConfirmationContext);
+  const isUpdating = snapshot.homebrewUpdatingItemIDs.includes(item.id);
+  const isUninstalling = snapshot.homebrewUninstallingItemIDs.includes(item.id);
+  const isIgnored = snapshot.ignoredHomebrewItemIDs.includes(item.id);
+  const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
+  const done = snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id);
+  const progress = snapshot.homebrewBatchProgressByItemID[item.id];
+  const updateState = actionStateFromFlags({
+    failed,
+    updating: isUpdating,
+    progress,
+    done
+  });
+  const recentlyUpdatedRecord = snapshot.homebrewRecentlyUpdated.find(
+    (record) => record.itemID === item.id
+  );
+
+  return (
+    <article className={isIgnored ? "item-card recent-card ignored-row" : "item-card recent-card"}>
+      <div className="item-card-top">
+        <HomebrewItemIcon item={item} snapshot={snapshot} />
+        <div className="item-card-actions">
+          {item.isOutdated && (
+            <UpdateActionButton
+              state={updateState}
+              disabled={isUninstalling}
+              onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
+            />
+          )}
+          <RowMoreActionButton
+            isIgnored={isIgnored}
+            disabled={isUninstalling}
+            onToggleIgnore={() => void window.baseline.toggleIgnoredHomebrew(item.id)}
+            uninstallLabel="Uninstall"
+            canUninstall={item.kind === "cask"}
+            uninstalling={isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling}
+            onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
+          />
+        </div>
+      </div>
+      <div className="item-card-main row-main">
+        <div className="row-title">
+          <strong>{item.name}</strong>
+          <span>{item.kind}</span>
+        </div>
+        <p>
+          {recentlyUpdatedRecord
+            ? updatedRelativeLabel(recentlyUpdatedRecord.updatedAt)
+            : "Updated recently"}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function IgnoredHomebrewCard({
+  item,
+  snapshot
+}: {
+  item: HomebrewManagedItem;
+  snapshot: BaselineSnapshot;
+}) {
+  const requestActionConfirmation = React.useContext(ActionConfirmationContext);
+  const isUpdating = snapshot.homebrewUpdatingItemIDs.includes(item.id);
+  const isUninstalling = snapshot.homebrewUninstallingItemIDs.includes(item.id);
+  const isIgnored = snapshot.ignoredHomebrewItemIDs.includes(item.id);
+  const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
+  const done = snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id);
+  const progress = snapshot.homebrewBatchProgressByItemID[item.id];
+  const updateState = actionStateFromFlags({
+    failed,
+    updating: isUpdating,
+    progress,
+    done
+  });
+
+  return (
+    <article className="item-card ignored-card ignored-row">
+      <div className="item-card-top">
+        <HomebrewItemIcon item={item} snapshot={snapshot} />
+        <div className="item-card-actions">
+          {item.isOutdated && (
+            <UpdateActionButton
+              state={updateState}
+              disabled={isUninstalling}
+              onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
+            />
+          )}
+          <RowMoreActionButton
+            isIgnored={isIgnored}
+            disabled={isUninstalling}
+            onToggleIgnore={() => void window.baseline.toggleIgnoredHomebrew(item.id)}
+            uninstallLabel="Uninstall"
+            canUninstall={item.kind === "cask"}
+            uninstalling={isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling}
+            onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
+          />
+        </div>
+      </div>
+      <div className="item-card-main row-main">
+        <div className="row-title">
+          <strong>{item.name}</strong>
+          <span>{item.kind}</span>
+        </div>
+        <p>
+          {item.latestVersion ? (
+            <VersionChange
+              from={item.installedVersion.raw || "unknown"}
+              to={item.latestVersion.raw}
+            />
+          ) : (
+            item.installedVersion.raw || "unknown"
+          )}
+        </p>
+      </div>
+    </article>
   );
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -43,6 +43,11 @@ type ActionConfirmation =
   | { type: "install"; item: HomebrewCaskDiscoveryItem }
   | { type: "uninstall"; item: HomebrewManagedItem };
 type RequestActionConfirmation = (confirmation: ActionConfirmation) => void;
+type RowUpdateMenuAction = {
+  state: ActionState;
+  disabled?: boolean;
+  onAction: () => void;
+};
 
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
@@ -945,16 +950,18 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
           )}
         </button>
         <div className="item-card-actions">
-          {update && (
-            <UpdateActionButton
-              state={actionState}
-              disabled={isUninstalling}
-              onAction={() => void window.baseline.performAppUpdate(app.id)}
-            />
-          )}
           <RowMoreActionButton
             isIgnored={isIgnored}
             disabled={isUninstalling}
+            updateAction={
+              update
+                ? {
+                    state: actionState,
+                    disabled: isUninstalling,
+                    onAction: () => void window.baseline.performAppUpdate(app.id)
+                  }
+                : undefined
+            }
             onToggleIgnore={() => void window.baseline.toggleIgnoredApp(app.id)}
             uninstallLabel="Uninstall"
             canUninstall={Boolean(uninstallableItem)}
@@ -1447,16 +1454,18 @@ function IgnoredHomebrewCard({
       <div className="item-card-top">
         <HomebrewItemIcon item={item} snapshot={snapshot} />
         <div className="item-card-actions">
-          {item.isOutdated && (
-            <UpdateActionButton
-              state={updateState}
-              disabled={isUninstalling}
-              onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
-            />
-          )}
           <RowMoreActionButton
             isIgnored={isIgnored}
             disabled={isUninstalling}
+            updateAction={
+              item.isOutdated
+                ? {
+                    state: updateState,
+                    disabled: isUninstalling,
+                    onAction: () => void window.baseline.performHomebrewUpdate(item.id)
+                  }
+                : undefined
+            }
             onToggleIgnore={() => void window.baseline.toggleIgnoredHomebrew(item.id)}
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
@@ -1655,6 +1664,7 @@ export function UpdateActionButton({
 function RowMoreActionButton({
   isIgnored,
   disabled,
+  updateAction,
   onToggleIgnore,
   uninstallLabel,
   canUninstall = false,
@@ -1664,6 +1674,7 @@ function RowMoreActionButton({
 }: {
   isIgnored: boolean;
   disabled?: boolean;
+  updateAction?: RowUpdateMenuAction;
   onToggleIgnore: () => void;
   uninstallLabel: string;
   canUninstall?: boolean;
@@ -1704,6 +1715,15 @@ function RowMoreActionButton({
     onToggleIgnore();
   };
 
+  const invokeUpdate = () => {
+    if (!updateAction || updateAction.state.type !== "ready" || updateAction.disabled) {
+      return;
+    }
+
+    setOpen(false);
+    updateAction.onAction();
+  };
+
   const invokeUninstall = () => {
     setOpen(false);
     onUninstall();
@@ -1724,6 +1744,32 @@ function RowMoreActionButton({
       </button>
       {open && (
         <div className="row-action-menu-popover" role="menu">
+          {updateAction && (
+            <button
+              onClick={invokeUpdate}
+              role="menuitem"
+              disabled={updateAction.disabled || updateAction.state.type !== "ready"}
+            >
+              {updateAction.state.type === "ready" ? (
+                <RefreshCcw size={14} />
+              ) : updateAction.state.type === "updating" ? (
+                updateAction.state.progress === undefined ? (
+                  <RefreshCcw className="spin" size={14} />
+                ) : (
+                  <ProgressRing value={updateAction.state.progress} />
+                )
+              ) : updateAction.state.type === "done" ? (
+                <Check size={14} />
+              ) : (
+                <span className="failure-glyph">!</span>
+              )}
+              <span>
+                {updateAction.state.type === "ready"
+                  ? "Update"
+                  : actionStateLabel(updateAction.state)}
+              </span>
+            </button>
+          )}
           <button onClick={invokeIgnore} role="menuitem" disabled={disabled}>
             {isIgnored ? <EyeOff size={14} /> : <Eye size={14} />}
             <span>{ignoreLabel}</span>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -569,7 +569,7 @@ function AllTab({
   compact?: boolean;
 }) {
   return (
-    <div className="stack">
+    <div className="stack all-tab-stack">
       <AppSection
         sectionID="available"
         title={`App Updates (${derived.availableApps.length})`}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -644,7 +644,7 @@ function AllUpdatesSection({
                     ? { type: "done" }
                     : { type: "ready" }
               }
-              readyLabel="Update All"
+              readyLabel="Update Brews"
               readyVariant="outline"
               onAction={() => void window.baseline.performHomebrewUpdateAll()}
             />
@@ -1440,7 +1440,7 @@ export function HomebrewSection({
                     ? { type: "done" }
                     : { type: "ready" }
               }
-              readyLabel="Update All"
+              readyLabel="Update Brews"
               readyVariant="outline"
               onAction={() => void window.baseline.performHomebrewUpdateAll()}
             />

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -534,6 +534,11 @@ button:disabled {
   border-top: 0;
 }
 
+.app-shell:not(.compact) .content > .stack > .panel + .panel {
+  border-top: 1px solid rgba(60, 60, 67, 0.06);
+  padding-top: 16px;
+}
+
 .compact .row {
   grid-template-columns: 48px minmax(0, 1fr) auto;
   min-height: 68px;
@@ -1405,7 +1410,8 @@ button:disabled {
   }
 
   .row,
-  .ignored-row {
+  .ignored-row,
+  .app-shell:not(.compact) .content > .stack > .panel + .panel {
     border-color: rgba(235, 235, 245, 0.06);
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -539,6 +539,11 @@ button:disabled {
   padding-top: 16px;
 }
 
+.app-shell:not(.compact) .content > .all-tab-stack > .panel:nth-child(2) {
+  border-top: 0;
+  padding-top: 0;
+}
+
 .compact .row {
   grid-template-columns: 48px minmax(0, 1fr) auto;
   min-height: 68px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -838,6 +838,7 @@ button:disabled {
 
   .primary-button.outline-button:not(:disabled):hover {
     background: rgba(0, 122, 255, 0.1);
+    box-shadow: none;
     color: #0a84ff;
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -38,6 +38,7 @@ button:disabled {
 .app-shell {
   --sidebar-width: 196px;
   --sidebar-background: rgba(255, 255, 255, 0.5);
+  --update-accent-rgb: 0, 122, 255;
 
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
@@ -469,6 +470,17 @@ button:disabled {
     border-color 150ms ease,
     box-shadow 150ms ease,
     transform 150ms ease;
+}
+
+.item-card.update-card {
+  background:
+    linear-gradient(
+      145deg,
+      rgba(var(--update-accent-rgb), 0.085),
+      rgba(var(--update-accent-rgb), 0.02) 42%,
+      rgba(var(--update-accent-rgb), 0) 72%
+    ),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(242, 242, 242, 0.96)), #ffffff;
 }
 
 .item-card-top {
@@ -950,7 +962,7 @@ button:disabled {
   padding: 0 12px;
   border: 0;
   border-radius: 999px;
-  background: #007aff;
+  background: rgb(var(--update-accent-rgb));
   color: white;
 }
 
@@ -1277,6 +1289,7 @@ button:disabled {
 
   .app-shell {
     --sidebar-background: rgba(25, 25, 25, 0.2);
+    --update-accent-rgb: 10, 132, 255;
   }
 
   .app-shell.compact {
@@ -1426,6 +1439,18 @@ button:disabled {
       0 8px 18px rgba(0, 0, 0, 0.16);
   }
 
+  .item-card.update-card {
+    background:
+      linear-gradient(
+        145deg,
+        rgba(var(--update-accent-rgb), 0.12),
+        rgba(var(--update-accent-rgb), 0.04) 40%,
+        rgba(var(--update-accent-rgb), 0.01) 72%
+      ),
+      linear-gradient(180deg, rgba(36, 36, 36, 0.78), rgba(36, 36, 36, 0) 88px),
+      linear-gradient(180deg, rgba(0, 0, 0, 0) 58%, rgba(0, 0, 0, 0.04)), #1a1a1a;
+  }
+
   .app-icon {
     background: linear-gradient(180deg, #77777d, #3a3a3c);
   }
@@ -1546,7 +1571,7 @@ button:disabled {
   }
 
   .primary-button {
-    background: #0a84ff;
+    background: rgb(var(--update-accent-rgb));
   }
 
   .primary-button.outline-button {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -455,13 +455,13 @@ button:disabled {
   min-width: 0;
   min-height: 138px;
   padding: 14px;
-  border: 1px solid rgba(60, 60, 67, 0.1);
+  border: 1.5px solid rgba(60, 60, 67, 0.075);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(250, 250, 252, 0.92)), #ffffff;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 244, 244, 0.96)), #ffffff;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.04),
-    0 10px 24px rgba(0, 0, 0, 0.035);
+    0 4px 10px rgba(0, 0, 0, 0.03);
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease,
@@ -815,11 +815,11 @@ button:disabled {
   }
 
   .item-card:hover {
-    transform: translateY(-1px);
-    border-color: rgba(60, 60, 67, 0.18);
+    transform: translateY(-3px);
+    border-color: rgba(60, 60, 67, 0.11);
     box-shadow:
-      0 2px 5px rgba(0, 0, 0, 0.06),
-      0 14px 30px rgba(0, 0, 0, 0.055);
+      0 1px 2px rgba(0, 0, 0, 0.05),
+      0 6px 14px rgba(0, 0, 0, 0.04);
   }
 
   .update-icon-button:not(:disabled):hover,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -539,11 +539,6 @@ button:disabled {
   padding-top: 16px;
 }
 
-.app-shell:not(.compact) .content > .all-tab-stack > .panel:nth-child(2) {
-  border-top: 0;
-  padding-top: 0;
-}
-
 .compact .row {
   grid-template-columns: 48px minmax(0, 1fr) auto;
   min-height: 68px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -734,7 +734,7 @@ button:disabled {
   gap: 5px;
   min-height: 26px;
   font-size: 12px;
-  font-weight: 590;
+  font-weight: 500;
   letter-spacing: 0;
   transition:
     transform 150ms ease,
@@ -958,7 +958,7 @@ button:disabled {
 
 .primary-button,
 .danger-button {
-  min-width: 68px;
+  min-width: 54px;
   padding: 0 12px;
   border: 0;
   border-radius: 999px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -457,11 +457,11 @@ button:disabled {
   min-width: 0;
   min-height: 124px;
   padding: 14px;
-  border: 1px solid rgba(60, 60, 67, 0.05);
+  border: 1px solid rgba(67, 67, 67, 0.05);
   border-radius: 12px;
   background-clip: padding-box;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 244, 244, 0.96)), #ffffff;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(242, 242, 242, 0.96)), #ffffff;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.04),
     0 4px 10px rgba(0, 0, 0, 0.03);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -452,8 +452,8 @@ button:disabled {
 
 .item-card {
   --card-inner-highlight-strong: rgba(255, 255, 255, 0.92);
-  --card-inner-highlight-medium: rgba(255, 255, 255, 0.48);
-  --card-inner-highlight-soft: rgba(255, 255, 255, 0.16);
+  --card-inner-highlight-medium: rgba(255, 255, 255, 0.64);
+  --card-inner-highlight-soft: rgba(255, 255, 255, 0.24);
 
   position: relative;
   display: grid;
@@ -521,8 +521,8 @@ button:disabled {
   background:
     linear-gradient(
       145deg,
-      rgba(var(--update-accent-rgb), 0.085),
-      rgba(var(--update-accent-rgb), 0.02) 42%,
+      rgba(var(--update-accent-rgb), 0.1),
+      rgba(var(--update-accent-rgb), 0.05) 42%,
       rgba(var(--update-accent-rgb), 0) 72%
     ),
     linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(242, 242, 242, 0.96)), #ffffff;
@@ -1475,7 +1475,7 @@ button:disabled {
   }
 
   .item-card {
-    --card-inner-highlight-strong: rgba(255, 255, 255, 0.14);
+    --card-inner-highlight-strong: rgba(255, 255, 255, 0.12);
     --card-inner-highlight-medium: rgba(255, 255, 255, 0.1);
     --card-inner-highlight-soft: rgba(255, 255, 255, 0.04);
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1443,8 +1443,8 @@ button:disabled {
     background:
       linear-gradient(
         145deg,
-        rgba(var(--update-accent-rgb), 0.12),
-        rgba(var(--update-accent-rgb), 0.04) 40%,
+        rgba(var(--update-accent-rgb), 0.085),
+        rgba(var(--update-accent-rgb), 0.02) 40%,
         rgba(var(--update-accent-rgb), 0.01) 72%
       ),
       linear-gradient(180deg, rgba(36, 36, 36, 0.78), rgba(36, 36, 36, 0) 88px),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -442,6 +442,76 @@ button:disabled {
   display: grid;
 }
 
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding-top: 4px;
+}
+
+.item-card {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  min-height: 138px;
+  padding: 14px;
+  border: 1px solid rgba(60, 60, 67, 0.1);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(250, 250, 252, 0.92)), #ffffff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 10px 24px rgba(0, 0, 0, 0.035);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    transform 150ms ease;
+}
+
+.item-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.item-card .app-icon,
+.item-card .app-icon img {
+  width: 50px;
+  height: 50px;
+}
+
+.item-card .app-icon {
+  border-radius: 12px;
+  font-size: 17px;
+}
+
+.item-card .app-icon.brew {
+  width: 50px;
+  height: 50px;
+}
+
+.item-card .app-icon.brew svg {
+  width: 26px;
+  height: 26px;
+}
+
+.item-card-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.item-card-main {
+  display: grid;
+  align-content: end;
+  min-width: 0;
+  margin-top: 16px;
+}
+
 .row {
   display: grid;
   grid-template-columns: 50px minmax(0, 1fr) auto;
@@ -744,6 +814,14 @@ button:disabled {
     color: #0d0d0d;
   }
 
+  .item-card:hover {
+    transform: translateY(-1px);
+    border-color: rgba(60, 60, 67, 0.18);
+    box-shadow:
+      0 2px 5px rgba(0, 0, 0, 0.06),
+      0 14px 30px rgba(0, 0, 0, 0.055);
+  }
+
   .update-icon-button:not(:disabled):hover,
   .primary-button:not(:disabled):hover {
     background: #0a84ff;
@@ -808,6 +886,10 @@ button:disabled {
     transform: none;
   }
 
+  .item-card {
+    transition: none;
+  }
+
   .toolbar-button:not(:disabled):hover,
   .icon-button:not(:disabled):hover,
   .secondary-icon-button:not(:disabled):hover,
@@ -829,6 +911,18 @@ button:disabled {
   .destructive-text-button:not(:disabled):active,
   .segmented button:not(:disabled):active {
     transform: none;
+  }
+}
+
+@media (max-width: 920px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .card-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -1311,6 +1405,14 @@ button:disabled {
     border-color: rgba(235, 235, 245, 0.06);
   }
 
+  .item-card {
+    border-color: rgba(235, 235, 245, 0.1);
+    background: linear-gradient(180deg, rgba(36, 36, 38, 0.96), rgba(28, 28, 30, 0.92)), #1c1c1e;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.28),
+      0 12px 28px rgba(0, 0, 0, 0.22);
+  }
+
   .app-icon {
     background: linear-gradient(180deg, #77777d, #3a3a3c);
   }
@@ -1403,6 +1505,13 @@ button:disabled {
 
     .row-action-menu-popover button:not(:disabled):hover {
       background: rgba(255, 255, 255, 0.1);
+    }
+
+    .item-card:hover {
+      border-color: rgba(235, 235, 245, 0.16);
+      box-shadow:
+        0 2px 5px rgba(0, 0, 0, 0.32),
+        0 16px 34px rgba(0, 0, 0, 0.28);
     }
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -452,8 +452,10 @@ button:disabled {
 .item-card {
   position: relative;
   display: grid;
+  grid-template-rows: auto auto;
+  align-content: start;
   min-width: 0;
-  min-height: 138px;
+  min-height: 124px;
   padding: 14px;
   border: 1px solid rgba(60, 60, 67, 0.05);
   border-radius: 8px;
@@ -510,7 +512,7 @@ button:disabled {
   display: grid;
   align-content: end;
   min-width: 0;
-  margin-top: 16px;
+  margin-top: 12px;
 }
 
 .row {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -455,8 +455,9 @@ button:disabled {
   min-width: 0;
   min-height: 138px;
   padding: 14px;
-  border: 1.5px solid rgba(60, 60, 67, 0.075);
+  border: 1px solid rgba(60, 60, 67, 0.05);
   border-radius: 8px;
+  background-clip: padding-box;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 244, 244, 0.96)), #ffffff;
   box-shadow:
@@ -816,7 +817,7 @@ button:disabled {
 
   .item-card:hover {
     transform: translateY(-3px);
-    border-color: rgba(60, 60, 67, 0.11);
+    border-color: rgba(60, 60, 67, 0.075);
     box-shadow:
       0 1px 2px rgba(0, 0, 0, 0.05),
       0 6px 14px rgba(0, 0, 0, 0.04);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -458,7 +458,7 @@ button:disabled {
   min-height: 124px;
   padding: 14px;
   border: 1px solid rgba(60, 60, 67, 0.05);
-  border-radius: 8px;
+  border-radius: 12px;
   background-clip: padding-box;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 244, 244, 0.96)), #ffffff;
@@ -924,7 +924,8 @@ button:disabled {
 }
 
 @media (max-width: 680px) {
-  .card-grid {
+  .card-grid,
+  .update-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1406,11 +1406,13 @@ button:disabled {
   }
 
   .item-card {
-    border-color: rgba(235, 235, 245, 0.1);
-    background: linear-gradient(180deg, rgba(36, 36, 38, 0.96), rgba(28, 28, 30, 0.92)), #1c1c1e;
+    border-color: rgba(245, 245, 245, 0.09);
+    background:
+      linear-gradient(180deg, rgba(36, 36, 36, 0.78), rgba(36, 36, 36, 0) 88px),
+      linear-gradient(180deg, rgba(0, 0, 0, 0) 58%, rgba(0, 0, 0, 0.04)), #1a1a1a;
     box-shadow:
-      0 1px 2px rgba(0, 0, 0, 0.28),
-      0 12px 28px rgba(0, 0, 0, 0.22);
+      0 1px 2px rgba(0, 0, 0, 0.24),
+      0 8px 18px rgba(0, 0, 0, 0.16);
   }
 
   .app-icon {
@@ -1508,10 +1510,10 @@ button:disabled {
     }
 
     .item-card:hover {
-      border-color: rgba(235, 235, 245, 0.16);
+      border-color: rgba(235, 235, 235, 0.12);
       box-shadow:
-        0 2px 5px rgba(0, 0, 0, 0.32),
-        0 16px 34px rgba(0, 0, 0, 0.28);
+        0 1px 3px rgba(0, 0, 0, 0.28),
+        0 10px 22px rgba(0, 0, 0, 0.18);
     }
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -470,6 +470,15 @@ button:disabled {
     border-color 150ms ease,
     box-shadow 150ms ease,
     transform 150ms ease;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.item-card :is(strong, span, p) {
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .item-card.update-card {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -451,6 +451,10 @@ button:disabled {
 }
 
 .item-card {
+  --card-inner-highlight-strong: rgba(255, 255, 255, 0.92);
+  --card-inner-highlight-medium: rgba(255, 255, 255, 0.48);
+  --card-inner-highlight-soft: rgba(255, 255, 255, 0.16);
+
   position: relative;
   display: grid;
   grid-template-rows: auto auto;
@@ -473,6 +477,38 @@ button:disabled {
   cursor: default;
   -webkit-user-select: none;
   user-select: none;
+}
+
+.item-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.25px;
+  background:
+    radial-gradient(
+      145% 145% at 0% 0%,
+      var(--card-inner-highlight-strong) 0%,
+      var(--card-inner-highlight-medium) 28%,
+      var(--card-inner-highlight-soft) 48%,
+      transparent 68%
+    ),
+    radial-gradient(
+      145% 145% at 100% 100%,
+      var(--card-inner-highlight-strong) 0%,
+      var(--card-inner-highlight-medium) 28%,
+      var(--card-inner-highlight-soft) 48%,
+      transparent 68%
+    );
+  pointer-events: none;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
 }
 
 .item-card :is(strong, span, p) {
@@ -1439,6 +1475,10 @@ button:disabled {
   }
 
   .item-card {
+    --card-inner-highlight-strong: rgba(255, 255, 255, 0.14);
+    --card-inner-highlight-medium: rgba(255, 255, 255, 0.1);
+    --card-inner-highlight-soft: rgba(255, 255, 255, 0.04);
+
     border-color: rgba(245, 245, 245, 0.09);
     background:
       linear-gradient(180deg, rgba(36, 36, 36, 0.78), rgba(36, 36, 36, 0) 88px),

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -1,0 +1,76 @@
+import type {
+  AppRecord,
+  HomebrewCaskDiscoveryItem,
+  HomebrewManagedItem,
+  UpdateRecord
+} from "./domain";
+
+export function homebrewItemHasAppRepresentation(
+  item: Pick<HomebrewManagedItem, "kind" | "token"> &
+    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>,
+  apps: AppRecord[],
+  updatesByAppID: Map<string, UpdateRecord>
+): boolean {
+  if (!isCask(item.kind)) {
+    return false;
+  }
+
+  const identifiers = homebrewItemIdentifiers(item);
+  return apps.some((app) => {
+    const update = updatesByAppID.get(app.id);
+    if (
+      update?.homebrewToken &&
+      identifiers.has(normalizedHomebrewAppName(update.homebrewToken))
+    ) {
+      return true;
+    }
+
+    const appCandidates = normalizedAppCandidates(app);
+    return [...identifiers].some((identifier) => appCandidates.has(identifier));
+  });
+}
+
+export function homebrewItemMatchesApp(
+  item: Pick<HomebrewManagedItem, "kind" | "token"> &
+    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>,
+  apps: AppRecord[]
+): boolean {
+  if (!isCask(item.kind)) {
+    return false;
+  }
+
+  const identifiers = homebrewItemIdentifiers(item);
+  return apps.some((app) =>
+    [...identifiers].some((identifier) => normalizedAppCandidates(app).has(identifier))
+  );
+}
+
+export function homebrewItemIdentifiers(
+  item: Pick<HomebrewManagedItem, "token"> &
+    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>
+): Set<string> {
+  return new Set(
+    [item.token, item.name, item.displayName]
+      .filter((value): value is string => Boolean(value))
+      .map(normalizedHomebrewAppName)
+  );
+}
+
+export function normalizedAppCandidates(app: AppRecord): Set<string> {
+  const fileName = app.bundlePath
+    .split("/")
+    .pop()
+    ?.replace(/\.app$/iu, "");
+  const candidates = [app.displayName, app.bundleIdentifier, fileName]
+    .filter((value): value is string => Boolean(value))
+    .map(normalizedHomebrewAppName);
+  return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));
+}
+
+export function normalizedHomebrewAppName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
+}
+
+export function isCask(kind: string): boolean {
+  return kind.toLowerCase() === "cask";
+}

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -18,10 +18,7 @@ export function homebrewItemHasAppRepresentation(
   const identifiers = homebrewItemIdentifiers(item);
   return apps.some((app) => {
     const update = updatesByAppID.get(app.id);
-    if (
-      update?.homebrewToken &&
-      identifiers.has(normalizedHomebrewAppName(update.homebrewToken))
-    ) {
+    if (update?.homebrewToken && identifiers.has(normalizedHomebrewAppName(update.homebrewToken))) {
       return true;
     }
 


### PR DESCRIPTION
## Summary
- redesigns full-window update, Recently Updated, and Ignored sections as responsive card grids
- preserves compact menu bar sections in their existing list layout
- centralizes Homebrew cask/app matching so app-backed casks are not duplicated across renderer and tray surfaces
- skips Safari web app bundles during app scanning without hiding normal apps that contain generic manifest metadata
- disables text selection/caret cursor behavior for card text

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npm run test:electron
- npm audit --omit=dev --audit-level=high
