### PR TITLE
Accept versioned unreleased changelog heading

### DIFF
--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -22,8 +22,8 @@ fi
 
 cd "$ROOT_DIR"
 
-if ! grep -q "## Unreleased" CHANGELOG.md; then
-  echo "CHANGELOG.md must contain an Unreleased section before preparing a release."
+if ! awk '/^## / && $0 ~ /Unreleased$/ { found = 1 } END { exit found ? 0 : 1 }' CHANGELOG.md; then
+  echo "CHANGELOG.md must contain an Unreleased section heading before preparing a release."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- allow release preparation to detect versioned Unreleased changelog headings such as `## 0.1.0 — Unreleased`
- keep the current changelog format intact

## Validation
- bash -n scripts/prepare-unsigned-release.sh
- guard accepts `## Unreleased` and `## 0.1.0 — Unreleased`
- guard rejects released headings