### PR TITLE
Add menu bar icon setting

### DIFF
--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -17,6 +17,34 @@ afterEach(async () => {
 });
 
 describe("snapshot persistence", () => {
+  it("defaults the menu bar icon preference on older snapshots", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    await mkdir(userData, { recursive: true });
+    await writeFile(path.join(userData, "baseline-snapshot.json"), "{}\n", "utf8");
+
+    const persistence = new SnapshotPersistence(userData);
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      showMenuBarIcon: true
+    });
+  });
+
+  it("preserves the menu bar icon preference across save and load", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    const persistence = new SnapshotPersistence(userData);
+
+    await persistence.save({
+      ...defaultPersistedSnapshot(),
+      showMenuBarIcon: false
+    });
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      showMenuBarIcon: false
+    });
+  });
+
   it("preserves collapsed section preferences across save and load", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1504,4 +1504,14 @@ describe("renderer button parity", () => {
     expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);
     expect(window.baseline.refresh).not.toHaveBeenCalled();
   });
+
+  it("updates the menu bar icon preference from settings", () => {
+    render(<SettingsView snapshot={snapshot()} />);
+
+    fireEvent.click(screen.getByLabelText("Show menu bar icon"));
+
+    expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
+      showMenuBarIcon: false
+    });
+  });
 });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -78,10 +78,10 @@ if (hasSingleInstanceLock) {
       }
     });
 
-    createTray();
     createMainWindow("main");
     wireStoreEvents();
     wireIpc();
+    updateTrayStatus(store.getSnapshot());
     if (process.env.BASELINE_SKIP_INITIAL_REFRESH === "1") {
       store.emit("snapshot", store.getSnapshot());
     } else {
@@ -185,6 +185,9 @@ async function loadRenderer(
 }
 
 function createTray(): void {
+  if (tray) {
+    return;
+  }
   trayBaseIcon = nativeImage.createFromDataURL(
     "data:image/svg+xml;charset=utf-8," +
       encodeURIComponent(
@@ -194,12 +197,24 @@ function createTray(): void {
   trayBaseIcon.setTemplateImage(true);
   trayRefreshIcon = nativeImage.createFromDataURL(trayRefreshIconDataURL);
   trayRefreshIcon.setTemplateImage(true);
+
   tray = new Tray(trayBaseIcon);
+
   tray.setToolTip("Baseline");
   tray.on("click", toggleMenuWindow);
 }
 
+function destroyTray(): void {
+  menuWindow?.destroy();
+  menuWindow = undefined;
+  tray?.destroy();
+  tray = undefined;
+}
+
 function toggleMenuWindow(): void {
+  if (!store.getSnapshot().showMenuBarIcon) {
+    return;
+  }
   const window = createMenuWindow();
   if (window.isVisible()) {
     window.hide();
@@ -264,6 +279,11 @@ function wireStoreEvents(): void {
 }
 
 function updateTrayStatus(snapshot: BaselineSnapshot): void {
+  if (!snapshot.showMenuBarIcon) {
+    destroyTray();
+    return;
+  }
+  createTray();
   if (!tray) {
     return;
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -930,6 +930,7 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     autoRefreshEnabled: snapshot.autoRefreshEnabled,
     refreshIntervalMinutes: snapshot.refreshIntervalMinutes,
     useMasForAppStoreUpdates: snapshot.useMasForAppStoreUpdates,
+    showMenuBarIcon: snapshot.showMenuBarIcon,
     lastRefreshDate: snapshot.lastRefreshDate
   };
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2319,6 +2319,11 @@ export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
               value={snapshot.useMasForAppStoreUpdates}
               patch="useMasForAppStoreUpdates"
             />
+            <Toggle
+              label="Show menu bar icon"
+              value={snapshot.showMenuBarIcon}
+              patch="showMenuBarIcon"
+            />
           </section>
 
           <section className="panel wide-panel">

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -144,6 +144,7 @@ export type PersistedSnapshot = {
   autoRefreshEnabled: boolean;
   refreshIntervalMinutes: number;
   useMasForAppStoreUpdates: boolean;
+  showMenuBarIcon: boolean;
   lastRefreshDate?: string;
 };
 
@@ -209,7 +210,8 @@ export function defaultPersistedSnapshot(): PersistedSnapshot {
     collapsedHomebrewSectionIDs: [],
     autoRefreshEnabled: true,
     refreshIntervalMinutes: 60,
-    useMasForAppStoreUpdates: true
+    useMasForAppStoreUpdates: true,
+    showMenuBarIcon: true
   };
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -46,6 +46,7 @@ export type PreferencePatch = Partial<{
   autoRefreshEnabled: boolean;
   refreshIntervalMinutes: number;
   useMasForAppStoreUpdates: boolean;
+  showMenuBarIcon: boolean;
 }>;
 
 export type BaselineAPI = {


### PR DESCRIPTION
## Summary

- Added a persisted Settings toggle for showing or hiding the Baseline menu bar icon.
- Defaulted the preference to enabled so existing users and older snapshots keep the current behavior.
- Wired the preference into the Electron tray lifecycle so the menu bar icon is created when enabled, destroyed when disabled, and the compact popover is unavailable while hidden.

## Validation
- `npm run typecheck`
- `npm test -- --run ElectronTests/persistence.test.ts ElectronTests/rendererButtons.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:electron`
- `npm audit --omit=dev --audit-level=high`
