### PR TITLE
Clarify first release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,6 @@ This project follows a lightweight changelog format inspired by Keep a Changelog
 - Preserved public update detection through App Store lookup, Sparkle/DevMate appcasts, and Homebrew metadata.
 - Added a local diagnostics report from Settings for support and troubleshooting.
 - Added preview validation and unsigned release preparation scripts.
-- Added GitHub Actions CI and unsigned DMG release publishing.
+- Added GitHub Actions CI and unsigned DMG release publishing infrastructure.
 - Documented the preview validation checklist.
 - Removed the legacy Swift/Tuist source from `main`; the previous implementation is archived at branch `legacy/swift-tuist` and tag `swift-tuist-final`.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -5,6 +5,7 @@ This repository uses GitHub Actions for pull request and `main` branch validatio
 Baseline is now an Electron app that still targets macOS first, so CI runs on GitHub's `macos-26` hosted runner.
 
 The CI workflow:
+
 - Installs Node dependencies with `npm ci`.
 - Lints release scripts with `bash -n`.
 - Typechecks the Electron main/preload/renderer TypeScript.
@@ -32,4 +33,4 @@ scripts/validate-preview.sh 0.0.0-preview
 
 That command also creates an unsigned DMG and smoke-launches the installed `/Applications/Baseline.app` copy.
 
-Unsigned DMG release publishing is handled by `.github/workflows/release.yml` when a `vX.Y.Z` tag is pushed.
+Unsigned DMG release publishing is handled by `.github/workflows/release.yml` when the first `vX.Y.Z` tag, or a later release tag, is pushed.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,10 +1,10 @@
 # Releasing Baseline
 
-Baseline currently supports Electron source builds and optional unsigned preview DMGs.
+Baseline currently supports Electron source builds and unsigned preview DMG release tooling. No public packaged release has been cut yet; use this process for the first public release and later unsigned preview releases.
 
 Unsigned DMGs are not notarized by Apple. macOS Gatekeeper may warn users before opening the app. Do not describe unsigned builds as signed, notarized, or production-grade.
 
-## Release Checklist
+## First Release Checklist
 
 1. Choose a version, for example `0.1.0`.
 2. Update `CHANGELOG.md`.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,6 +1,6 @@
 # Validation
 
-Use this checklist before handing off a preview build or opening a release PR.
+Use this checklist before handing off a local preview build, opening a release PR, or cutting the first public release.
 
 ## Known-Good Preview
 


### PR DESCRIPTION
## Summary

- clarify that unsigned DMG support is release infrastructure for the first public release
- align CI, validation, release, and changelog wording with the current no-release-yet README state

## Validation
- Not run; documentation-only change.
