### PR TITLE
Add appearance mode setting

### DIFF
--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -17,6 +17,51 @@ afterEach(async () => {
 });
 
 describe("snapshot persistence", () => {
+  it("defaults the appearance preference on older snapshots", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    await mkdir(userData, { recursive: true });
+    await writeFile(path.join(userData, "baseline-snapshot.json"), "{}\n", "utf8");
+
+    const persistence = new SnapshotPersistence(userData);
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      appearancePreference: "system"
+    });
+  });
+
+  it("preserves the appearance preference across save and load", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    const persistence = new SnapshotPersistence(userData);
+
+    await persistence.save({
+      ...defaultPersistedSnapshot(),
+      appearancePreference: "dark"
+    });
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      appearancePreference: "dark"
+    });
+  });
+
+  it("normalizes invalid appearance preferences from older or edited snapshots", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    await mkdir(userData, { recursive: true });
+    await writeFile(
+      path.join(userData, "baseline-snapshot.json"),
+      JSON.stringify({ appearancePreference: "sepia" }),
+      "utf8"
+    );
+
+    const persistence = new SnapshotPersistence(userData);
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      appearancePreference: "system"
+    });
+  });
+
   it("defaults the menu bar icon preference on older snapshots", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1545,6 +1545,21 @@ describe("renderer button parity", () => {
     expect(window.baseline.refresh).not.toHaveBeenCalled();
   });
 
+  it("updates the appearance preference from settings", () => {
+    render(<SettingsView snapshot={snapshot({ appearancePreference: "light" })} />);
+
+    expect(screen.getByRole("button", { name: "Light Mode" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dark Mode" }));
+
+    expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
+      appearancePreference: "dark"
+    });
+  });
+
   it("updates the menu bar icon preference from settings", () => {
     render(<SettingsView snapshot={snapshot()} />);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7,6 +7,7 @@ import {
   clipboard,
   dialog,
   ipcMain,
+  nativeTheme,
   nativeImage,
   screen,
   shell,
@@ -14,7 +15,12 @@ import {
 } from "electron";
 import path from "node:path";
 import { renderDiagnostics } from "../shared/diagnostics";
-import type { BaselineSnapshot, HomebrewCaskDiscoveryItem, MenuTab } from "../shared/domain";
+import type {
+  AppearancePreference,
+  BaselineSnapshot,
+  HomebrewCaskDiscoveryItem,
+  MenuTab
+} from "../shared/domain";
 import { homebrewItemHasAppRepresentation } from "../shared/homebrewAppLinking";
 import { ipcChannels, type PreferencePatch } from "../shared/ipc";
 import { isAllowedExternalURL } from "../shared/security";
@@ -63,6 +69,7 @@ if (hasSingleInstanceLock) {
 
     const persistence = new SnapshotPersistence(app.getPath("userData"));
     const persisted = await persistence.load();
+    applyAppearancePreference(persisted.appearancePreference);
     store = new UpdateStore({
       persistence,
       persisted,
@@ -253,6 +260,7 @@ function showWindow(window?: BrowserWindow): void {
 
 function wireStoreEvents(): void {
   store.on("snapshot", (snapshot) => {
+    applyAppearancePreference(snapshot.appearancePreference);
     updateTrayStatus(snapshot);
     for (const window of BrowserWindow.getAllWindows()) {
       window.webContents.send(ipcChannels.snapshotChanged, snapshot);
@@ -276,6 +284,10 @@ function wireStoreEvents(): void {
       window.webContents.send(ipcChannels.homebrewCommandEvent, event);
     }
   });
+}
+
+function applyAppearancePreference(preference: AppearancePreference): void {
+  nativeTheme.themeSource = preference;
 }
 
 function updateTrayStatus(snapshot: BaselineSnapshot): void {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4,7 +4,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { PersistedSnapshot } from "../shared/domain";
-import { defaultPersistedSnapshot } from "../shared/domain";
+import { defaultPersistedSnapshot, normalizeAppearancePreference } from "../shared/domain";
 import { version } from "../shared/version";
 export { defaultPersistedSnapshot };
 
@@ -63,6 +63,7 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
       fromVersion: version(record.fromVersion?.raw),
       toVersion: version(record.toVersion?.raw)
     })),
+    appearancePreference: normalizeAppearancePreference(input.appearancePreference),
     refreshIntervalMinutes: clamp(
       input.refreshIntervalMinutes ?? defaults.refreshIntervalMinutes,
       5,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -22,7 +22,8 @@ import {
   emptyHomebrewCaskIndex,
   emptyHomebrewFormulaIndex,
   homebrewDiscoverID,
-  homebrewItemID
+  homebrewItemID,
+  normalizeAppearancePreference
 } from "../shared/domain";
 import {
   HomebrewMaintenanceOutputParser,
@@ -203,7 +204,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       patch.refreshIntervalMinutes === undefined
         ? this.state.refreshIntervalMinutes
         : Math.min(Math.max(Math.trunc(patch.refreshIntervalMinutes), 5), 1440);
-    this.patch({ ...patch, refreshIntervalMinutes });
+    const appearancePreference = normalizeAppearancePreference(
+      patch.appearancePreference ?? this.state.appearancePreference
+    );
+    this.patch({ ...patch, appearancePreference, refreshIntervalMinutes });
     this.restartAutoRefreshLoop();
     await this.persist();
   }
@@ -929,6 +933,7 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     collapsedHomebrewSectionIDs: snapshot.collapsedHomebrewSectionIDs,
     autoRefreshEnabled: snapshot.autoRefreshEnabled,
     refreshIntervalMinutes: snapshot.refreshIntervalMinutes,
+    appearancePreference: snapshot.appearancePreference,
     useMasForAppStoreUpdates: snapshot.useMasForAppStoreUpdates,
     showMenuBarIcon: snapshot.showMenuBarIcon,
     lastRefreshDate: snapshot.lastRefreshDate

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -15,12 +15,15 @@ import {
   EyeOff,
   ExternalLink,
   FolderPlus,
+  Monitor,
   MoreHorizontal,
+  Moon,
   Package,
   RefreshCcw,
   Search,
   Server,
   Settings,
+  Sun,
   Terminal,
   Trash2,
   X,
@@ -28,6 +31,7 @@ import {
 } from "lucide-react";
 import type {
   AppRecord,
+  AppearancePreference,
   BaselineSnapshot,
   HomebrewCaskDiscoveryItem,
   HomebrewManagedItem,
@@ -2295,6 +2299,11 @@ export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
           </section>
 
           <section className="panel">
+            <PanelTitle title="Appearance" />
+            <AppearanceSelector value={snapshot.appearancePreference} />
+          </section>
+
+          <section className="panel">
             <PanelTitle title="Refresh" />
             <Toggle
               label="Auto refresh"
@@ -2384,8 +2393,43 @@ export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
 
 type TogglePatch = Exclude<
   keyof Parameters<typeof window.baseline.updatePreferences>[0],
-  "selectedTab" | "refreshIntervalMinutes"
+  "selectedTab" | "refreshIntervalMinutes" | "appearancePreference"
 >;
+
+const appearanceOptions: Array<{
+  value: AppearancePreference;
+  label: string;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+}> = [
+  { value: "system", label: "System Default", icon: Monitor },
+  { value: "light", label: "Light Mode", icon: Sun },
+  { value: "dark", label: "Dark Mode", icon: Moon }
+];
+
+function AppearanceSelector({ value }: { value: AppearancePreference }) {
+  return (
+    <div className="appearance-options" role="group" aria-label="Appearance">
+      {appearanceOptions.map((option) => {
+        const Icon = option.icon;
+        const selected = option.value === value;
+        return (
+          <button
+            aria-pressed={selected}
+            className={selected ? "selected" : ""}
+            key={option.value}
+            onClick={() =>
+              void window.baseline.updatePreferences({ appearancePreference: option.value })
+            }
+            type="button"
+          >
+            <Icon size={15} strokeWidth={toolbarIconStrokeWidth} />
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 function Toggle({ label, value, patch }: { label: string; value: boolean; patch: TogglePatch }) {
   return (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1328,6 +1328,47 @@ button:disabled {
   padding: 10px 12px;
 }
 
+.appearance-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 3px;
+  margin: 12px;
+  padding: 2px;
+  border-radius: 8px;
+  background: rgba(118, 118, 128, 0.12);
+}
+
+.appearance-options button {
+  display: grid;
+  grid-template-columns: 15px minmax(0, 1fr);
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #2c2c2e;
+  font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+}
+
+.appearance-options button.selected {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 0 0 0.5px rgba(60, 60, 67, 0.08),
+    0 1px 3px rgba(0, 0, 0, 0.1);
+  color: #0d0d0d;
+}
+
+.appearance-options span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .directory-list {
   display: grid;
 }
@@ -1580,6 +1621,22 @@ button:disabled {
   .ghost-button {
     border-color: rgba(235, 235, 245, 0.16);
     background: rgba(255, 255, 255, 0.08);
+  }
+
+  .appearance-options {
+    background: rgba(118, 118, 128, 0.28);
+  }
+
+  .appearance-options button {
+    color: rgba(235, 235, 245, 0.78);
+  }
+
+  .appearance-options button.selected {
+    background: rgba(99, 99, 102, 0.78);
+    box-shadow:
+      0 0 0 0.5px rgba(255, 255, 255, 0.14),
+      0 1px 3px rgba(0, 0, 0, 0.4);
+    color: #ffffff;
   }
 
   .toolbar-button.refresh-button,

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -33,7 +33,8 @@ export function renderDiagnostics(
     `- Last refresh: ${snapshot.lastRefreshDate ?? "Never"}`,
     `- Refreshing: ${yesNo(snapshot.isRefreshing)}`,
     `- Auto refresh: ${yesNo(snapshot.autoRefreshEnabled)}`,
-    `- Refresh interval: ${snapshot.refreshIntervalMinutes} minutes`
+    `- Refresh interval: ${snapshot.refreshIntervalMinutes} minutes`,
+    `- Appearance: ${appearanceLabel(snapshot.appearancePreference)}`
   ];
 
   if (safeLastMessage) {
@@ -70,6 +71,14 @@ export function renderDiagnostics(
 
 function yesNo(value: boolean): string {
   return value ? "Yes" : "No";
+}
+
+function appearanceLabel(value: BaselineSnapshot["appearancePreference"]): string {
+  return {
+    system: "System Default",
+    light: "Light Mode",
+    dark: "Dark Mode"
+  }[value];
 }
 
 function defaultScanDirectories(additional: string[]): string[] {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -6,6 +6,7 @@ import type { VersionValue } from "./version";
 export type UpdateSource = "appStore" | "sparkle" | "homebrew" | "web" | "unknown";
 export type SupportLevel = "supported" | "limited" | "unsupported";
 export type MenuTab = "all" | "apps" | "homebrew" | "installed" | "ignored";
+export type AppearancePreference = "system" | "light" | "dark";
 export type HomebrewManagedItemKind = "formula" | "cask";
 export type HomebrewPresentation = "formula" | "app" | "cli" | "package" | "cask";
 
@@ -143,6 +144,7 @@ export type PersistedSnapshot = {
   collapsedHomebrewSectionIDs: string[];
   autoRefreshEnabled: boolean;
   refreshIntervalMinutes: number;
+  appearancePreference: AppearancePreference;
   useMasForAppStoreUpdates: boolean;
   showMenuBarIcon: boolean;
   lastRefreshDate?: string;
@@ -210,9 +212,17 @@ export function defaultPersistedSnapshot(): PersistedSnapshot {
     collapsedHomebrewSectionIDs: [],
     autoRefreshEnabled: true,
     refreshIntervalMinutes: 60,
+    appearancePreference: "system",
     useMasForAppStoreUpdates: true,
     showMenuBarIcon: true
   };
+}
+
+export function normalizeAppearancePreference(value: unknown): AppearancePreference {
+  if (value === "light" || value === "dark" || value === "system") {
+    return value;
+  }
+  return "system";
 }
 
 export function homebrewItemID(kind: HomebrewManagedItemKind, token: string): string {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -3,6 +3,7 @@
 
 import type {
   BaselineSnapshot,
+  AppearancePreference,
   HomebrewCaskDiscoveryItem,
   HomebrewManagedItem,
   MenuTab,
@@ -45,6 +46,7 @@ export type PreferencePatch = Partial<{
   collapsedHomebrewSectionIDs: string[];
   autoRefreshEnabled: boolean;
   refreshIntervalMinutes: number;
+  appearancePreference: AppearancePreference;
   useMasForAppStoreUpdates: boolean;
   showMenuBarIcon: boolean;
 }>;


### PR DESCRIPTION
## Summary

- Added a persisted Appearance setting with System Default, Light Mode, and Dark Mode options.
- Applied the selected appearance through Electron `nativeTheme`, allowing the existing light/dark stylesheet to follow the chosen mode.
- Updated Settings UI, diagnostics, persistence normalization, and renderer/persistence regression coverage.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:electron`
- `npm audit --omit=dev --audit-level=high`
