### PR TITLE
Keep ignored item action menus fully saturated

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -628,10 +628,12 @@ button:disabled {
 .ignored-row > .app-icon,
 .ignored-row > .app-icon img,
 .ignored-row > .row-main,
+.ignored-row > .row-actions > .primary-button,
 .ignored-row > .row-actions > .update-icon-button,
 .ignored-row > .row-actions > .row-action-menu > .secondary-icon-button,
 .ignored-row > .item-card-main,
 .ignored-row > .item-card-top > :not(.item-card-actions),
+.ignored-row > .item-card-top > .item-card-actions > .primary-button,
 .ignored-row > .item-card-top > .item-card-actions > .update-icon-button,
 .ignored-row > .item-card-top > .item-card-actions > .row-action-menu > .secondary-icon-button {
   opacity: 0.9;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -625,7 +625,15 @@ button:disabled {
   border-top: 1px solid rgba(60, 60, 67, 0.06);
 }
 
-.ignored-row {
+.ignored-row > .app-icon,
+.ignored-row > .app-icon img,
+.ignored-row > .row-main,
+.ignored-row > .row-actions > .update-icon-button,
+.ignored-row > .row-actions > .row-action-menu > .secondary-icon-button,
+.ignored-row > .item-card-main,
+.ignored-row > .item-card-top > :not(.item-card-actions),
+.ignored-row > .item-card-top > .item-card-actions > .update-icon-button,
+.ignored-row > .item-card-top > .item-card-actions > .row-action-menu > .secondary-icon-button {
   opacity: 0.9;
   filter: saturate(0.45);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -793,6 +793,12 @@ button:disabled {
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
 }
 
+.row:has(.row-action-menu-popover),
+.item-card:has(.row-action-menu-popover) {
+  position: relative;
+  z-index: 30;
+}
+
 .row-action-menu-popover button {
   display: grid;
   grid-template-columns: 16px minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- Keep ignored app and Homebrew cards visually muted without applying the muted filter to their actions popover.
- Scope the ignored-row opacity/saturation styling to card/list content and action trigger buttons only.

## Validation
- npm test -- ElectronTests/rendererButtons.test.tsx
- npm run typecheck
- npm run lint
- npm run build
