### PR TITLE
Clarify GPL licensing and copyright

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,8 @@
+# Copyright
+
+Copyright (C) 2026 Arshia Ghaffarian.
+
+Unless a file states otherwise, Baseline source code and project documentation
+are licensed under the GNU General Public License v3.0 only
+(`GPL-3.0-only`). The full license text is in [LICENSE](LICENSE).
+

--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";

--- a/ElectronTests/homebrewAppLinking.test.ts
+++ b/ElectronTests/homebrewAppLinking.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { describe, expect, it } from "vitest";
 import { homebrewItemHasAppRepresentation } from "../src/shared/homebrewAppLinking";
 import type { AppRecord, HomebrewManagedItem, UpdateRecord } from "../src/shared/domain";

--- a/ElectronTests/homebrewInventoryClient.test.ts
+++ b/ElectronTests/homebrewInventoryClient.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const commandMock = vi.hoisted(() => ({

--- a/ElectronTests/homebrewProgress.test.ts
+++ b/ElectronTests/homebrewProgress.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { describe, expect, it } from "vitest";
 import {
   HomebrewMaintenanceOutputParser,

--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/ElectronTests/security.test.ts
+++ b/ElectronTests/security.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { describe, expect, it } from "vitest";
 import {
   isAllowedExternalURL,

--- a/ElectronTests/setup.ts
+++ b/ElectronTests/setup.ts
@@ -1,1 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import "@testing-library/jest-dom/vitest";

--- a/ElectronTests/trayWindowPosition.test.ts
+++ b/ElectronTests/trayWindowPosition.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { describe, expect, it } from "vitest";
 import { calculateTrayWindowPosition } from "../src/main/trayWindowPosition";
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/ElectronTests/version.test.ts
+++ b/ElectronTests/version.test.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { describe, expect, it } from "vitest";
 import { compareVersions, isVersionGreater, version } from "../src/shared/version";
 

--- a/README.md
+++ b/README.md
@@ -132,4 +132,9 @@ Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), follow
 
 ## License
 
-Baseline is licensed under the GNU General Public License v3.0. See [LICENSE](LICENSE).
+Baseline is licensed as `GPL-3.0-only`. See [LICENSE](LICENSE) for the full
+GNU General Public License v3.0 text.
+
+Copyright (C) 2026 Arshia Ghaffarian. Modified versions that are distributed
+must remain licensed under the GPL, including the corresponding source code and
+notices required by the license.

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { _electron as electron, expect, test } from "@playwright/test";
 import { mkdtemp } from "node:fs/promises";
 import os from "node:os";

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 const js = require("@eslint/js");
 const tseslint = require("typescript-eslint");
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { MakerDMG } from "@electron-forge/maker-dmg";
 import { MakerZIP } from "@electron-forge/maker-zip";

--- a/index.html
+++ b/index.html
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+SPDX-License-Identifier: GPL-3.0-only
+-->
 <!doctype html>
 <html lang="en">
   <head>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "updates",
     "homebrew"
   ],
-  "author": "Arshia Ghaf",
+  "author": "Arshia Ghaffarian",
   "license": "GPL-3.0-only",
   "type": "commonjs",
   "config": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 module.exports = {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/scripts/create-unsigned-dmg.sh
+++ b/scripts/create-unsigned-dmg.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+# SPDX-License-Identifier: GPL-3.0-only
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+# SPDX-License-Identifier: GPL-3.0-only
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then

--- a/scripts/validate-preview.sh
+++ b/scripts/validate-preview.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+# SPDX-License-Identifier: GPL-3.0-only
 set -euo pipefail
 
 APP_NAME="Baseline"

--- a/src/main/appStoreLookupClient.ts
+++ b/src/main/appStoreLookupClient.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { AppStoreLookupResult } from "../shared/domain";
 import { byteLimits, sanitizeExternalURL } from "../shared/security";
 import { isVersionGreater, type VersionValue, version } from "../shared/version";

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { execFile } from "node:child_process";
 import { app as electronApp, nativeImage, type NativeImage } from "electron";
 import { mkdtemp, readdir, rm, stat } from "node:fs/promises";

--- a/src/main/commandRunner.ts
+++ b/src/main/commandRunner.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import { constants } from "node:fs";

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type {
   HomebrewCaskDiscoveryItem,
   HomebrewCaskEntry,

--- a/src/main/homebrewFormulaClient.ts
+++ b/src/main/homebrewFormulaClient.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type {
   HomebrewCaskDiscoveryItem,
   HomebrewFormulaEntry,

--- a/src/main/homebrewInventoryClient.ts
+++ b/src/main/homebrewInventoryClient.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { HomebrewManagedItem, HomebrewManagedItemKind } from "../shared/domain";
 import { homebrewItemID } from "../shared/domain";
 import { maxVersion, version } from "../shared/version";

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -58,7 +58,7 @@ if (!hasSingleInstanceLock) {
 if (hasSingleInstanceLock) {
   void app.whenReady().then(async () => {
     app.setAboutPanelOptions({
-      copyright: "Copyright (C) 2026 Arshia Ghaffarian"
+      copyright: "© 2026 Arshia Ghaffarian"
     });
 
     const persistence = new SnapshotPersistence(app.getPath("userData"));

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -57,6 +57,10 @@ if (!hasSingleInstanceLock) {
 
 if (hasSingleInstanceLock) {
   void app.whenReady().then(async () => {
+    app.setAboutPanelOptions({
+      copyright: "Copyright (C) 2026 Arshia Ghaffarian"
+    });
+
     const persistence = new SnapshotPersistence(app.getPath("userData"));
     const persisted = await persistence.load();
     store = new UpdateStore({

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import {
   app,
   BrowserWindow,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { PersistedSnapshot } from "../shared/domain";

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { contextBridge, ipcRenderer } from "electron";
 import { ipcChannels, type BaselineAPI, type PreferencePatch } from "../shared/ipc";
 import type { HomebrewCaskDiscoveryItem } from "../shared/domain";

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { XMLParser } from "fast-xml-parser";
 import type { SparkleLookupResult } from "../shared/domain";
 import { byteLimits, isAllowedFeedURL, sanitizeExternalURL } from "../shared/security";

--- a/src/main/trayWindowPosition.ts
+++ b/src/main/trayWindowPosition.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { Display, Rectangle } from "electron";
 
 type TrayDisplay = Pick<Display, "workArea">;

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { BaselineAPI } from "../shared/ipc";
 
 declare global {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -1,1 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 declare module "*.css";

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { BaselineSnapshot, UpdateSource } from "./domain";
 import { sourceDisplayName } from "./domain";
 

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { VersionValue } from "./version";
 
 export type UpdateSource = "appStore" | "sparkle" | "homebrew" | "web" | "unknown";

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type {
   AppRecord,
   HomebrewCaskDiscoveryItem,

--- a/src/shared/homebrewProgress.ts
+++ b/src/shared/homebrewProgress.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { HomebrewManagedItemKind } from "./domain";
 
 export type HomebrewMaintenanceRunEvent =

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type {
   BaselineSnapshot,
   HomebrewCaskDiscoveryItem,

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { isIP } from "node:net";
 
 export const byteLimits = {

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 export type VersionValue = {
   raw: string;
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import type { Config } from "tailwindcss";
 
 export default {

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { defineConfig } from "vite";
 
 export default defineConfig({

--- a/vite.preload.config.ts
+++ b/vite.preload.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { defineConfig } from "vite";
 
 export default defineConfig({

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 


### PR DESCRIPTION
## Summary

- Clarified Baseline’s GPL-3.0-only licensing and copyright ownership.
- Added explicit copyright notice.
- Updated the README to explain that distributed modified versions must remain GPL-licensed.
- Added GPL-3.0-only SPDX headers across source, test, config, script, stylesheet, and HTML files.
- Displayed the same copyright notice in the native macOS About panel.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:electron`
