### PR TITLE
Restore retry state after Homebrew update failures

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1246,7 +1246,10 @@ describe("update store helpers", () => {
           })
         }
       },
-      runBrewCommand: async () => ({ success: false, status: 1, output: "Error: update failed" })
+      runBrewCommand: async (_args, onOutputLine = () => undefined) => {
+        onOutputLine("Pouring retryable--1.1.0.arm64_tahoe.bottle.tar.gz");
+        return { success: false, status: 1, output: "Error: update failed" };
+      }
     });
 
     vi.useFakeTimers();
@@ -1260,6 +1263,7 @@ describe("update store helpers", () => {
 
       vi.advanceTimersByTime(1);
       expect(store.getSnapshot().homebrewBatchFailedItemIDs).not.toContain(itemID);
+      expect(store.getSnapshot().homebrewBatchProgressByItemID[itemID]).toBeUndefined();
       expect(store.getSnapshot().homebrewItems.find((item) => item.id === itemID)?.isOutdated).toBe(
         true
       );
@@ -1316,7 +1320,10 @@ describe("update store helpers", () => {
           })
         }
       },
-      runBrewCommand: async () => ({ success: false, status: 1, output: "Error: update failed" })
+      runBrewCommand: async (_args, onOutputLine = () => undefined) => {
+        onOutputLine("Downloading homebrew-fallback");
+        return { success: false, status: 1, output: "Error: update failed" };
+      }
     });
 
     vi.useFakeTimers();
@@ -1327,6 +1334,7 @@ describe("update store helpers", () => {
 
       vi.advanceTimersByTime(4000);
       expect(store.getSnapshot().homebrewFallbackFailedAppIDs).not.toContain(app.id);
+      expect(store.getSnapshot().homebrewFallbackProgressByAppID[app.id]).toBeUndefined();
       expect(store.getSnapshot().updates.find((update) => update.appID === app.id)).toBeDefined();
     } finally {
       vi.useRealTimers();

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1209,6 +1209,129 @@ describe("update store helpers", () => {
     expect(snapshot.homebrewBatchFailedItemIDs).not.toContain(itemID);
     expect(snapshot.refreshErrorMessage).toBeUndefined();
   });
+
+  it("returns failed Homebrew item updates to retryable state after a short delay", async () => {
+    const itemID = "formula:retryable";
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: itemID,
+            token: "retryable",
+            name: "retryable",
+            kind: "formula",
+            installedVersion: version("1.0.0"),
+            latestVersion: version("1.1.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: itemID,
+                token: "retryable",
+                name: "retryable",
+                kind: "formula",
+                installedVersion: version("1.0.0"),
+                latestVersion: version("1.1.0"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
+      runBrewCommand: async () => ({ success: false, status: 1, output: "Error: update failed" })
+    });
+
+    vi.useFakeTimers();
+    try {
+      await store.performHomebrewUpdate(itemID);
+
+      expect(store.getSnapshot().homebrewBatchFailedItemIDs).toContain(itemID);
+
+      vi.advanceTimersByTime(3999);
+      expect(store.getSnapshot().homebrewBatchFailedItemIDs).toContain(itemID);
+
+      vi.advanceTimersByTime(1);
+      expect(store.getSnapshot().homebrewBatchFailedItemIDs).not.toContain(itemID);
+      expect(store.getSnapshot().homebrewItems.find((item) => item.id === itemID)?.isOutdated).toBe(
+        true
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns failed Homebrew app fallback updates to retryable state after a short delay", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Homebrew Fallback.app",
+      displayName: "Homebrew Fallback",
+      bundleIdentifier: "com.example.homebrew-fallback",
+      localVersion: version("1.0.0")
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "homebrew",
+            supportLevel: "limited",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            homebrewToken: "homebrew-fallback",
+            checkedAt: "2026-05-20T12:00:00.000Z"
+          }
+        ]
+      },
+      clients: {
+        scanner: { scanApplications: async () => [app] },
+        appStore: { lookupOutcome: async () => ({ type: "completed" }) },
+        sparkle: { lookupOutcome: async () => ({ type: "completed" }) },
+        homebrew: {
+          fetchIndex: async () => emptyHomebrewCaskIndex,
+          lookupUpdate: () => ({
+            remoteVersion: version("2.0.0"),
+            token: "homebrew-fallback"
+          }),
+          searchCasks: () => []
+        },
+        homebrewFormula: {
+          fetchIndex: async () => emptyHomebrewFormulaIndex,
+          searchFormulae: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
+      runBrewCommand: async () => ({ success: false, status: 1, output: "Error: update failed" })
+    });
+
+    vi.useFakeTimers();
+    try {
+      await store.performAppUpdate(app.id);
+
+      expect(store.getSnapshot().homebrewFallbackFailedAppIDs).toContain(app.id);
+
+      vi.advanceTimersByTime(4000);
+      expect(store.getSnapshot().homebrewFallbackFailedAppIDs).not.toContain(app.id);
+      expect(store.getSnapshot().updates.find((update) => update.appID === app.id)).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 async function makeStore({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -51,6 +51,8 @@ type StoreEvents = {
   homebrewCommand: [HomebrewMaintenanceRunEvent];
 };
 
+const TRANSIENT_HOMEBREW_FAILURE_MS = 4000;
+
 export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly persistence: SnapshotPersistence;
   private readonly scanner: Pick<BundleScannerClient, "scanApplications">;
@@ -68,6 +70,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly openAppBundle: (bundlePath: string) => Promise<void>;
   private refreshTask?: Promise<void>;
   private autoRefreshTimer?: NodeJS.Timeout;
+  private readonly homebrewBatchFailureClearTimers = new Map<string, NodeJS.Timeout>();
+  private readonly homebrewFallbackFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
 
@@ -310,6 +314,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     const command =
       item.kind === "cask" ? ["upgrade", "--cask", item.token] : ["upgrade", item.token];
     await this.withHomebrewUpdating(itemID, async () => {
+      this.clearHomebrewBatchFailureTimer(itemID);
+      this.patch({
+        homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID)
+      });
       const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
       const result = await this.runBrewWithEvents(command, (event) => {
         this.applyHomebrewProgressEvent(
@@ -343,6 +351,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             [itemID]: 1
           }
         });
+        this.scheduleHomebrewBatchFailureClear([itemID]);
       }
       await this.refresh();
     });
@@ -376,8 +385,14 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           affectedIDs.map((id) => [id, HomebrewMaintenanceProgressStage.queued])
         )
       },
+      homebrewBatchFailedItemIDs: this.state.homebrewBatchFailedItemIDs.filter(
+        (id) => !affectedIDs.includes(id)
+      ),
       refreshErrorMessage: undefined
     });
