### PR TITLE
Fix sidebar update badges during search

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -205,6 +205,46 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
   });
 
+  it("keeps sidebar update badges fixed while search filters the content", () => {
+    const installedApp: AppRecord = {
+      ...app,
+      id: "app:stable",
+      displayName: "Stable App",
+      bundleIdentifier: "com.example.stable"
+    };
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.1.0"),
+      isOutdated: true
+    };
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          apps: [app, installedApp],
+          homebrewItems: [formula],
+          searchText: "stable"
+        })}
+      />
+    );
+
+    const [allButton, appsButton, homebrewButton] = Array.from(
+      container.querySelectorAll(".source-list button")
+    );
+
+    expect(within(allButton as HTMLElement).getByText("2")).toBeInTheDocument();
+    expect(within(appsButton as HTMLElement).getByText("1")).toBeInTheDocument();
+    expect(within(homebrewButton as HTMLElement).getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("Stable App")).toBeInTheDocument();
+    expect(screen.queryByText("Example")).not.toBeInTheDocument();
+    expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+  });
+
   it("uses the same short search placeholder on every tab", () => {
     const { rerender } = render(
       <Dashboard compact onOpenSettings={() => undefined} snapshot={snapshot()} />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -138,6 +138,7 @@ export function Dashboard({
   onOpenSettings: () => void;
 }) {
   const derived = useMemo(() => deriveSections(snapshot), [snapshot]);
+  const sidebarDerived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
   const selectedTab = snapshot.selectedTab;
   const [toolbarSearchOpen, setToolbarSearchOpen] = useState(Boolean(snapshot.searchText));
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
@@ -220,7 +221,7 @@ export function Dashboard({
     const title = selectedTabTitle(selectedTab);
     shell = (
       <main className="app-shell">
-        <Sidebar snapshot={snapshot} derived={derived} route="main" />
+        <Sidebar snapshot={snapshot} derived={sidebarDerived} route="main" />
         <section className="workspace">
           <header className="topbar">
             <div>


### PR DESCRIPTION
## Summary

- Keep sidebar update badge counts based on the full update set instead of the active search filter.
- Add a renderer regression test covering search-filtered content with stable All/Apps/Homebrew badges.

## Root Cause

The sidebar reused the same derived section model as the main workspace. That model applies `snapshot.searchText`, so searching for an installed app could reduce the update badge counts to the filtered result set.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:electron`
