### PR TITLE
Make Homebrew recent records test deterministic

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -93,7 +93,8 @@ describe("update store helpers", () => {
           installedVersion: version("1.100.0")
         })
       ],
-      now
+      now,
+      { currentDate: new Date("2026-05-01T12:00:00.000Z") }
     );
 
     expect(records).toEqual([

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1041,7 +1041,8 @@ export function mergeHomebrewRecentlyUpdatedRecords(
   existingRecords: HomebrewRecentlyUpdatedRecord[],
   previousItems: HomebrewManagedItem[],
   currentItems: HomebrewManagedItem[],
-  now: string
+  now: string,
+  options: { currentDate?: Date } = {}
 ): HomebrewRecentlyUpdatedRecord[] {
   const records = [...existingRecords];
   const previousByID = new Map(previousItems.map((item) => [item.id, item]));
@@ -1067,7 +1068,7 @@ export function mergeHomebrewRecentlyUpdatedRecords(
   }
 
   const retentionMs = 14 * 24 * 60 * 60 * 1000;
-  const cutoff = Date.now() - retentionMs;
+  const cutoff = (options.currentDate?.getTime() ?? Date.now()) - retentionMs;
   const deduped = new Map<string, HomebrewRecentlyUpdatedRecord>();
   for (const record of records) {
     if (new Date(record.updatedAt).getTime() >= cutoff && !deduped.has(record.itemID)) {


### PR DESCRIPTION
## Summary
- Inject the retention cutoff clock into Homebrew recently updated record merging
- Keep production behavior defaulting to the real current time
- Pin the brittle unit test to a deterministic current date so it does not expire over time

## Validation
- npm test -- ElectronTests/updateStore.test.ts
- npm run typecheck
- npm run lint