+    for (const id of affectedIDs) {
+      this.clearHomebrewBatchFailureTimer(id);
+    }
 
     const parser = new HomebrewMaintenanceOutputParser(
       affected.map((item) => item.token.toLowerCase())
@@ -407,12 +422,22 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       ),
       homebrewBatchFailedItemIDs: success
         ? this.state.homebrewBatchFailedItemIDs.filter((id) => !affectedIDs.includes(id))
-        : this.state.homebrewBatchFailedItemIDs,
+        : [
+            ...new Set([
+              ...this.state.homebrewBatchFailedItemIDs,
+              ...affectedIDs.filter(
+                (id) => !this.state.homebrewUpdatedPendingRefreshItemIDs.includes(id)
+              )
+            ])
+          ],
       homebrewUpdatedPendingRefreshItemIDs: success
         ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...affectedIDs])]
         : this.state.homebrewUpdatedPendingRefreshItemIDs,
       refreshErrorMessage: success ? undefined : "Homebrew maintenance cycle failed."
     });
+    if (!success) {
+      this.scheduleHomebrewBatchFailureClear(affectedIDs);
+    }
     await this.refresh();
   }
 
@@ -683,6 +708,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return;
     }
     await this.withAppUpdating(appRecord.id, async () => {
+      this.clearHomebrewFallbackFailureTimer(appRecord.id);
+      this.patch({
+        homebrewFallbackFailedAppIDs: removeFromArray(
+          this.state.homebrewFallbackFailedAppIDs,
+          appRecord.id
+        )
+      });
       const parser = new HomebrewMaintenanceOutputParser([token.toLowerCase()]);
       const success = await this.runBrewWithEvents(["upgrade", "--cask", token], (event) => {
         this.applyHomebrewFallbackEvent(event, parser, appRecord.id, token.toLowerCase());
@@ -698,6 +730,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           ? undefined
           : `Homebrew update failed for ${appRecord.displayName}.`
       });
+      if (!success) {
+        this.scheduleHomebrewFallbackFailureClear([appRecord.id]);
+      }
       await this.refresh();
     });
   }
