### PR TITLE
Refresh license badge cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img alt="Project status: Beta" src="https://img.shields.io/badge/status-beta-blue?style=for-the-badge" />
   <img alt="Minimum macOS version" src="https://img.shields.io/badge/macOS-13.0%2B-000000?style=for-the-badge&logo=apple" />
   <a href="https://github.com/arshiaghaf/baseline/blob/main/LICENSE">
-    <img alt="GPL-3.0-only license" src="https://img.shields.io/github/license/arshiaghaf/baseline?style=for-the-badge&logo=github" />
+    <img alt="GPL-3.0-only license" src="https://img.shields.io/github/license/arshiaghaf/baseline?style=for-the-badge&logo=github&cacheSeconds=3600" />
   </a>
 </p>
 


### PR DESCRIPTION
## Summary

- keeps the project license metadata as GPL-3.0-only
- refreshes the auto-detected Shields license badge URL with an explicit cacheSeconds parameter

## Validation
- Not run; documentation-only change.
