### PR TITLE
Render installed search matches as cards

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1308,7 +1308,7 @@ describe("renderer button parity", () => {
       version: version("1.0.0")
     };
 
-    render(
+    const { container } = render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}
@@ -1329,6 +1329,27 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("All your apps are up to date.")).not.toBeInTheDocument();
     expect(screen.queryByText("All your Homebrew items are up to date.")).not.toBeInTheDocument();
     expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent("Discover");
+
+    const sections = Array.from(container.querySelectorAll("section.panel"));
+    const discoverSection = sections.find((section) =>
+      within(section as HTMLElement).queryByRole("heading", { name: "Discover" })
+    ) as HTMLElement | undefined;
+    const installedAppsSection = sections.find((section) =>
+      within(section as HTMLElement).queryByRole("heading", { name: "Installed Apps" })
+    ) as HTMLElement | undefined;
+    const installedHomebrewSection = sections.find((section) =>
+      within(section as HTMLElement).queryByRole("heading", { name: "Installed Homebrew" })
+    ) as HTMLElement | undefined;
+
+    expect(discoverSection).toBeDefined();
+    expect(installedAppsSection).toBeDefined();
+    expect(installedHomebrewSection).toBeDefined();
+    expect(discoverSection!.querySelector(".rows .row")).not.toBeNull();
+    expect(discoverSection!.querySelector(".item-card")).toBeNull();
+    expect(installedAppsSection!.querySelector(".card-grid .item-card")).not.toBeNull();
+    expect(installedAppsSection!.querySelector(".rows .row")).toBeNull();
+    expect(installedHomebrewSection!.querySelector(".card-grid .item-card")).not.toBeNull();
+    expect(installedHomebrewSection!.querySelector(".rows .row")).toBeNull();
   });
 
   it("shows app-backed Homebrew updates in search when the app result does not match", () => {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -576,6 +576,7 @@ function SearchResults({
           apps={searchInstalledApps}
           snapshot={snapshot}
           empty="No installed apps found."
+          cardLayout
         />
       )}
       {derived.homebrewInstalled.length > 0 && (
@@ -585,6 +586,7 @@ function SearchResults({
           items={derived.homebrewInstalled}
           snapshot={snapshot}
           empty="No installed Homebrew items found."
+          cardLayout
         />
       )}
       {!hasResults && <Empty text="No matches found." />}


### PR DESCRIPTION
## Summary
- render installed app and installed Homebrew search matches as cards
- keep Discover search results in the existing row layout
- add a renderer regression test for the mixed search layout

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npm run test:electron
