### PR TITLE
Use graceful Electron smoke test shutdown

### DIFF
--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -61,9 +61,12 @@ async function launchBaseline(options: { packaged?: boolean; userData?: string }
 }
 
 async function closeApp(app: Awaited<ReturnType<typeof electron.launch>>) {
-  await app.evaluate(async ({ app }) => {
-    app.exit(0);
-  });
+  await Promise.all([
+    app.waitForEvent("close"),
+    app.evaluate(async ({ app }) => {
+      app.quit();
+    })
+  ]);
 }
 
 test("launches the Electron shell and renders the dashboard", async () => {


### PR DESCRIPTION
## Summary
- replace forced Electron smoke test shutdown with app.quit()
- wait for Playwright's Electron application close event before relaunching

## Validation
- npm run test:electron
- npm run typecheck
