### PR TITLE
Fix Homebrew cask app linking

### DIFF
--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -169,7 +169,7 @@ describe("ported clients", () => {
     expect(index.byBundleIdentifier["com.example.schema-drift"]?.token).toBe("schema-drift-app");
   });
 
-  it("does not use quit metadata when only non-app artifact targets exist", () => {
+  it("does not treat non-app artifact targets as app bundle names", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(
@@ -200,10 +200,36 @@ describe("ported clients", () => {
     );
 
     expect(index.byBundleIdentifier["com.example.pkg-target"]).toBeUndefined();
-    expect(index.byAppBundleName["tool-helper.app"]?.[0]?.token).toBe("pkg-with-target");
+    expect(index.byAppBundleName["tool-helper.app"]).toBeUndefined();
     expect(
       client.lookupUpdate("com.example.pkg-target", "Audio MIDI Setup.app", version("0.9.0"), index)
     ).toBeUndefined();
+  });
+
+  it("keeps app-suffixed artifact targets available for app matching", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "renamed-app-target",
+            version: "2.0.0",
+            artifacts: [
+              {
+                artifact: [
+                  "Original.app",
+                  {
+                    target: "Renamed.app"
+                  }
+                ]
+              }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byAppBundleName["renamed.app"]?.[0]?.token).toBe("renamed-app-target");
   });
 
   it("searches formulae", () => {

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -94,6 +94,23 @@ describe("ported clients", () => {
     ).toBe("app-with-helper");
   });
 
+  it("keeps array-valued bundleIdentifier metadata", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "schema-drift-app",
+            version: "3.0.0",
+            bundleIdentifier: ["com.example.schema-drift"]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.schema-drift"]?.token).toBe("schema-drift-app");
+  });
+
   it("searches formulae", () => {
     const client = new HomebrewFormulaClient();
     const index = client.parseIndex(

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -169,6 +169,68 @@ describe("ported clients", () => {
     expect(index.byBundleIdentifier["com.example.schema-drift"]?.token).toBe("schema-drift-app");
   });
 
+  it("keeps explicit bundle identifiers ahead of newer inferred identifiers", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "explicit-owner",
+            version: "1.0.0",
+            bundleIdentifier: "com.example.shared"
+          },
+          {
+            token: "inferred-owner",
+            version: "2.0.0",
+            artifacts: [
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.shared"
+                  }
+                ]
+              },
+              { pkg: ["InferredOwner.pkg"] }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.shared"]?.token).toBe("explicit-owner");
+  });
+
+  it("lets explicit bundle identifiers replace older inferred identifiers", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "inferred-owner",
+            version: "2.0.0",
+            artifacts: [
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.shared"
+                  }
+                ]
+              },
+              { pkg: ["InferredOwner.pkg"] }
+            ]
+          },
+          {
+            token: "explicit-owner",
+            version: "1.0.0",
+            bundleIdentifier: "com.example.shared"
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.shared"]?.token).toBe("explicit-owner");
+  });
+
   it("does not treat non-app artifact targets as app bundle names", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -111,6 +111,39 @@ describe("ported clients", () => {
     expect(index.byBundleIdentifier["com.example.schema-drift"]?.token).toBe("schema-drift-app");
   });
 
+  it("uses quit metadata when non-app artifacts have targets", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "pkg-with-target",
+            version: "1.0.0",
+            artifacts: [
+              {
+                binary: [
+                  "tool",
+                  {
+                    target: "tool-helper"
+                  }
+                ]
+              },
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.pkg-target"
+                  }
+                ]
+              }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.pkg-target"]?.token).toBe("pkg-with-target");
+  });
+
   it("searches formulae", () => {
     const client = new HomebrewFormulaClient();
     const index = client.parseIndex(

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -64,6 +64,64 @@ describe("ported clients", () => {
     ).toBeUndefined();
   });
 
+  it("indexes package-backed casks without login items by uninstall quit metadata", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "pkg-backed-without-login-item",
+            version: "4.0.0",
+            artifacts: [
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.pkgbacked.no-login",
+                    delete: "/Applications/Package Backed No Login.app"
+                  }
+                ]
+              },
+              { pkg: ["PackageBackedNoLogin.pkg"] }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.pkgbacked.no-login"]?.token).toBe(
+      "pkg-backed-without-login-item"
+    );
+    expect(index.byAppBundleName["package backed no login.app"]?.[0]?.token).toBe(
+      "pkg-backed-without-login-item"
+    );
+  });
+
+  it("indexes package-backed casks with only quit metadata when no non-app target is present", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "pkg-backed-quit-only",
+            version: "5.0.0",
+            artifacts: [
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.quitonly"
+                  }
+                ]
+              },
+              { pkg: ["QuitOnly.pkg"] }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.quitonly"]?.token).toBe("pkg-backed-quit-only");
+  });
+
   it("does not let quit metadata override app artifact matching", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -33,7 +33,7 @@ describe("ported clients", () => {
     expect(index.byAppBundleName["example.app"]?.[0]?.token).toBe("example-app");
   });
 
-  it("indexes package-backed casks by uninstall metadata", () => {
+  it("matches package-backed casks by app name without indexing inferred quit IDs", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(
@@ -57,14 +57,21 @@ describe("ported clients", () => {
       )
     );
 
-    expect(index.byBundleIdentifier["com.example.pkgbacked"]?.token).toBe("pkg-backed-app");
+    expect(index.byBundleIdentifier["com.example.pkgbacked"]).toBeUndefined();
     expect(index.byAppBundleName["package backed.app"]?.[0]?.token).toBe("pkg-backed-app");
     expect(
       client.lookupUpdate("com.example.pkgbacked", "Package Backed.app", version("1.2.1"), index)
     ).toBeUndefined();
+    expect(
+      client.lookupUpdate("com.example.pkgbacked", "Package Backed.app", version("1.0.0"), index)
+        ?.token
+    ).toBe("pkg-backed-app");
+    expect(
+      client.lookupUpdate("com.example.pkgbacked", "Helper.app", version("1.0.0"), index)
+    ).toBeUndefined();
   });
 
-  it("indexes package-backed casks without login items by uninstall quit metadata", () => {
+  it("matches package-backed casks without login items by deleted app name", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(
@@ -88,15 +95,21 @@ describe("ported clients", () => {
       )
     );
 
-    expect(index.byBundleIdentifier["com.example.pkgbacked.no-login"]?.token).toBe(
-      "pkg-backed-without-login-item"
-    );
+    expect(index.byBundleIdentifier["com.example.pkgbacked.no-login"]).toBeUndefined();
     expect(index.byAppBundleName["package backed no login.app"]?.[0]?.token).toBe(
       "pkg-backed-without-login-item"
     );
+    expect(
+      client.lookupUpdate(
+        "com.example.pkgbacked.no-login",
+        "Package Backed No Login.app",
+        version("3.0.0"),
+        index
+      )?.token
+    ).toBe("pkg-backed-without-login-item");
   });
 
-  it("indexes package-backed casks with only quit metadata when no non-app target is present", () => {
+  it("keeps quit-only package-backed casks searchable without authoritative app matching", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(
@@ -119,7 +132,13 @@ describe("ported clients", () => {
       )
     );
 
-    expect(index.byBundleIdentifier["com.example.quitonly"]?.token).toBe("pkg-backed-quit-only");
+    expect(index.byToken["pkg-backed-quit-only"]?.inferredBundleIdentifiers).toEqual([
+      "com.example.quitonly"
+    ]);
+    expect(index.byBundleIdentifier["com.example.quitonly"]).toBeUndefined();
+    expect(client.searchCasks("quit only", index, new Set()).at(0)?.token).toBe(
+      "pkg-backed-quit-only"
+    );
   });
 
   it("does not let quit metadata override app artifact matching", () => {
@@ -169,7 +188,7 @@ describe("ported clients", () => {
     expect(index.byBundleIdentifier["com.example.schema-drift"]?.token).toBe("schema-drift-app");
   });
 
-  it("keeps explicit bundle identifiers ahead of newer inferred identifiers", () => {
+  it("keeps explicit bundle identifiers when newer casks only infer the same identifier", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(
@@ -200,7 +219,7 @@ describe("ported clients", () => {
     expect(index.byBundleIdentifier["com.example.shared"]?.token).toBe("explicit-owner");
   });
 
-  it("lets explicit bundle identifiers replace older inferred identifiers", () => {
+  it("indexes explicit bundle identifiers even when older casks only infer the same identifier", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -33,6 +33,37 @@ describe("ported clients", () => {
     expect(index.byAppBundleName["example.app"]?.[0]?.token).toBe("example-app");
   });
 
+  it("indexes package-backed casks by uninstall metadata", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "pkg-backed-app",
+            version: "1.2.0",
+            artifacts: [
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.pkgbacked",
+                    login_item: "Package Backed"
+                  }
+                ]
+              },
+              { pkg: ["PackageBacked.pkg"] }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.pkgbacked"]?.token).toBe("pkg-backed-app");
+    expect(index.byAppBundleName["package backed.app"]?.[0]?.token).toBe("pkg-backed-app");
+    expect(
+      client.lookupUpdate("com.example.pkgbacked", "Package Backed.app", version("1.2.1"), index)
+    ).toBeUndefined();
+  });
+
   it("searches formulae", () => {
     const client = new HomebrewFormulaClient();
     const index = client.parseIndex(

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -111,7 +111,7 @@ describe("ported clients", () => {
     expect(index.byBundleIdentifier["com.example.schema-drift"]?.token).toBe("schema-drift-app");
   });
 
-  it("uses quit metadata when non-app artifacts have targets", () => {
+  it("does not use quit metadata when only non-app artifact targets exist", () => {
     const client = new HomebrewCaskClient();
     const index = client.parseIndex(
       Buffer.from(
@@ -141,7 +141,11 @@ describe("ported clients", () => {
       )
     );
 
-    expect(index.byBundleIdentifier["com.example.pkg-target"]?.token).toBe("pkg-with-target");
+    expect(index.byBundleIdentifier["com.example.pkg-target"]).toBeUndefined();
+    expect(index.byAppBundleName["tool-helper.app"]?.[0]?.token).toBe("pkg-with-target");
+    expect(
+      client.lookupUpdate("com.example.pkg-target", "Audio MIDI Setup.app", version("0.9.0"), index)
+    ).toBeUndefined();
   });
 
   it("searches formulae", () => {

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -64,6 +64,36 @@ describe("ported clients", () => {
     ).toBeUndefined();
   });
 
+  it("does not let quit metadata override app artifact matching", () => {
+    const client = new HomebrewCaskClient();
+    const index = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "app-with-helper",
+            version: "2.0.0",
+            artifacts: [
+              { app: ["App With Helper.app"] },
+              {
+                uninstall: [
+                  {
+                    quit: "com.example.helper"
+                  }
+                ]
+              }
+            ]
+          }
+        ])
+      )
+    );
+
+    expect(index.byBundleIdentifier["com.example.helper"]).toBeUndefined();
+    expect(index.byAppBundleName["app with helper.app"]?.[0]?.token).toBe("app-with-helper");
+    expect(
+      client.lookupUpdate("com.example.main", "App With Helper.app", version("1.0.0"), index)?.token
+    ).toBe("app-with-helper");
+  });
+
   it("searches formulae", () => {
     const client = new HomebrewFormulaClient();
     const index = client.parseIndex(

--- a/ElectronTests/homebrewAppLinking.test.ts
+++ b/ElectronTests/homebrewAppLinking.test.ts
@@ -40,8 +40,14 @@ describe("Homebrew app linking", () => {
     );
   });
 
-  it("matches casks to ignored apps by app bundle name", () => {
-    expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map())).toBe(true);
+  it("matches casks to ignored apps by explicit app link", () => {
+    expect(homebrewItemHasAppRepresentation({ ...codeCask, appID: app.id }, [app], new Map())).toBe(
+      true
+    );
+  });
+
+  it("does not use app bundle names alone as app-backed proof", () => {
+    expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map())).toBe(false);
   });
 
   it("does not treat formulae as app-backed items", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -800,7 +800,8 @@ describe("renderer button parity", () => {
     const currentCask: HomebrewManagedItem = {
       ...cask,
       latestVersion: version("2.0.0"),
-      isOutdated: false
+      isOutdated: false,
+      appID: app.id
     };
     const standaloneCask: HomebrewManagedItem = {
       ...cask,
@@ -1097,7 +1098,8 @@ describe("renderer button parity", () => {
       token: "managed",
       name: "Managed",
       latestVersion: version("1.0.0"),
-      isOutdated: false
+      isOutdated: false,
+      appID: caskBackedApp.id
     };
 
     render(
@@ -1149,7 +1151,8 @@ describe("renderer button parity", () => {
       token: "managed",
       name: "Managed",
       latestVersion: version("1.0.0"),
-      isOutdated: false
+      isOutdated: false,
+      appID: managedApp.id
     };
 
     render(
@@ -1174,6 +1177,48 @@ describe("renderer button parity", () => {
     expect(installedHomebrew).not.toBeNull();
     expect(within(installedApps as HTMLElement).getAllByText("Managed")).toHaveLength(1);
     expect(within(installedHomebrew as HTMLElement).getByText("Managed")).toBeInTheDocument();
+  });
+
+  it("does not treat a non-app cask token as proof that an installed app is cask-backed", () => {
+    const installedApp: AppRecord = {
+      ...app,
+      id: "app:managed",
+      bundlePath: "/Applications/Managed.app",
+      displayName: "Managed",
+      bundleIdentifier: "com.example.managed"
+    };
+    const nonAppCask: HomebrewManagedItem = {
+      ...cask,
+      id: "cask:managed",
+      token: "managed",
+      name: "managed",
+      latestVersion: version("1.0.0"),
+      isOutdated: false,
+      iconDataURL: undefined
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "installed",
+          apps: [installedApp],
+          updates: [],
+          homebrewItems: [nonAppCask],
+          homebrewDiscoverItems: []
+        })}
+      />
+    );
+
+    const installedApps = screen.getByRole("button", { name: "Installed Apps" }).closest("section");
+    const installedHomebrew = screen
+      .getByRole("button", { name: "Installed Homebrew" })
+      .closest("section");
+    expect(installedApps).not.toBeNull();
+    expect(installedHomebrew).not.toBeNull();
+    expect(within(installedApps as HTMLElement).getByText("Managed")).toBeInTheDocument();
+    expect(within(installedHomebrew as HTMLElement).getByText("managed")).toBeInTheDocument();
   });
 
   it("collapses persisted secondary sections and toggles them through preferences", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1081,19 +1081,21 @@ describe("renderer button parity", () => {
   it("search hides cask-backed apps from Installed Apps", () => {
     const caskBackedApp: AppRecord = {
       ...app,
-      id: "app:notion",
-      displayName: "Notion"
+      id: "app:managed",
+      bundlePath: "/Applications/Managed.app",
+      displayName: "Managed"
     };
     const nonCaskApp: AppRecord = {
       ...app,
-      id: "app:notion-notes",
-      displayName: "Notion Notes"
+      id: "app:managed-helper",
+      bundlePath: "/Applications/Managed Helper.app",
+      displayName: "Managed Helper"
     };
     const installedCask: HomebrewManagedItem = {
       ...cask,
-      id: "cask:notion",
-      token: "notion",
-      name: "Notion",
+      id: "cask:managed",
+      token: "managed",
+      name: "Managed",
       latestVersion: version("1.0.0"),
       isOutdated: false
     };
@@ -1104,7 +1106,7 @@ describe("renderer button parity", () => {
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           selectedTab: "apps",
-          searchText: "notion",
+          searchText: "managed",
           apps: [caskBackedApp, nonCaskApp],
           updates: [],
           homebrewItems: [installedCask],
@@ -1121,9 +1123,57 @@ describe("renderer button parity", () => {
       .closest("section");
     expect(installedApps).not.toBeNull();
     expect(installedHomebrew).not.toBeNull();
-    expect(within(installedApps as HTMLElement).queryByText("Notion")).not.toBeInTheDocument();
-    expect(within(installedApps as HTMLElement).getByText("Notion Notes")).toBeInTheDocument();
-    expect(within(installedHomebrew as HTMLElement).getByText("Notion")).toBeInTheDocument();
+    expect(within(installedApps as HTMLElement).queryByText("Managed")).not.toBeInTheDocument();
+    expect(within(installedApps as HTMLElement).getByText("Managed Helper")).toBeInTheDocument();
+    expect(within(installedHomebrew as HTMLElement).getByText("Managed")).toBeInTheDocument();
+  });
+
+  it("does not show a Homebrew-backed app twice when another installed variant shares its display name", () => {
+    const managedApp: AppRecord = {
+      ...app,
+      id: "app:managed",
+      bundlePath: "/Applications/Managed.app",
+      displayName: "Managed",
+      bundleIdentifier: "com.example.managed"
+    };
+    const unmanagedVariant: AppRecord = {
+      ...app,
+      id: "app:managed-variant",
+      bundlePath: "/Applications/Managed Variant.app",
+      displayName: "Managed",
+      bundleIdentifier: "com.example.managed.variant"
+    };
+    const installedCask: HomebrewManagedItem = {
+      ...cask,
+      id: "cask:managed",
+      token: "managed",
+      name: "Managed",
+      latestVersion: version("1.0.0"),
+      isOutdated: false
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "installed",
+          apps: [managedApp, unmanagedVariant],
+          updates: [],
+          homebrewItems: [installedCask],
+          homebrewDiscoverItems: []
+        })}
+      />
+    );
+
+    const installedApps = screen.getByRole("button", { name: "Installed Apps" }).closest("section");
+    const installedHomebrew = screen
+      .getByRole("button", { name: "Installed Homebrew" })
+      .closest("section");
+    expect(installedApps).not.toBeNull();
+    expect(installedHomebrew).not.toBeNull();
+    expect(within(installedApps as HTMLElement).getAllByText("Managed")).toHaveLength(1);
+    expect(within(installedHomebrew as HTMLElement).getByText("Managed")).toBeInTheDocument();
   });
 
   it("collapses persisted secondary sections and toggles them through preferences", () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -143,6 +143,44 @@ describe("update store helpers", () => {
     expect(records[0]?.toVersion).toEqual(version("1.2.0"));
   });
 
+  it("drops stale Homebrew recent records when the current installed version no longer matches", () => {
+    const records = mergeHomebrewRecentlyUpdatedRecords(
+      [
+        {
+          id: "cask:managed-tool",
+          itemID: "cask:managed-tool",
+          token: "managed-tool",
+          kind: "cask",
+          displayName: "Managed Tool",
+          fromVersion: version("2.0.0"),
+          toVersion: version("3.0.0"),
+          updatedAt: new Date().toISOString()
+        }
+      ],
+      [
+        homebrewItem({
+          id: "cask:managed-tool",
+          token: "managed-tool",
+          name: "Managed Tool",
+          kind: "cask",
+          installedVersion: version("2.0.0")
+        })
+      ],
+      [
+        homebrewItem({
+          id: "cask:managed-tool",
+          token: "managed-tool",
+          name: "Managed Tool",
+          kind: "cask",
+          installedVersion: version("1.0.0")
+        })
+      ],
+      new Date().toISOString()
+    );
+
+    expect(records).toHaveLength(0);
+  });
+
   it("keeps previous Homebrew outdated state when outdated detection is unreliable", () => {
     const current = [
       homebrewItem({
@@ -595,7 +633,7 @@ describe("update store helpers", () => {
       installedVersion: version("1.2026.98.2"),
       latestVersion: version("1.2026.119.1"),
       isOutdated: true,
-      iconDataURL: "data:image/png;base64,icon"
+      iconDataURL: undefined
     });
   });
 
@@ -647,7 +685,7 @@ describe("update store helpers", () => {
       installedVersion: version("1.2026.98.2"),
       latestVersion: version("1.2026.119.1"),
       isOutdated: true,
-      iconDataURL: "data:image/png;base64,icon"
+      iconDataURL: undefined
     });
   });
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -437,6 +437,13 @@ describe("update store helpers", () => {
   });
 
   it("falls back to app names when inferred quit metadata points at a helper", async () => {
+    const helperApp = appRecord({
+      bundlePath: "/Applications/Package Backed Helper.app",
+      displayName: "Package Backed Helper",
+      bundleIdentifier: "com.example.pkgbacked.helper",
+      localVersion: version("1.4.0"),
+      iconDataURL: "data:image/png;base64,helper"
+    });
     const packageBackedApp = appRecord({
       bundlePath: "/Applications/Package Backed.app",
       displayName: "Package Backed",
@@ -453,11 +460,11 @@ describe("update store helpers", () => {
     };
     const store = await makeStore({
       clients: {
-        scanner: { scanApplications: async () => [packageBackedApp] },
+        scanner: { scanApplications: async () => [helperApp, packageBackedApp] },
         homebrew: {
           fetchIndex: async () => ({
             byToken: { "pkg-backed-app": entry },
-            byBundleIdentifier: { "com.example.pkgbacked.helper": entry },
+            byBundleIdentifier: {},
             byAppBundleName: { "package backed.app": [entry] }
           }),
           lookupUpdate: () => undefined,

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -397,6 +397,67 @@ describe("update store helpers", () => {
     expect(item?.latestVersion).toBeUndefined();
   });
 
+  it("falls back to app names when inferred quit metadata points at a helper", async () => {
+    const packageBackedApp = appRecord({
+      bundlePath: "/Applications/Package Backed.app",
+      displayName: "Package Backed",
+      bundleIdentifier: "com.example.pkgbacked",
+      localVersion: version("1.3.0"),
+      iconDataURL: "data:image/png;base64,package-backed"
+    });
+    const entry = {
+      token: "pkg-backed-app",
+      version: version("1.2.0"),
+      bundleIdentifiers: [],
+      inferredBundleIdentifiers: ["com.example.pkgbacked.helper"],
+      appBundleNames: ["package backed.app"]
+    };
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [packageBackedApp] },
+        homebrew: {
+          fetchIndex: async () => ({
+            byToken: { "pkg-backed-app": entry },
+            byBundleIdentifier: { "com.example.pkgbacked.helper": entry },
+            byAppBundleName: { "package backed.app": [entry] }
+          }),
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:pkg-backed-app",
+                token: "pkg-backed-app",
+                name: "pkg-backed-app",
+                kind: "cask",
+                installedVersion: version("1.1.0"),
+                latestVersion: version("1.2.0"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:pkg-backed-app");
+    expect(item).toMatchObject({
+      name: "Package Backed",
+      installedVersion: version("1.3.0"),
+      iconDataURL: "data:image/png;base64,package-backed",
+      isOutdated: false
+    });
+    expect(item?.latestVersion).toBeUndefined();
+  });
+
   it("uses the app bundle version for self-updated casks that still have a newer cask release", async () => {
     const selfUpdatingApp = appRecord({
       bundlePath: "/Applications/Self Updating App.app",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -348,7 +348,8 @@ describe("update store helpers", () => {
     const entry = {
       token: "pkg-backed-app",
       version: version("1.2.0"),
-      bundleIdentifiers: ["com.example.pkgbacked"],
+      bundleIdentifiers: [],
+      inferredBundleIdentifiers: ["com.example.pkgbacked"],
       appBundleNames: ["package backed.app"]
     };
     const store = await makeStore({

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -588,6 +588,57 @@ describe("update store helpers", () => {
     });
   });
 
+  it("preserves proven cask app links when current cask metadata is unavailable", async () => {
+    const selfUpdatingApp = appRecord({
+      bundlePath: "/Applications/Self Updating App.app",
+      displayName: "Self Updating App",
+      bundleIdentifier: "com.example.selfupdating",
+      localVersion: version("1.2026.119.1")
+    });
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [selfUpdatingApp] },
+        homebrew: {
+          fetchIndex: vi
+            .fn()
+            .mockResolvedValueOnce(caskIndexForSelfUpdatingApp(version("1.2026.119.1")))
+            .mockResolvedValue(emptyHomebrewCaskIndex),
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:self-updating-app",
+                token: "self-updating-app",
+                name: "self-updating-app",
+                kind: "cask",
+                installedVersion: version("1.2026.98.2"),
+                latestVersion: version("1.2026.119.1"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:self-updating-app");
+    expect(item).toMatchObject({
+      appID: selfUpdatingApp.id,
+      name: "self-updating-app",
+      installedVersion: version("1.2026.98.2")
+    });
+  });
+
   it("does not use app bundle-name matches when cask and app bundle identifiers conflict", async () => {
     const sameNameApp = appRecord({
       bundlePath: "/Applications/Self Updating App.app",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -337,6 +337,66 @@ describe("update store helpers", () => {
     expect(item?.latestVersion).toBeUndefined();
   });
 
+  it("matches package-backed casks through uninstall metadata before comparing versions", async () => {
+    const packageBackedApp = appRecord({
+      bundlePath: "/Applications/Package Backed.app",
+      displayName: "Package Backed",
+      bundleIdentifier: "com.example.pkgbacked",
+      localVersion: version("1.3.0"),
+      iconDataURL: "data:image/png;base64,package-backed"
+    });
+    const entry = {
+      token: "pkg-backed-app",
+      version: version("1.2.0"),
+      bundleIdentifiers: ["com.example.pkgbacked"],
+      appBundleNames: ["package backed.app"]
+    };
+    const store = await makeStore({
+      clients: {
+        scanner: { scanApplications: async () => [packageBackedApp] },
+        homebrew: {
+          fetchIndex: async () => ({
+            byToken: { "pkg-backed-app": entry },
+            byBundleIdentifier: { "com.example.pkgbacked": entry },
+            byAppBundleName: { "package backed.app": [entry] }
+          }),
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:pkg-backed-app",
+                token: "pkg-backed-app",
+                name: "pkg-backed-app",
+                kind: "cask",
+                installedVersion: version("1.1.0"),
+                latestVersion: version("1.2.0"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    const item = store
+      .getSnapshot()
+      .homebrewItems.find((candidate) => candidate.id === "cask:pkg-backed-app");
+    expect(item).toMatchObject({
+      name: "Package Backed",
+      installedVersion: version("1.3.0"),
+      iconDataURL: "data:image/png;base64,package-backed",
+      isOutdated: false
+    });
+    expect(item?.latestVersion).toBeUndefined();
+  });
+
   it("uses the app bundle version for self-updated casks that still have a newer cask release", async () => {
     const selfUpdatingApp = appRecord({
       bundlePath: "/Applications/Self Updating App.app",

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -162,7 +162,7 @@ function extractBundleIdentifiers(object: any): string[] {
       }
     }
   });
-  const found = explicit.size > 0 || hasAppArtifactName(object) ? explicit : quit;
+  const found = explicit.size > 0 || hasExplicitAppArtifactName(object) ? explicit : quit;
   return [...found].sort();
 }
 
@@ -199,10 +199,10 @@ function walk(value: any, visitor: (key: string, value: any) => void): void {
   }
 }
 
-function hasAppArtifactName(object: any): boolean {
+function hasExplicitAppArtifactName(object: any): boolean {
   let found = false;
   walk(object, (key, value) => {
-    if (found || !["app", "apps", "target"].includes(key)) {
+    if (found || !["app", "apps"].includes(key)) {
       return;
     }
     if (typeof value === "string") {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -170,7 +170,7 @@ function extractBundleIdentifierMetadata(
   if (explicit.size > 0 || hasExplicitAppArtifactName(object)) {
     return { bundleIdentifiers: [...explicit].sort() };
   }
-  if (hasPackageBackedAppNameHint(object)) {
+  if (isPackageBackedAppCandidate(object)) {
     return { bundleIdentifiers: [], inferredBundleIdentifiers: [...quit].sort() };
   }
   return { bundleIdentifiers: [] };
@@ -178,19 +178,22 @@ function extractBundleIdentifierMetadata(
 
 function extractAppBundleNames(object: any): string[] {
   const found = new Set<string>();
+  const addNormalized = (value: string, options: { requireAppSuffix?: boolean } = {}) => {
+    if (options.requireAppSuffix && !value.trim().toLowerCase().endsWith(".app")) {
+      return;
+    }
+    const normalized = normalizeAppBundleName(value);
+    if (normalized) found.add(normalized);
+  };
   walk(object, (key, value) => {
     if (["app", "apps", "target", "login_item"].includes(key)) {
       if (typeof value === "string") {
-        const normalized = normalizeAppBundleName(value);
-        if (normalized) found.add(normalized);
+        addNormalized(value);
       } else if (Array.isArray(value)) {
-        value
-          .filter((entry) => typeof entry === "string")
-          .forEach((entry) => {
-            const normalized = normalizeAppBundleName(entry);
-            if (normalized) found.add(normalized);
-          });
+        value.filter((entry) => typeof entry === "string").forEach((entry) => addNormalized(entry));
       }
+    } else if (key === "delete") {
+      stringValues(value).forEach((entry) => addNormalized(entry, { requireAppSuffix: true }));
     }
   });
   return [...found].sort();
@@ -237,6 +240,56 @@ function hasPackageBackedAppNameHint(object: any): boolean {
     }
   });
   return found;
+}
+
+function isPackageBackedAppCandidate(object: any): boolean {
+  if (!hasArtifactKey(object, "pkg") || hasExplicitAppArtifactName(object)) {
+    return false;
+  }
+  if (hasPackageBackedAppNameHint(object) || hasDeletedAppPathHint(object)) {
+    return true;
+  }
+  return !hasTargetArtifactName(object);
+}
+
+function hasDeletedAppPathHint(object: any): boolean {
+  let found = false;
+  walk(object, (key, value) => {
+    if (found || key !== "delete") {
+      return;
+    }
+    found = stringValues(value).some((entry) => entry.trim().toLowerCase().endsWith(".app"));
+  });
+  return found;
+}
+
+function hasTargetArtifactName(object: any): boolean {
+  let found = false;
+  walk(object, (key, value) => {
+    if (found || key !== "target") {
+      return;
+    }
+    found = stringValues(value).some((entry) => normalizeAppBundleName(entry));
+  });
+  return found;
+}
+
+function hasArtifactKey(object: any, artifactKey: string): boolean {
+  return Array.isArray(object?.artifacts)
+    ? object.artifacts.some(
+        (artifact: unknown) => artifact && typeof artifact === "object" && artifactKey in artifact
+      )
+    : false;
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === "string");
+  }
+  return [];
 }
 
 function comparableVersion(raw: unknown): string {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -100,12 +100,15 @@ export class HomebrewCaskClient {
         token,
         version: version(comparableVersion(item?.version)),
         homepageURL: sanitizeExternalURL(item?.homepage),
-        bundleIdentifiers: extractBundleIdentifiers(item),
+        ...extractBundleIdentifierMetadata(item),
         appBundleNames: extractAppBundleNames(item)
       };
       byToken[token.toLowerCase()] = entry;
 
-      for (const identifier of entry.bundleIdentifiers) {
+      for (const identifier of [
+        ...entry.bundleIdentifiers,
+        ...(entry.inferredBundleIdentifiers ?? [])
+      ]) {
         const key = identifier.toLowerCase();
         const existing = byBundleIdentifier[key];
         if (!existing || compareVersions(entry.version, existing.version) >= 0) {
@@ -139,7 +142,9 @@ export class HomebrewCaskClient {
   }
 }
 
-function extractBundleIdentifiers(object: any): string[] {
+function extractBundleIdentifierMetadata(
+  object: any
+): Pick<HomebrewCaskEntry, "bundleIdentifiers" | "inferredBundleIdentifiers"> {
   const explicit = new Set<string>();
   const quit = new Set<string>();
   walk(object, (key, value) => {
@@ -162,13 +167,13 @@ function extractBundleIdentifiers(object: any): string[] {
       }
     }
   });
-  const found =
-    explicit.size > 0 || hasExplicitAppArtifactName(object)
-      ? explicit
-      : hasPackageBackedAppNameHint(object)
-        ? quit
-        : new Set<string>();
-  return [...found].sort();
+  if (explicit.size > 0 || hasExplicitAppArtifactName(object)) {
+    return { bundleIdentifiers: [...explicit].sort() };
+  }
+  if (hasPackageBackedAppNameHint(object)) {
+    return { bundleIdentifiers: [], inferredBundleIdentifiers: [...quit].sort() };
+  }
+  return { bundleIdentifiers: [] };
 }
 
 function extractAppBundleNames(object: any): string[] {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -146,7 +146,8 @@ function extractBundleIdentifiers(object: any): string[] {
       key === "bundle_id" ||
       key === "bundle_ids" ||
       key === "bundle_identifier" ||
-      key === "bundleIdentifier"
+      key === "bundleIdentifier" ||
+      key === "quit"
     ) {
       if (typeof value === "string") {
         found.add(value);
@@ -161,7 +162,7 @@ function extractBundleIdentifiers(object: any): string[] {
 function extractAppBundleNames(object: any): string[] {
   const found = new Set<string>();
   walk(object, (key, value) => {
-    if (["app", "apps", "target"].includes(key)) {
+    if (["app", "apps", "target", "login_item"].includes(key)) {
       if (typeof value === "string") {
         const normalized = normalizeAppBundleName(value);
         if (normalized) found.add(normalized);

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -162,7 +162,12 @@ function extractBundleIdentifiers(object: any): string[] {
       }
     }
   });
-  const found = explicit.size > 0 || hasExplicitAppArtifactName(object) ? explicit : quit;
+  const found =
+    explicit.size > 0 || hasExplicitAppArtifactName(object)
+      ? explicit
+      : hasPackageBackedAppNameHint(object)
+        ? quit
+        : new Set<string>();
   return [...found].sort();
 }
 
@@ -203,6 +208,21 @@ function hasExplicitAppArtifactName(object: any): boolean {
   let found = false;
   walk(object, (key, value) => {
     if (found || !["app", "apps"].includes(key)) {
+      return;
+    }
+    if (typeof value === "string") {
+      found = normalizeAppBundleName(value) !== undefined;
+    } else if (Array.isArray(value)) {
+      found = value.some((entry) => typeof entry === "string" && normalizeAppBundleName(entry));
+    }
+  });
+  return found;
+}
+
+function hasPackageBackedAppNameHint(object: any): boolean {
+  let found = false;
+  walk(object, (key, value) => {
+    if (found || key !== "login_item") {
       return;
     }
     if (typeof value === "string") {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -140,22 +140,26 @@ export class HomebrewCaskClient {
 }
 
 function extractBundleIdentifiers(object: any): string[] {
-  const found = new Set<string>();
+  const explicit = new Set<string>();
+  const quit = new Set<string>();
   walk(object, (key, value) => {
-    if (
-      key === "bundle_id" ||
-      key === "bundle_ids" ||
-      key === "bundle_identifier" ||
-      key === "bundleIdentifier" ||
-      key === "quit"
-    ) {
+    if (key === "bundle_id" || key === "bundle_ids" || key === "bundle_identifier") {
       if (typeof value === "string") {
-        found.add(value);
+        explicit.add(value);
       } else if (Array.isArray(value)) {
-        value.filter((entry) => typeof entry === "string").forEach((entry) => found.add(entry));
+        value.filter((entry) => typeof entry === "string").forEach((entry) => explicit.add(entry));
+      }
+    } else if (key === "bundleIdentifier" && typeof value === "string") {
+      explicit.add(value);
+    } else if (key === "quit") {
+      if (typeof value === "string") {
+        quit.add(value);
+      } else if (Array.isArray(value)) {
+        value.filter((entry) => typeof entry === "string").forEach((entry) => quit.add(entry));
       }
     }
   });
+  const found = explicit.size > 0 || hasAppArtifactName(object) ? explicit : quit;
   return [...found].sort();
 }
 
@@ -190,6 +194,21 @@ function walk(value: any, visitor: (key: string, value: any) => void): void {
       walk(child, visitor);
     }
   }
+}
+
+function hasAppArtifactName(object: any): boolean {
+  let found = false;
+  walk(object, (key, value) => {
+    if (found || !["app", "apps", "target"].includes(key)) {
+      return;
+    }
+    if (typeof value === "string") {
+      found = normalizeAppBundleName(value) !== undefined;
+    } else if (Array.isArray(value)) {
+      found = value.some((entry) => typeof entry === "string" && normalizeAppBundleName(entry));
+    }
+  });
+  return found;
 }
 
 function comparableVersion(raw: unknown): string {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -88,6 +88,7 @@ export class HomebrewCaskClient {
     const raw = JSON.parse(data.toString("utf8")) as any[];
     const byToken: Record<string, HomebrewCaskEntry> = {};
     const byBundleIdentifier: Record<string, HomebrewCaskEntry> = {};
+    const byBundleIdentifierSource: Record<string, "explicit" | "inferred"> = {};
     const byAppBundleName: Record<string, HomebrewCaskEntry[]> = {};
 
     for (const item of raw) {
@@ -105,15 +106,23 @@ export class HomebrewCaskClient {
       };
       byToken[token.toLowerCase()] = entry;
 
-      for (const identifier of [
-        ...entry.bundleIdentifiers,
-        ...(entry.inferredBundleIdentifiers ?? [])
-      ]) {
-        const key = identifier.toLowerCase();
-        const existing = byBundleIdentifier[key];
-        if (!existing || compareVersions(entry.version, existing.version) >= 0) {
-          byBundleIdentifier[key] = entry;
-        }
+      for (const identifier of entry.bundleIdentifiers) {
+        indexBundleIdentifier(
+          byBundleIdentifier,
+          byBundleIdentifierSource,
+          identifier,
+          entry,
+          "explicit"
+        );
+      }
+      for (const identifier of entry.inferredBundleIdentifiers ?? []) {
+        indexBundleIdentifier(
+          byBundleIdentifier,
+          byBundleIdentifierSource,
+          identifier,
+          entry,
+          "inferred"
+        );
       }
 
       for (const appName of entry.appBundleNames) {
@@ -174,6 +183,33 @@ function extractBundleIdentifierMetadata(
     return { bundleIdentifiers: [], inferredBundleIdentifiers: [...quit].sort() };
   }
   return { bundleIdentifiers: [] };
+}
+
+function indexBundleIdentifier(
+  byBundleIdentifier: Record<string, HomebrewCaskEntry>,
+  byBundleIdentifierSource: Record<string, "explicit" | "inferred">,
+  identifier: string,
+  entry: HomebrewCaskEntry,
+  source: "explicit" | "inferred"
+): void {
+  const key = identifier.toLowerCase();
+  const existing = byBundleIdentifier[key];
+  const existingSource = byBundleIdentifierSource[key];
+  if (!existing) {
+    byBundleIdentifier[key] = entry;
+    byBundleIdentifierSource[key] = source;
+    return;
+  }
+  if (existingSource === "explicit" && source === "inferred") {
+    return;
+  }
+  if (
+    (existingSource === "inferred" && source === "explicit") ||
+    (existingSource === source && compareVersions(entry.version, existing.version) >= 0)
+  ) {
+    byBundleIdentifier[key] = entry;
+    byBundleIdentifierSource[key] = source;
+  }
 }
 
 function extractAppBundleNames(object: any): string[] {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -186,12 +186,14 @@ function extractAppBundleNames(object: any): string[] {
     if (normalized) found.add(normalized);
   };
   walk(object, (key, value) => {
-    if (["app", "apps", "target", "login_item"].includes(key)) {
+    if (["app", "apps", "login_item"].includes(key)) {
       if (typeof value === "string") {
         addNormalized(value);
       } else if (Array.isArray(value)) {
         value.filter((entry) => typeof entry === "string").forEach((entry) => addNormalized(entry));
       }
+    } else if (key === "target") {
+      stringValues(value).forEach((entry) => addNormalized(entry, { requireAppSuffix: true }));
     } else if (key === "delete") {
       stringValues(value).forEach((entry) => addNormalized(entry, { requireAppSuffix: true }));
     }

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -143,14 +143,17 @@ function extractBundleIdentifiers(object: any): string[] {
   const explicit = new Set<string>();
   const quit = new Set<string>();
   walk(object, (key, value) => {
-    if (key === "bundle_id" || key === "bundle_ids" || key === "bundle_identifier") {
+    if (
+      key === "bundle_id" ||
+      key === "bundle_ids" ||
+      key === "bundle_identifier" ||
+      key === "bundleIdentifier"
+    ) {
       if (typeof value === "string") {
         explicit.add(value);
       } else if (Array.isArray(value)) {
         value.filter((entry) => typeof entry === "string").forEach((entry) => explicit.add(entry));
       }
-    } else if (key === "bundleIdentifier" && typeof value === "string") {
-      explicit.add(value);
     } else if (key === "quit") {
       if (typeof value === "string") {
         quit.add(value);

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -88,7 +88,6 @@ export class HomebrewCaskClient {
     const raw = JSON.parse(data.toString("utf8")) as any[];
     const byToken: Record<string, HomebrewCaskEntry> = {};
     const byBundleIdentifier: Record<string, HomebrewCaskEntry> = {};
-    const byBundleIdentifierSource: Record<string, "explicit" | "inferred"> = {};
     const byAppBundleName: Record<string, HomebrewCaskEntry[]> = {};
 
     for (const item of raw) {
@@ -107,22 +106,7 @@ export class HomebrewCaskClient {
       byToken[token.toLowerCase()] = entry;
 
       for (const identifier of entry.bundleIdentifiers) {
-        indexBundleIdentifier(
-          byBundleIdentifier,
-          byBundleIdentifierSource,
-          identifier,
-          entry,
-          "explicit"
-        );
-      }
-      for (const identifier of entry.inferredBundleIdentifiers ?? []) {
-        indexBundleIdentifier(
-          byBundleIdentifier,
-          byBundleIdentifierSource,
-          identifier,
-          entry,
-          "inferred"
-        );
+        indexBundleIdentifier(byBundleIdentifier, identifier, entry);
       }
 
       for (const appName of entry.appBundleNames) {
@@ -187,28 +171,13 @@ function extractBundleIdentifierMetadata(
 
 function indexBundleIdentifier(
   byBundleIdentifier: Record<string, HomebrewCaskEntry>,
-  byBundleIdentifierSource: Record<string, "explicit" | "inferred">,
   identifier: string,
-  entry: HomebrewCaskEntry,
-  source: "explicit" | "inferred"
+  entry: HomebrewCaskEntry
 ): void {
   const key = identifier.toLowerCase();
   const existing = byBundleIdentifier[key];
-  const existingSource = byBundleIdentifierSource[key];
-  if (!existing) {
+  if (!existing || compareVersions(entry.version, existing.version) >= 0) {
     byBundleIdentifier[key] = entry;
-    byBundleIdentifierSource[key] = source;
-    return;
-  }
-  if (existingSource === "explicit" && source === "inferred") {
-    return;
-  }
-  if (
-    (existingSource === "inferred" && source === "explicit") ||
-    (existingSource === source && compareVersions(entry.version, existing.version) >= 0)
-  ) {
-    byBundleIdentifier[key] = entry;
-    byBundleIdentifierSource[key] = source;
   }
 }
 
@@ -380,6 +349,7 @@ function compareEntries(lhs: HomebrewCaskEntry, rhs: HomebrewCaskEntry): number 
 function deduplicatedEntries(index: HomebrewCaskIndex): HomebrewCaskEntry[] {
   const map = new Map<string, HomebrewCaskEntry>();
   for (const entry of [
+    ...Object.values(index.byToken),
     ...Object.values(index.byBundleIdentifier),
     ...Object.values(index.byAppBundleName).flat()
   ]) {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1020,6 +1020,7 @@ function reconcileHomebrewInventory(
     if (!latestVersion || !isVersionGreater(latestVersion, installedVersion)) {
       return {
         ...item,
+        name: matchingApp?.displayName ?? item.name,
         iconDataURL: iconDataURL ?? item.iconDataURL,
         installedVersion,
         latestVersion: undefined,
@@ -1029,6 +1030,7 @@ function reconcileHomebrewInventory(
     }
     return {
       ...item,
+      name: matchingApp?.displayName ?? item.name,
       iconDataURL: iconDataURL ?? item.iconDataURL,
       installedVersion,
       latestVersion,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1009,7 +1009,9 @@ function reconcileHomebrewInventory(
     const caskEntry = caskIndex.byToken[item.token.toLowerCase()];
     const matchingApp = matchingHomebrewApp(updatesByToken, appsByID, apps, item, caskEntry);
     const iconDataURL =
-      matchingApp?.iconDataURL ?? matchingHomebrewAppIcon(item, updatesByToken, appsByID, apps);
+      matchingApp?.iconDataURL ??
+      (caskEntry ? undefined : matchingHomebrewAppIcon(item, updatesByToken, appsByID, apps));
+    const preservedIconDataURL = caskEntry && !matchingApp ? undefined : item.iconDataURL;
     const update = updatesByToken.get(item.token.toLowerCase());
     const installedVersion =
       matchingApp && isVersionGreater(matchingApp.localVersion, item.installedVersion)
@@ -1020,8 +1022,9 @@ function reconcileHomebrewInventory(
     if (!latestVersion || !isVersionGreater(latestVersion, installedVersion)) {
       return {
         ...item,
+        appID: matchingApp?.id,
         name: matchingApp?.displayName ?? item.name,
-        iconDataURL: iconDataURL ?? item.iconDataURL,
+        iconDataURL: iconDataURL ?? preservedIconDataURL,
         installedVersion,
         latestVersion: undefined,
         isOutdated: false,
@@ -1030,8 +1033,9 @@ function reconcileHomebrewInventory(
     }
     return {
       ...item,
+      appID: matchingApp?.id,
       name: matchingApp?.displayName ?? item.name,
-      iconDataURL: iconDataURL ?? item.iconDataURL,
+      iconDataURL: iconDataURL ?? preservedIconDataURL,
       installedVersion,
       latestVersion,
       isOutdated: true
@@ -1071,9 +1075,16 @@ export function mergeHomebrewRecentlyUpdatedRecords(
 
   const retentionMs = 14 * 24 * 60 * 60 * 1000;
   const cutoff = (options.currentDate?.getTime() ?? Date.now()) - retentionMs;
+  const currentByID = new Map(currentItems.map((item) => [item.id, item]));
   const deduped = new Map<string, HomebrewRecentlyUpdatedRecord>();
   for (const record of records) {
-    if (new Date(record.updatedAt).getTime() >= cutoff && !deduped.has(record.itemID)) {
+    const currentItem = currentByID.get(record.itemID);
+    if (
+      currentItem &&
+      compareVersions(record.toVersion, currentItem.installedVersion) === 0 &&
+      new Date(record.updatedAt).getTime() >= cutoff &&
+      !deduped.has(record.itemID)
+    ) {
       deduped.set(record.itemID, record);
     }
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1133,6 +1133,12 @@ function appMatchesCaskEntry(app: AppRecord, caskEntry: HomebrewCaskEntry | unde
   if (bundleIdentifier && bundleIdentifiers.size > 0) {
     return bundleIdentifiers.has(bundleIdentifier);
   }
+  const inferredBundleIdentifiers = new Set(
+    (caskEntry.inferredBundleIdentifiers ?? []).map((identifier) => identifier.toLowerCase())
+  );
+  if (bundleIdentifier && inferredBundleIdentifiers.has(bundleIdentifier)) {
+    return true;
+  }
 
   return new Set(caskEntry.appBundleNames).has(normalizedAppBundleName(app.bundlePath));
 }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -585,7 +585,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         ),
         updates,
         apps,
-        homebrewIndex
+        homebrewIndex,
+        previousHomebrewItems
       );
       const recentlyUpdated = this.mergeRecentlyUpdated(apps, updates, previousUpdates, now);
       const homebrewRecentlyUpdated = mergeHomebrewRecentlyUpdatedRecords(
@@ -989,7 +990,8 @@ function reconcileHomebrewInventory(
   items: HomebrewManagedItem[],
   updates: UpdateRecord[],
   apps: AppRecord[] = [],
-  caskIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex
+  caskIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex,
+  previousItems: HomebrewManagedItem[] = []
 ): HomebrewManagedItem[] {
   const updatesByToken = new Map<string, UpdateRecord>();
   for (const update of updates) {
@@ -1002,6 +1004,7 @@ function reconcileHomebrewInventory(
     }
   }
   const appsByID = new Map(apps.map((app) => [app.id, app]));
+  const previousItemsByID = new Map(previousItems.map((item) => [item.id, item]));
   return items.map((item) => {
     if (item.kind !== "cask") {
       return item;
@@ -1018,11 +1021,17 @@ function reconcileHomebrewInventory(
         ? matchingApp.localVersion
         : item.installedVersion;
     const latestVersion = bestHomebrewCaskLatestVersion(item, update, caskEntry);
+    const previousAppID = previousItemsByID.get(item.id)?.appID;
+    const preservedAppID =
+      !caskEntry && !matchingApp && previousAppID && appsByID.has(previousAppID)
+        ? previousAppID
+        : undefined;
+    const appID = matchingApp?.id ?? preservedAppID;
 
     if (!latestVersion || !isVersionGreater(latestVersion, installedVersion)) {
       return {
         ...item,
-        appID: matchingApp?.id,
+        appID,
         name: matchingApp?.displayName ?? item.name,
         iconDataURL: iconDataURL ?? preservedIconDataURL,
         installedVersion,
@@ -1033,7 +1042,7 @@ function reconcileHomebrewInventory(
     }
     return {
       ...item,
-      appID: matchingApp?.id,
+      appID,
       name: matchingApp?.displayName ?? item.name,
       iconDataURL: iconDataURL ?? preservedIconDataURL,
       installedVersion,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1153,14 +1153,17 @@ function appMatchesCaskEntry(app: AppRecord, caskEntry: HomebrewCaskEntry | unde
   if (bundleIdentifier && bundleIdentifiers.size > 0) {
     return bundleIdentifiers.has(bundleIdentifier);
   }
+  const matchesAppBundleName = new Set(caskEntry.appBundleNames).has(
+    normalizedAppBundleName(app.bundlePath)
+  );
   const inferredBundleIdentifiers = new Set(
     (caskEntry.inferredBundleIdentifiers ?? []).map((identifier) => identifier.toLowerCase())
   );
   if (bundleIdentifier && inferredBundleIdentifiers.has(bundleIdentifier)) {
-    return true;
+    return matchesAppBundleName;
   }
 
-  return new Set(caskEntry.appBundleNames).has(normalizedAppBundleName(app.bundlePath));
+  return matchesAppBundleName;
 }
 
 function matchingHomebrewAppIcon(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -38,6 +38,7 @@ import {
   homebrewItemMatchesApp,
   isCask,
   normalizedAppCandidates,
+  normalizedStrongAppCandidates,
   normalizedHomebrewAppName
 } from "../shared/homebrewAppLinking";
 import "./styles.css";
@@ -2486,6 +2487,7 @@ function deriveSections(snapshot: BaselineSnapshot) {
     .sort((lhs, rhs) => sortByUpdateDate(lhs, rhs, updatesByAppID));
   const installedApps = snapshot.apps
     .filter((app) => !updatesByAppID.has(app.id) && !snapshot.ignoredIDs.includes(app.id))
+    .filter((app) => !uninstallableHomebrewItemForApp(app, snapshot))
     .filter(appFilter)
     .sort(sortByName);
   const ignoredApps = snapshot.apps
@@ -2560,6 +2562,13 @@ function matchingAppForHomebrewItem(
     return appFromUpdate;
   }
 
+  const appFromStrongMatch = snapshot.apps.find((app) =>
+    [...identifiers].some((identifier) => normalizedStrongAppCandidates(app).has(identifier))
+  );
+  if (appFromStrongMatch) {
+    return appFromStrongMatch;
+  }
+
   return snapshot.apps.find((app) =>
     [...identifiers].some((identifier) => normalizedAppCandidates(app).has(identifier))
   );
@@ -2580,7 +2589,7 @@ function uninstallableHomebrewItemForApp(
     }
   }
 
-  const appCandidates = normalizedAppCandidates(app);
+  const appCandidates = normalizedStrongAppCandidates(app);
   return snapshot.homebrewItems.find((item) => {
     if (item.kind !== "cask") {
       return false;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -37,8 +37,6 @@ import {
   homebrewItemIdentifiers,
   homebrewItemMatchesApp,
   isCask,
-  normalizedAppCandidates,
-  normalizedStrongAppCandidates,
   normalizedHomebrewAppName
 } from "../shared/homebrewAppLinking";
 import "./styles.css";
@@ -1821,7 +1819,7 @@ function HomebrewItemIcon({
 }: {
   item: Pick<HomebrewManagedItem, "kind" | "token"> &
     Partial<
-      Pick<HomebrewManagedItem, "name" | "iconDataURL"> &
+      Pick<HomebrewManagedItem, "appID" | "name" | "iconDataURL"> &
         Pick<HomebrewCaskDiscoveryItem, "displayName">
     >;
   snapshot: BaselineSnapshot;
@@ -2543,11 +2541,19 @@ function deriveSections(snapshot: BaselineSnapshot) {
 
 function matchingAppForHomebrewItem(
   item: Pick<HomebrewManagedItem, "kind" | "token"> &
-    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>,
+    Partial<
+      Pick<HomebrewManagedItem, "appID" | "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">
+    >,
   snapshot: BaselineSnapshot
 ): AppRecord | undefined {
   if (!isCask(item.kind)) {
     return undefined;
+  }
+  const appFromExplicitLink = item.appID
+    ? snapshot.apps.find((app) => app.id === item.appID)
+    : undefined;
+  if (appFromExplicitLink) {
+    return appFromExplicitLink;
   }
 
   const identifiers = homebrewItemIdentifiers(item);
@@ -2562,22 +2568,20 @@ function matchingAppForHomebrewItem(
     return appFromUpdate;
   }
 
-  const appFromStrongMatch = snapshot.apps.find((app) =>
-    [...identifiers].some((identifier) => normalizedStrongAppCandidates(app).has(identifier))
-  );
-  if (appFromStrongMatch) {
-    return appFromStrongMatch;
-  }
-
-  return snapshot.apps.find((app) =>
-    [...identifiers].some((identifier) => normalizedAppCandidates(app).has(identifier))
-  );
+  return appFromUpdate;
 }
 
 function uninstallableHomebrewItemForApp(
   app: AppRecord,
   snapshot: BaselineSnapshot
 ): HomebrewManagedItem | undefined {
+  const matchedByExplicitLink = snapshot.homebrewItems.find(
+    (item) => item.kind === "cask" && item.appID === app.id
+  );
+  if (matchedByExplicitLink) {
+    return matchedByExplicitLink;
+  }
+
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
   if (update?.homebrewToken) {
     const token = normalizedHomebrewAppName(update.homebrewToken);
@@ -2589,14 +2593,7 @@ function uninstallableHomebrewItemForApp(
     }
   }
 
-  const appCandidates = normalizedStrongAppCandidates(app);
-  return snapshot.homebrewItems.find((item) => {
-    if (item.kind !== "cask") {
-      return false;
-    }
-    const identifiers = homebrewItemIdentifiers(item);
-    return [...identifiers].some((identifier) => appCandidates.has(identifier));
-  });
+  return undefined;
 }
 
 function sortByName(lhs: AppRecord, rhs: AppRecord): number {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -118,6 +118,7 @@ export type HomebrewManagedItem = {
   isOutdated: boolean;
   releaseDate?: string;
   iconDataURL?: string;
+  appID?: string;
 };
 
 export type PersistedSnapshot = {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -42,6 +42,7 @@ export type HomebrewCaskEntry = {
   version: VersionValue;
   homepageURL?: string;
   bundleIdentifiers: string[];
+  inferredBundleIdentifiers?: string[];
   appBundleNames: string[];
 };
 

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -7,12 +7,17 @@ import type {
 
 export function homebrewItemHasAppRepresentation(
   item: Pick<HomebrewManagedItem, "kind" | "token"> &
-    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>,
+    Partial<
+      Pick<HomebrewManagedItem, "appID" | "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">
+    >,
   apps: AppRecord[],
   updatesByAppID: Map<string, UpdateRecord>
 ): boolean {
   if (!isCask(item.kind)) {
     return false;
+  }
+  if (item.appID && apps.some((app) => app.id === item.appID)) {
+    return true;
   }
 
   const identifiers = homebrewItemIdentifiers(item);
@@ -21,25 +26,25 @@ export function homebrewItemHasAppRepresentation(
     if (update?.homebrewToken && identifiers.has(normalizedHomebrewAppName(update.homebrewToken))) {
       return true;
     }
-
-    const appCandidates = normalizedStrongAppCandidates(app);
-    return [...identifiers].some((identifier) => appCandidates.has(identifier));
+    return false;
   });
 }
 
 export function homebrewItemMatchesApp(
   item: Pick<HomebrewManagedItem, "kind" | "token"> &
-    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>,
+    Partial<
+      Pick<HomebrewManagedItem, "appID" | "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">
+    >,
   apps: AppRecord[]
 ): boolean {
   if (!isCask(item.kind)) {
     return false;
   }
+  if (item.appID) {
+    return apps.some((app) => app.id === item.appID);
+  }
 
-  const identifiers = homebrewItemIdentifiers(item);
-  return apps.some((app) =>
-    [...identifiers].some((identifier) => normalizedStrongAppCandidates(app).has(identifier))
-  );
+  return false;
 }
 
 export function homebrewItemIdentifiers(

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -58,28 +58,6 @@ export function homebrewItemIdentifiers(
   );
 }
 
-export function normalizedAppCandidates(app: AppRecord): Set<string> {
-  const fileName = app.bundlePath
-    .split("/")
-    .pop()
-    ?.replace(/\.app$/iu, "");
-  const candidates = [app.displayName, app.bundleIdentifier, fileName]
-    .filter((value): value is string => Boolean(value))
-    .map(normalizedHomebrewAppName);
-  return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));
-}
-
-export function normalizedStrongAppCandidates(app: AppRecord): Set<string> {
-  const fileName = app.bundlePath
-    .split("/")
-    .pop()
-    ?.replace(/\.app$/iu, "");
-  const candidates = [app.bundleIdentifier, fileName]
-    .filter((value): value is string => Boolean(value))
-    .map(normalizedHomebrewAppName);
-  return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));
-}
-
 export function normalizedHomebrewAppName(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
 }

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -22,7 +22,7 @@ export function homebrewItemHasAppRepresentation(
       return true;
     }
 
-    const appCandidates = normalizedAppCandidates(app);
+    const appCandidates = normalizedStrongAppCandidates(app);
     return [...identifiers].some((identifier) => appCandidates.has(identifier));
   });
 }
@@ -38,7 +38,7 @@ export function homebrewItemMatchesApp(
 
   const identifiers = homebrewItemIdentifiers(item);
   return apps.some((app) =>
-    [...identifiers].some((identifier) => normalizedAppCandidates(app).has(identifier))
+    [...identifiers].some((identifier) => normalizedStrongAppCandidates(app).has(identifier))
   );
 }
 
@@ -59,6 +59,17 @@ export function normalizedAppCandidates(app: AppRecord): Set<string> {
     .pop()
     ?.replace(/\.app$/iu, "");
   const candidates = [app.displayName, app.bundleIdentifier, fileName]
+    .filter((value): value is string => Boolean(value))
+    .map(normalizedHomebrewAppName);
+  return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));
+}
+
+export function normalizedStrongAppCandidates(app: AppRecord): Set<string> {
+  const fileName = app.bundlePath
+    .split("/")
+    .pop()
+    ?.replace(/\.app$/iu, "");
+  const candidates = [app.bundleIdentifier, fileName]
     .filter((value): value is string => Boolean(value))
     .map(normalizedHomebrewAppName);
   return new Set(candidates.flatMap((value) => [value, value.replace(/^com/u, "")]));


### PR DESCRIPTION
## Summary
- infer package-backed Homebrew GUI app metadata from cask uninstall/app hints while avoiding CLI/binary target false matches
- reconcile cask inventory rows to scanned apps only when metadata proves the app link, then persist that explicit app link for renderer/tray de-duplication
- prune stale Homebrew recently-updated records when the recorded target version no longer matches the current installed item
- add regression coverage for package-backed casks, CLI-vs-GUI cask separation, explicit app-backed row suppression, and stale recent records

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npm run test:electron
- npm audit --omit=dev --audit-level=high
