### PR TITLE
Make sidebar tabs exit search mode

### DIFF
--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -45,6 +45,21 @@ describe("snapshot persistence", () => {
     });
   });
 
+  it("does not restore the previously selected sidebar tab", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    const persistence = new SnapshotPersistence(userData);
+
+    await persistence.save({
+      ...defaultPersistedSnapshot(),
+      selectedTab: "homebrew"
+    });
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      selectedTab: "all"
+    });
+  });
+
   it("normalizes invalid appearance preferences from older or edited snapshots", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -417,27 +417,6 @@ describe("renderer button parity", () => {
     expect(window.baseline.setSearchText).not.toHaveBeenCalled();
   });
 
-  it("collapses toolbar search from main window chrome clicks without clearing text", async () => {
-    const { container } = render(
-      <Dashboard
-        compact={false}
-        onOpenSettings={() => undefined}
-        snapshot={snapshot({ searchText: "obsidian" })}
-      />
-    );
-
-    fireEvent.click(container.querySelector(".topbar") as HTMLElement);
-    await waitFor(() => expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument());
-    expect(window.baseline.setSearchText).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
-    expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
-
-    fireEvent.click(container.querySelector(".sidebar") as HTMLElement);
-    await waitFor(() => expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument());
-    expect(window.baseline.setSearchText).not.toHaveBeenCalled();
-  });
-
   it("keeps toolbar search open for clicks inside the search controls", () => {
     render(
       <Dashboard

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -205,6 +205,107 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
   });
 
+  it("closes search mode on sidebar tab clicks without clearing the saved query", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:obsidian-cli",
+      token: "obsidian-cli",
+      name: "obsidian-cli",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.1.0"),
+      isOutdated: true
+    };
+    const discoverItem: HomebrewCaskDiscoveryItem = {
+      id: "cask:obsidian",
+      token: "obsidian",
+      displayName: "Obsidian",
+      kind: "cask",
+      version: version("1.6.0")
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "apps",
+          searchText: "obsidian",
+          apps: [app],
+          updates: [update],
+          homebrewItems: [formula],
+          homebrewDiscoverItems: [discoverItem]
+        })}
+      />
+    );
+
+    expect(screen.getByText("Obsidian")).toBeInTheDocument();
+    expect(screen.getByText("obsidian-cli")).toBeInTheDocument();
+    expect(screen.queryByText("Example")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
+
+    expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("apps");
+    expect(window.baseline.setSearchText).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(screen.getByText("Example")).toBeInTheDocument();
+    expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
+    expect(screen.queryByText("obsidian-cli")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(screen.getByDisplayValue("obsidian")).toBeInTheDocument();
+    expect(screen.getByText("Obsidian")).toBeInTheDocument();
+    expect(screen.getByText("obsidian-cli")).toBeInTheDocument();
+  });
+
+  it("does not show discovery results after dismissing search into the Homebrew tab", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.1.0"),
+      isOutdated: true
+    };
+    const discoverItem: HomebrewCaskDiscoveryItem = {
+      id: "cask:obsidian",
+      token: "obsidian",
+      displayName: "Obsidian",
+      kind: "cask",
+      version: version("1.6.0")
+    };
+
+    const searchSnapshot = snapshot({
+      selectedTab: "apps",
+      searchText: "obsidian",
+      apps: [],
+      updates: [],
+      homebrewItems: [formula],
+      homebrewDiscoverItems: [discoverItem]
+    });
+    const { rerender } = render(
+      <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={searchSnapshot} />
+    );
+
+    expect(screen.getByText("Obsidian")).toBeInTheDocument();
+    expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Homebrew/ }));
+
+    expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("homebrew");
+    rerender(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={{ ...searchSnapshot, selectedTab: "homebrew" }}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(screen.getByText("ripgrep")).toBeInTheDocument();
+    expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
+  });
+
   it("keeps sidebar update badges fixed while search filters the content", () => {
     const installedApp: AppRecord = {
       ...app,

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -397,6 +397,41 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
   });
 
+  it("keeps Settings sidebar badges fixed when a saved query is present", () => {
+    const installedApp: AppRecord = {
+      ...app,
+      id: "app:stable",
+      displayName: "Stable App",
+      bundleIdentifier: "com.example.stable"
+    };
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.1.0"),
+      isOutdated: true
+    };
+    const { container } = render(
+      <SettingsView
+        snapshot={snapshot({
+          apps: [app, installedApp],
+          homebrewItems: [formula],
+          searchText: "stable"
+        })}
+      />
+    );
+
+    const [allButton, appsButton, homebrewButton] = Array.from(
+      container.querySelectorAll(".source-list button")
+    );
+
+    expect(within(allButton as HTMLElement).getByText("2")).toBeInTheDocument();
+    expect(within(appsButton as HTMLElement).getByText("1")).toBeInTheDocument();
+    expect(within(homebrewButton as HTMLElement).getByText("1")).toBeInTheDocument();
+  });
+
   it("uses the same short search placeholder on every tab", () => {
     const { rerender } = render(
       <Dashboard compact onOpenSettings={() => undefined} snapshot={snapshot()} />

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -417,6 +417,27 @@ describe("renderer button parity", () => {
     expect(window.baseline.setSearchText).not.toHaveBeenCalled();
   });
 
+  it("collapses toolbar search from main window chrome clicks without clearing text", async () => {
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ searchText: "obsidian" })}
+      />
+    );
+
+    fireEvent.click(container.querySelector(".topbar") as HTMLElement);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument());
+    expect(window.baseline.setSearchText).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
+
+    fireEvent.click(container.querySelector(".sidebar") as HTMLElement);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument());
+    expect(window.baseline.setSearchText).not.toHaveBeenCalled();
+  });
+
   it("keeps toolbar search open for clicks inside the search controls", () => {
     render(
       <Dashboard

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -306,6 +306,57 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
   });
 
+  it("keeps a preserved query inactive after search is dismissed across remounts", () => {
+    const discoverItem: HomebrewCaskDiscoveryItem = {
+      id: "cask:obsidian",
+      token: "obsidian",
+      displayName: "Obsidian",
+      kind: "cask",
+      version: version("1.6.0")
+    };
+    const searchSnapshot = snapshot({
+      selectedTab: "apps",
+      searchText: "obsidian",
+      apps: [app],
+      updates: [update],
+      homebrewItems: [],
+      homebrewDiscoverItems: [discoverItem]
+    });
+    let searchOpen = true;
+    const setSearchOpen = vi.fn((open: boolean) => {
+      searchOpen = open;
+    });
+
+    const { unmount } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        onToolbarSearchOpenChange={setSearchOpen}
+        toolbarSearchOpen={searchOpen}
+        snapshot={searchSnapshot}
+      />
+    );
+
+    expect(screen.getByText("Obsidian")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
+    expect(setSearchOpen).toHaveBeenCalledWith(false);
+
+    unmount();
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        onToolbarSearchOpenChange={setSearchOpen}
+        toolbarSearchOpen={searchOpen}
+        snapshot={searchSnapshot}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(screen.getByText("Example")).toBeInTheDocument();
+    expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
+  });
+
   it("keeps sidebar update badges fixed while search filters the content", () => {
     const installedApp: AppRecord = {
       ...app,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -35,6 +35,7 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
   return {
     ...defaults,
     ...input,
+    selectedTab: "all",
     apps: (input.apps ?? []).map((app) => ({
       ...app,
       id: app.id ?? app.bundlePath,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -196,7 +196,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   async setSelectedTab(selectedTab: MenuTab): Promise<void> {
-    await this.updatePreferences({ selectedTab });
+    this.patch({ selectedTab });
   }
 
   async updatePreferences(patch: PreferencePatch): Promise<void> {
@@ -928,7 +928,7 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     ignoredIDs: snapshot.ignoredIDs,
     ignoredHomebrewItemIDs: snapshot.ignoredHomebrewItemIDs,
     additionalDirectories: snapshot.additionalDirectories,
-    selectedTab: snapshot.selectedTab,
+    selectedTab: "all",
     collapsedAppSectionIDs: snapshot.collapsedAppSectionIDs,
     collapsedHomebrewSectionIDs: snapshot.collapsedHomebrewSectionIDs,
     autoRefreshEnabled: snapshot.autoRefreshEnabled,

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -141,12 +141,24 @@ export function Dashboard({
   compact: boolean;
   onOpenSettings: () => void;
 }) {
-  const derived = useMemo(() => deriveSections(snapshot), [snapshot]);
-  const sidebarDerived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
   const selectedTab = snapshot.selectedTab;
   const [toolbarSearchOpen, setToolbarSearchOpen] = useState(Boolean(snapshot.searchText));
+  const previousSearchTextRef = useRef(snapshot.searchText);
+  const derived = useMemo(
+    () => deriveSections(toolbarSearchOpen ? snapshot : { ...snapshot, searchText: "" }),
+    [snapshot, toolbarSearchOpen]
+  );
+  const sidebarDerived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
   const compactShellRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const previousSearchText = previousSearchTextRef.current;
+    previousSearchTextRef.current = snapshot.searchText;
+    if (!previousSearchText.trim() && snapshot.searchText.trim()) {
+      setToolbarSearchOpen(true);
+    }
+  }, [snapshot.searchText]);
 
   useEffect(() => {
     if (!compact || toolbarSearchOpen) {
@@ -217,7 +229,12 @@ export function Dashboard({
           </div>
         </header>
         <section className="content single">
-          <SelectedTabContent snapshot={snapshot} derived={derived} compact={compact} />
+          <SelectedTabContent
+            snapshot={snapshot}
+            derived={derived}
+            compact={compact}
+            searchActive={toolbarSearchOpen}
+          />
         </section>
       </main>
     );
@@ -225,7 +242,12 @@ export function Dashboard({
     const title = selectedTabTitle(selectedTab);
     shell = (
       <main className="app-shell">
-        <Sidebar snapshot={snapshot} derived={sidebarDerived} route="main" />
+        <Sidebar
+          snapshot={snapshot}
+          derived={sidebarDerived}
+          route="main"
+          onNavigate={() => setToolbarSearchOpen(false)}
+        />
         <section className="workspace">
           <header className="topbar">
             <div>
@@ -266,7 +288,12 @@ export function Dashboard({
           )}
 
           <section className="content">
-            <SelectedTabContent snapshot={snapshot} derived={derived} compact={compact} />
+            <SelectedTabContent
+              snapshot={snapshot}
+              derived={derived}
+              compact={compact}
+              searchActive={toolbarSearchOpen}
+            />
           </section>
         </section>
       </main>
@@ -336,21 +363,26 @@ function compactPopoverControlFocusTarget(
 function Sidebar({
   snapshot,
   derived,
-  route
+  route,
+  onNavigate
 }: {
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
   route: "main" | "settings";
+  onNavigate?: () => void;
 }) {
+  const selectTab = (tab: MenuTab) => {
+    onNavigate?.();
+    window.location.hash = "/main";
+    void window.baseline.setSelectedTab(tab);
+  };
+
   return (
     <aside className="sidebar">
       <nav className="source-list">
         <button
           className={route === "main" && snapshot.selectedTab === "all" ? "selected" : ""}
-          onClick={() => {
-            window.location.hash = "/main";
-            void window.baseline.setSelectedTab("all");
-          }}
+          onClick={() => selectTab("all")}
         >
           <Server size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>All</span>
@@ -358,10 +390,7 @@ function Sidebar({
         </button>
         <button
           className={route === "main" && snapshot.selectedTab === "apps" ? "selected" : ""}
-          onClick={() => {
-            window.location.hash = "/main";
-            void window.baseline.setSelectedTab("apps");
-          }}
+          onClick={() => selectTab("apps")}
         >
           <AppWindowMac size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Apps</span>
@@ -369,10 +398,7 @@ function Sidebar({
         </button>
         <button
           className={route === "main" && snapshot.selectedTab === "homebrew" ? "selected" : ""}
-          onClick={() => {
-            window.location.hash = "/main";
-            void window.baseline.setSelectedTab("homebrew");
-          }}
+          onClick={() => selectTab("homebrew")}
         >
           <Beer size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Homebrew</span>
@@ -382,20 +408,14 @@ function Sidebar({
       <nav className="source-list secondary-source-list">
         <button
           className={route === "main" && snapshot.selectedTab === "installed" ? "selected" : ""}
-          onClick={() => {
-            window.location.hash = "/main";
-            void window.baseline.setSelectedTab("installed");
-          }}
+          onClick={() => selectTab("installed")}
         >
           <CheckCircle2 size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Installed</span>
         </button>
         <button
           className={route === "main" && snapshot.selectedTab === "ignored" ? "selected" : ""}
-          onClick={() => {
-            window.location.hash = "/main";
-            void window.baseline.setSelectedTab("ignored");
-          }}
+          onClick={() => selectTab("ignored")}
         >
           <EyeOff size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Ignored</span>
@@ -404,7 +424,10 @@ function Sidebar({
       <div className="sidebar-footer">
         <button
           className={route === "settings" ? "selected" : ""}
-          onClick={() => (window.location.hash = "/settings")}
+          onClick={() => {
+            onNavigate?.();
+            window.location.hash = "/settings";
+          }}
         >
           <Settings size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Settings</span>
@@ -501,17 +524,19 @@ function ToolbarSearch({
 function SelectedTabContent({
   snapshot,
   derived,
-  compact
+  compact,
+  searchActive
 }: {
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
   compact: boolean;
+  searchActive: boolean;
 }) {
+  if (searchActive && snapshot.searchText.trim()) {
+    return <SearchResults snapshot={snapshot} derived={derived} />;
+  }
   if (!compact && snapshot.selectedTab === "ignored") {
     return <IgnoredTab snapshot={snapshot} derived={derived} compact={compact} />;
-  }
-  if (snapshot.searchText.trim()) {
-    return <SearchResults snapshot={snapshot} derived={derived} />;
   }
   if (compact) {
     return <AllTab snapshot={snapshot} derived={derived} compact />;
@@ -543,7 +568,9 @@ function SearchResults({
     derived.availableApps.length > 0 ||
     derived.allHomebrewOutdated.length > 0 ||
     searchInstalledApps.length > 0 ||
-    derived.homebrewInstalled.length > 0;
+    derived.homebrewInstalled.length > 0 ||
+    derived.ignoredApps.length > 0 ||
+    derived.homebrewIgnored.length > 0;
 
   return (
     <div className="stack">
@@ -587,8 +614,47 @@ function SearchResults({
           empty="No installed Homebrew items found."
         />
       )}
+      {(derived.ignoredApps.length > 0 || derived.homebrewIgnored.length > 0) && (
+        <SearchIgnoredSection snapshot={snapshot} derived={derived} />
+      )}
       {!hasResults && <Empty text="No matches found." />}
     </div>
+  );
+}
+
+function SearchIgnoredSection({
+  snapshot,
+  derived
+}: {
+  snapshot: BaselineSnapshot;
+  derived: DerivedSections;
+}) {
+  const items: IgnoredGridItem[] = [
+    ...derived.ignoredApps.map((app) => ({
+      type: "app" as const,
+      id: app.id,
+      item: app
+    })),
+    ...derived.homebrewIgnored.map((item) => ({
+      type: "homebrew" as const,
+      id: item.id,
+      item
+    }))
+  ];
+
+  return (
+    <section className="panel">
+      <PanelTitle title="Ignored" />
+      <CardGrid sectionClassName="ignored-grid">
+        {items.map((item) =>
+          item.type === "app" ? (
+            <IgnoredAppCard key={`app:${item.id}`} app={item.item} snapshot={snapshot} />
+          ) : (
+            <IgnoredHomebrewCard key={`homebrew:${item.id}`} item={item.item} snapshot={snapshot} />
+          )
+        )}
+      </CardGrid>
+    </section>
   );
 }
 
@@ -1319,7 +1385,6 @@ function HomebrewTab({
 }) {
   return (
     <div className="stack">
-      {snapshot.searchText.trim() && <DiscoverSection snapshot={snapshot} />}
       <HomebrewSection
         sectionID="outdated"
         title={`Outdated (${derived.allHomebrewOutdated.length})`}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -249,7 +249,7 @@ export function Dashboard({
           onNavigate={() => setToolbarSearchOpen(false)}
         />
         <section className="workspace">
-          <header className="topbar" onClick={() => setToolbarSearchOpen(false)}>
+          <header className="topbar">
             <div>
               <h1>{title}</h1>
             </div>
@@ -378,7 +378,7 @@ function Sidebar({
   };
 
   return (
-    <aside className="sidebar" onClick={() => onNavigate?.()}>
+    <aside className="sidebar">
       <nav className="source-list">
         <button
           className={route === "main" && snapshot.selectedTab === "all" ? "selected" : ""}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -101,11 +101,21 @@ const initialSnapshot: BaselineSnapshot = {
 function App() {
   const [snapshot, setSnapshot] = useState<BaselineSnapshot>(initialSnapshot);
   const [route, setRoute] = useState<Route>(currentRoute());
+  const [toolbarSearchOpen, setToolbarSearchOpen] = useState(false);
+  const previousSearchTextRef = useRef(initialSnapshot.searchText);
 
   useEffect(() => {
     void window.baseline.getSnapshot().then(setSnapshot);
     return window.baseline.onSnapshotChanged(setSnapshot);
   }, []);
+
+  useEffect(() => {
+    const previousSearchText = previousSearchTextRef.current;
+    previousSearchTextRef.current = snapshot.searchText;
+    if (!previousSearchText.trim() && snapshot.searchText.trim()) {
+      setToolbarSearchOpen(true);
+    }
+  }, [snapshot.searchText]);
 
   useEffect(() => {
     const onHashChange = () => setRoute(currentRoute());
@@ -121,7 +131,10 @@ function App() {
     <Dashboard
       snapshot={snapshot}
       compact={route === "menubar"}
+      toolbarSearchOpen={toolbarSearchOpen}
+      onToolbarSearchOpenChange={setToolbarSearchOpen}
       onOpenSettings={() => {
+        setToolbarSearchOpen(false);
         if (route === "menubar") {
           void window.baseline.showSettings();
         } else {
@@ -135,14 +148,28 @@ function App() {
 export function Dashboard({
   snapshot,
   compact,
+  toolbarSearchOpen: controlledToolbarSearchOpen,
+  onToolbarSearchOpenChange,
   onOpenSettings
 }: {
   snapshot: BaselineSnapshot;
   compact: boolean;
+  toolbarSearchOpen?: boolean;
+  onToolbarSearchOpenChange?: (open: boolean) => void;
   onOpenSettings: () => void;
 }) {
   const selectedTab = snapshot.selectedTab;
-  const [toolbarSearchOpen, setToolbarSearchOpen] = useState(Boolean(snapshot.searchText));
+  const [uncontrolledToolbarSearchOpen, setUncontrolledToolbarSearchOpen] = useState(
+    Boolean(snapshot.searchText)
+  );
+  const toolbarSearchOpen = controlledToolbarSearchOpen ?? uncontrolledToolbarSearchOpen;
+  const setToolbarSearchOpen = (open: boolean) => {
+    if (onToolbarSearchOpenChange) {
+      onToolbarSearchOpenChange(open);
+      return;
+    }
+    setUncontrolledToolbarSearchOpen(open);
+  };
   const previousSearchTextRef = useRef(snapshot.searchText);
   const derived = useMemo(
     () => deriveSections(toolbarSearchOpen ? snapshot : { ...snapshot, searchText: "" }),
@@ -153,12 +180,15 @@ export function Dashboard({
   const compactShellRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
+    if (controlledToolbarSearchOpen !== undefined) {
+      return;
+    }
     const previousSearchText = previousSearchTextRef.current;
     previousSearchTextRef.current = snapshot.searchText;
     if (!previousSearchText.trim() && snapshot.searchText.trim()) {
       setToolbarSearchOpen(true);
     }
-  }, [snapshot.searchText]);
+  }, [controlledToolbarSearchOpen, snapshot.searchText]);
 
   useEffect(() => {
     if (!compact || toolbarSearchOpen) {
@@ -202,7 +232,7 @@ export function Dashboard({
             <ToolbarSearch
               open={toolbarSearchOpen}
               snapshot={snapshot}
-              onToggle={() => setToolbarSearchOpen((open) => !open)}
+              onToggle={() => setToolbarSearchOpen(!toolbarSearchOpen)}
               onClose={() => setToolbarSearchOpen(false)}
               toolbarButtonTabIndex={-1}
             />
@@ -257,7 +287,7 @@ export function Dashboard({
               <ToolbarSearch
                 open={toolbarSearchOpen}
                 snapshot={snapshot}
-                onToggle={() => setToolbarSearchOpen((open) => !open)}
+                onToggle={() => setToolbarSearchOpen(!toolbarSearchOpen)}
                 onClose={() => setToolbarSearchOpen(false)}
               />
               <button

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2359,7 +2359,7 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
 
 export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
   const [diagnosticsCopied, setDiagnosticsCopied] = useState(false);
-  const derived = useMemo(() => deriveSections(snapshot), [snapshot]);
+  const derived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
 
   return (
     <main className="app-shell">

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -249,7 +249,7 @@ export function Dashboard({
           onNavigate={() => setToolbarSearchOpen(false)}
         />
         <section className="workspace">
-          <header className="topbar">
+          <header className="topbar" onClick={() => setToolbarSearchOpen(false)}>
             <div>
               <h1>{title}</h1>
             </div>
@@ -378,7 +378,7 @@ function Sidebar({
   };
 
   return (
-    <aside className="sidebar">
+    <aside className="sidebar" onClick={() => onNavigate?.()}>
       <nav className="source-list">
         <button
           className={route === "main" && snapshot.selectedTab === "all" ? "selected" : ""}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -41,7 +41,6 @@ export const ipcChannels = {
 } as const;
 
 export type PreferencePatch = Partial<{
-  selectedTab: MenuTab;
   collapsedAppSectionIDs: string[];
   collapsedHomebrewSectionIDs: string[];
   autoRefreshEnabled: boolean;


### PR DESCRIPTION
## Summary

- Make search universal across Apps, Homebrew, Installed, Ignored, and Discovery.
- Use the expanded search box as the active search state, so a saved query does not keep overriding tab content after search is dismissed.
- Close active search when the user selects a sidebar tab or Settings, while preserving the query for the next search.
- Open the main window on All after a full quit and relaunch.

## Validation
- `npm test -- --run ElectronTests/persistence.test.ts ElectronTests/rendererButtons.test.tsx`
- `npm run typecheck`
- `npm run lint`