@@ -892,6 +927,59 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({
         homebrewUpdatingItemIDs: removeFromArray(this.state.homebrewUpdatingItemIDs, itemID)
       });
+    }
+  }
+
+  private scheduleHomebrewBatchFailureClear(itemIDs: string[]): void {
+    for (const itemID of itemIDs) {
+      this.clearHomebrewBatchFailureTimer(itemID);
+      const timer = setTimeout(() => {
+        this.homebrewBatchFailureClearTimers.delete(itemID);
+        if (!this.state.homebrewBatchFailedItemIDs.includes(itemID)) {
+          return;
+        }
+        this.patch({
+          homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID)
+        });
+      }, TRANSIENT_HOMEBREW_FAILURE_MS);
+      timer.unref?.();
+      this.homebrewBatchFailureClearTimers.set(itemID, timer);
+    }
+  }
+
+  private scheduleHomebrewFallbackFailureClear(appIDs: string[]): void {
+    for (const appID of appIDs) {
+      this.clearHomebrewFallbackFailureTimer(appID);
+      const timer = setTimeout(() => {
+        this.homebrewFallbackFailureClearTimers.delete(appID);
+        if (!this.state.homebrewFallbackFailedAppIDs.includes(appID)) {
+          return;
+        }
+        this.patch({
+          homebrewFallbackFailedAppIDs: removeFromArray(
+            this.state.homebrewFallbackFailedAppIDs,
+            appID
+          )
+        });
+      }, TRANSIENT_HOMEBREW_FAILURE_MS);
+      timer.unref?.();
+      this.homebrewFallbackFailureClearTimers.set(appID, timer);
+    }
+  }
+
+  private clearHomebrewBatchFailureTimer(itemID: string): void {
+    const timer = this.homebrewBatchFailureClearTimers.get(itemID);
+    if (timer) {
+      clearTimeout(timer);
+      this.homebrewBatchFailureClearTimers.delete(itemID);
+    }
+  }
+
+  private clearHomebrewFallbackFailureTimer(appID: string): void {
+    const timer = this.homebrewFallbackFailureClearTimers.get(appID);
+    if (timer) {
+      clearTimeout(timer);
+      this.homebrewFallbackFailureClearTimers.delete(appID);
     }
   }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -939,7 +939,11 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           return;
         }
         this.patch({
-          homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID)
+          homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID),
+          homebrewBatchProgressByItemID: removeRecordKey(
+            this.state.homebrewBatchProgressByItemID,
+            itemID
+          )
         });
       }, TRANSIENT_HOMEBREW_FAILURE_MS);
       timer.unref?.();
@@ -958,6 +962,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         this.patch({
           homebrewFallbackFailedAppIDs: removeFromArray(
             this.state.homebrewFallbackFailedAppIDs,
+            appID
+          ),
+          homebrewFallbackProgressByAppID: removeRecordKey(
+            this.state.homebrewFallbackProgressByAppID,
             appID
           )
         });
@@ -1042,6 +1050,12 @@ function addToArray<T>(values: T[], value: T): T[] {
 
 function removeFromArray<T>(values: T[], value: T): T[] {
   return values.filter((candidate) => candidate !== value);
+}
+
+function removeRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  const next = { ...record };
+  delete next[key];
+  return next;
 }
 
 export function preservePreviousHomebrewOutdatedState(


### PR DESCRIPTION
## Summary

- make failed Homebrew update indicators transient so rows return to a retryable Update state
- clear stale Homebrew failure markers immediately when a retry starts
- add store regressions for direct Homebrew item updates and Homebrew-backed app fallback updates

## Validation
- npm test -- --run ElectronTests/updateStore.test.ts ElectronTests/rendererButtons.test.tsx
- npm run typecheck
- npm run lint
