### PR TITLE
Tighten unreleased changelog heading guard

### DIFF
--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -22,7 +22,7 @@ fi
 
 cd "$ROOT_DIR"
 
-if ! awk '/^## / && $0 ~ /Unreleased$/ { found = 1 } END { exit found ? 0 : 1 }' CHANGELOG.md; then
+if ! grep -Eq '^## (Unreleased|[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)? — Unreleased)$' CHANGELOG.md; then
   echo "CHANGELOG.md must contain an Unreleased section heading before preparing a release."
   exit 1
 fi


### PR DESCRIPTION
## Summary

- restrict release preparation to exact Unreleased heading formats
- accept `## Unreleased` and semver versioned headings like `## 0.1.0 — Unreleased`
- reject malformed headings such as `## Previously Unreleased`

## Validation
- `bash -n scripts/prepare-unsigned-release.sh`
- heading guard accepts plain, versioned, and prerelease Unreleased headings
- heading guard rejects malformed and released headings
