### PR TITLE
Add build number metadata

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -87,6 +87,13 @@ function snapshot(patch: Partial<BaselineSnapshot> = {}): BaselineSnapshot {
 function installBaselineMock() {
   window.baseline = {
     getSnapshot: vi.fn(),
+    getAppMetadata: vi.fn(() =>
+      Promise.resolve({
+        version: "0.1.0",
+        buildNumber: "224",
+        displayVersion: "0.1.0 (224)"
+      })
+    ),
     getDiagnostics: vi.fn(),
     getToolStatus: vi.fn(),
     refreshToolStatus: vi.fn(),
@@ -1751,6 +1758,14 @@ describe("renderer button parity", () => {
 
     expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);
     expect(window.baseline.refresh).not.toHaveBeenCalled();
+  });
+
+  it("shows app version and build number in settings", async () => {
+    render(<SettingsView snapshot={snapshot()} />);
+
+    expect(await screen.findByText("0.1.0 (224)")).toBeInTheDocument();
+    expect(screen.getByText("Build")).toBeInTheDocument();
+    expect(screen.getByText("224")).toBeInTheDocument();
   });
 
   it("updates the appearance preference from settings", () => {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -33,13 +33,15 @@ git tag v0.1.0
 git push baseline v0.1.0
 ```
 
-8. The GitHub Actions release workflow builds the Electron unsigned DMG, writes `dist/Baseline-0.1.0-unsigned.dmg.sha256`, creates the GitHub Release, and uploads both files.
+8. The GitHub Actions release workflow builds the Electron unsigned DMG with the GitHub run number as the macOS build number, writes `dist/Baseline-0.1.0-unsigned.dmg.sha256`, creates the GitHub Release, and uploads both files.
 9. Verify the GitHub Release contains:
    - `Baseline-0.1.0-unsigned.dmg`
    - `Baseline-0.1.0-unsigned.dmg.sha256`
    - release notes that clearly label the artifact as unsigned.
 
 The release workflow accepts tags like `v0.1.0` and `v0.1.0-beta.1`.
+
+The user-facing app version maps to `CFBundleShortVersionString`. The build number in parentheses maps to `CFBundleVersion` and should be a monotonically increasing numeric value supplied by CI through `GITHUB_RUN_NUMBER` or overridden explicitly with `BASELINE_BUILD_NUMBER` for local artifact builds.
 
 ## Future Signed Release Path
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,7 +7,7 @@ Unsigned DMGs are not notarized by Apple. macOS Gatekeeper may warn users before
 ## First Release Checklist
 
 1. Choose a version, for example `0.1.0`.
-2. Update `CHANGELOG.md`.
+2. Update `package.json` and `package-lock.json` to the release version, then update `CHANGELOG.md`.
 3. Run local validation:
 
 ```bash
@@ -41,7 +41,7 @@ git push baseline v0.1.0
 
 The release workflow accepts tags like `v0.1.0` and `v0.1.0-beta.1`.
 
-The user-facing app version maps to `CFBundleShortVersionString`. The build number in parentheses maps to `CFBundleVersion` and should be a monotonically increasing numeric value supplied by CI through `GITHUB_RUN_NUMBER` or overridden explicitly with `BASELINE_BUILD_NUMBER` for local artifact builds.
+The user-facing app version maps to `CFBundleShortVersionString` and is sourced from `package.json`. Release artifact preparation fails if the requested release version does not match `package.json`. The build number in parentheses maps to `CFBundleVersion` and should be a monotonically increasing numeric value supplied by CI through `GITHUB_RUN_NUMBER` or overridden explicitly with `BASELINE_BUILD_NUMBER` for local artifact builds.
 
 ## Future Signed Release Path
 

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 const expectedBaselineAPI = [
   "chooseDirectory",
   "copyDiagnostics",
+  "getAppMetadata",
   "getDiagnostics",
   "getSnapshot",
   "getToolStatus",

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -6,6 +6,9 @@ import { MakerDMG } from "@electron-forge/maker-dmg";
 import { MakerZIP } from "@electron-forge/maker-zip";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { execFileSync } from "node:child_process";
+import packageJSON from "./package.json";
+
+const buildNumberPattern = /^[0-9][0-9.]*$/u;
 
 function macOSMajorVersion(): number | undefined {
   if (process.platform !== "darwin") {
@@ -26,11 +29,14 @@ function macOSMajorVersion(): number | undefined {
 
 const appIcon =
   (macOSMajorVersion() ?? 26) >= 26 ? "assets/app-icon" : "assets/app-icon-legacy.icns";
+const buildNumber = releaseBuildNumber();
 
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Baseline",
     executableName: "Baseline",
+    appVersion: packageJSON.version,
+    buildVersion: buildNumber,
     icon: appIcon,
     appBundleId: "com.arshiaghaf.baseline",
     appCategoryType: "public.app-category.utilities",
@@ -73,3 +79,29 @@ const config: ForgeConfig = {
 };
 
 export default config;
+
+function releaseBuildNumber(): string {
+  return (
+    validBuildNumber(process.env.BASELINE_BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER) ??
+    gitCommitCount() ??
+    "1"
+  );
+}
+
+function gitCommitCount(): string | undefined {
+  try {
+    return validBuildNumber(
+      execFileSync("/usr/bin/git", ["rev-list", "--count", "HEAD"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      }).trim()
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function validBuildNumber(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && buildNumberPattern.test(trimmed) ? trimmed : undefined;
+}

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -22,6 +22,24 @@ fi
 
 cd "$ROOT_DIR"
 
+command -v node >/dev/null 2>&1 || {
+  echo "node is required."
+  exit 1
+}
+
+PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+PACKAGE_LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
+
+if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
+  echo "package.json version ($PACKAGE_VERSION) must match release version ($VERSION)."
+  exit 1
+fi
+
+if [[ "$PACKAGE_LOCK_VERSION" != "$VERSION" ]]; then
+  echo "package-lock.json version ($PACKAGE_LOCK_VERSION) must match release version ($VERSION)."
+  exit 1
+fi
+
 if ! grep -Eq '^## (Unreleased|[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)? — Unreleased)$' CHANGELOG.md; then
   echo "CHANGELOG.md must contain an Unreleased section heading before preparing a release."
   exit 1

--- a/src/main/appMetadata.ts
+++ b/src/main/appMetadata.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import type { App } from "electron";
+import { formatAppDisplayVersion, type AppMetadata } from "../shared/appMetadata";
+
+const buildNumberPattern = /^[0-9][0-9.]*$/u;
+
+export function appMetadata(app: App): AppMetadata {
+  const version = app.getVersion();
+  const buildNumber =
+    buildNumberFromEnvironment() ?? (app.isPackaged ? buildNumberFromBundle() : localBuildNumber());
+
+  return {
+    version,
+    buildNumber,
+    displayVersion: formatAppDisplayVersion(version, buildNumber)
+  };
+}
+
+function buildNumberFromEnvironment(): string | undefined {
+  return validBuildNumber(process.env.BASELINE_BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER);
+}
+
+function buildNumberFromBundle(): string | undefined {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+
+  const infoPlistPath = path.join(process.resourcesPath, "..", "Info.plist");
+  return runBuildNumberCommand("/usr/bin/plutil", [
+    "-extract",
+    "CFBundleVersion",
+    "raw",
+    "-o",
+    "-",
+    infoPlistPath
+  ]);
+}
+
+function localBuildNumber(): string | undefined {
+  return runBuildNumberCommand("/usr/bin/git", ["rev-list", "--count", "HEAD"], process.cwd());
+}
+
+function runBuildNumberCommand(command: string, args: string[], cwd?: string): string | undefined {
+  try {
+    return validBuildNumber(
+      execFileSync(command, args, {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      }).trim()
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function validBuildNumber(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && buildNumberPattern.test(trimmed) ? trimmed : undefined;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import {
   Tray
 } from "electron";
 import path from "node:path";
+import { appMetadata } from "./appMetadata";
 import { renderDiagnostics } from "../shared/diagnostics";
 import type {
   AppearancePreference,
@@ -38,6 +39,7 @@ let trayBaseIcon: Electron.NativeImage | undefined;
 let trayRefreshIcon: Electron.NativeImage | undefined;
 let store: UpdateStore;
 let isQuitting = false;
+let metadata: ReturnType<typeof appMetadata>;
 
 const trayRefreshIconDataURL =
   "data:image/png;base64," +
@@ -63,7 +65,10 @@ if (!hasSingleInstanceLock) {
 
 if (hasSingleInstanceLock) {
   void app.whenReady().then(async () => {
+    metadata = appMetadata(app);
     app.setAboutPanelOptions({
+      applicationVersion: metadata.version,
+      version: metadata.buildNumber,
       copyright: "© 2026 Arshia Ghaffarian"
     });
 
@@ -336,8 +341,9 @@ function trayUpdateTitle(snapshot: BaselineSnapshot): string {
 
 function wireIpc(): void {
   ipcMain.handle(ipcChannels.getSnapshot, () => store.getSnapshot());
+  ipcMain.handle(ipcChannels.getAppMetadata, () => metadata);
   ipcMain.handle(ipcChannels.getDiagnostics, () =>
-    renderDiagnostics(store.getSnapshot(), app.getVersion(), process.platform)
+    renderDiagnostics(store.getSnapshot(), metadata, process.platform)
   );
   ipcMain.handle(ipcChannels.getToolStatus, () => {
     const snapshot = store.getSnapshot();
@@ -399,7 +405,7 @@ function wireIpc(): void {
     store.removeDirectory(String(directory))
   );
   ipcMain.handle(ipcChannels.copyDiagnostics, () => {
-    clipboard.writeText(renderDiagnostics(store.getSnapshot(), app.getVersion(), process.platform));
+    clipboard.writeText(renderDiagnostics(store.getSnapshot(), metadata, process.platform));
   });
   ipcMain.handle(ipcChannels.showMainWindow, () => showMainWindow("main"));
   ipcMain.handle(ipcChannels.showSettings, () => showMainWindow("settings"));

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -8,6 +8,7 @@ import type { HomebrewMaintenanceRunEvent } from "../shared/homebrewProgress";
 
 const api: BaselineAPI = {
   getSnapshot: () => ipcRenderer.invoke(ipcChannels.getSnapshot),
+  getAppMetadata: () => ipcRenderer.invoke(ipcChannels.getAppMetadata),
   getDiagnostics: () => ipcRenderer.invoke(ipcChannels.getDiagnostics),
   getToolStatus: () => ipcRenderer.invoke(ipcChannels.getToolStatus),
   refreshToolStatus: () => ipcRenderer.invoke(ipcChannels.refreshToolStatus),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -29,6 +29,7 @@ import {
   X,
   XCircle
 } from "lucide-react";
+import type { AppMetadata } from "../shared/appMetadata";
 import type {
   AppRecord,
   AppearancePreference,
@@ -2361,7 +2362,12 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
 
 export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
   const [diagnosticsCopied, setDiagnosticsCopied] = useState(false);
+  const [appMetadata, setAppMetadata] = useState<AppMetadata>();
   const derived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
+
+  useEffect(() => {
+    void window.baseline.getAppMetadata().then(setAppMetadata);
+  }, []);
 
   return (
     <main className="app-shell">
@@ -2381,6 +2387,22 @@ export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
         </header>
 
         <section className="settings-grid">
+          <section className="panel">
+            <PanelTitle title="About" />
+            <div className="metadata-list">
+              <div>
+                <span>Version</span>
+                <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
+              </div>
+              {appMetadata?.buildNumber && (
+                <div>
+                  <span>Build</span>
+                  <strong>{appMetadata.buildNumber}</strong>
+                </div>
+              )}
+            </div>
+          </section>
+
           <section className="panel">
             <PanelTitle title="Readiness" />
             <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -759,6 +759,34 @@ button:disabled {
   padding: 14px 12px;
 }
 
+.metadata-list {
+  display: grid;
+  gap: 10px;
+}
+
+.metadata-list div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-width: 0;
+}
+
+.metadata-list span {
+  color: rgba(60, 60, 67, 0.5);
+  font-size: 12px;
+  font-weight: 300;
+}
+
+.metadata-list strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #1c1c1e;
+  font-size: 12px;
+  font-weight: 500;
+  text-align: right;
+}
+
 .version-token {
   letter-spacing: 0.05em;
 }

--- a/src/shared/appMetadata.ts
+++ b/src/shared/appMetadata.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+export type AppMetadata = {
+  version: string;
+  buildNumber?: string;
+  displayVersion: string;
+};
+
+export function formatAppDisplayVersion(version: string, buildNumber?: string): string {
+  const safeVersion = version.trim() || "Unknown";
+  const safeBuildNumber = buildNumber?.trim();
+  return safeBuildNumber ? `${safeVersion} (${safeBuildNumber})` : safeVersion;
+}

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -3,10 +3,11 @@
 
 import type { BaselineSnapshot, UpdateSource } from "./domain";
 import { sourceDisplayName } from "./domain";
+import { formatAppDisplayVersion, type AppMetadata } from "./appMetadata";
 
 export function renderDiagnostics(
   snapshot: BaselineSnapshot,
-  appVersion = "Unknown",
+  appMetadata: Pick<AppMetadata, "version" | "buildNumber"> | string = "Unknown",
   platform = process.platform
 ): string {
   const updatesBySource = new Map<UpdateSource, number>();
@@ -27,7 +28,7 @@ export function renderDiagnostics(
     "Baseline Diagnostics",
     `Generated: ${new Date().toISOString()}`,
     `Platform: ${platform}`,
-    `App version: ${appVersion}`,
+    `App version: ${diagnosticsAppVersion(appMetadata)}`,
     "",
     "Refresh",
     `- Last refresh: ${snapshot.lastRefreshDate ?? "Never"}`,
@@ -67,6 +68,14 @@ export function renderDiagnostics(
   );
 
   return lines.join("\n");
+}
+
+function diagnosticsAppVersion(
+  appMetadata: Pick<AppMetadata, "version" | "buildNumber"> | string
+): string {
+  return typeof appMetadata === "string"
+    ? appMetadata
+    : formatAppDisplayVersion(appMetadata.version, appMetadata.buildNumber);
 }
 
 function yesNo(value: boolean): string {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,9 +10,11 @@ import type {
   ToolStatus
 } from "./domain";
 import type { HomebrewMaintenanceRunEvent } from "./homebrewProgress";
+import type { AppMetadata } from "./appMetadata";
 
 export const ipcChannels = {
   getSnapshot: "baseline:getSnapshot",
+  getAppMetadata: "baseline:getAppMetadata",
   getDiagnostics: "baseline:getDiagnostics",
   getToolStatus: "baseline:getToolStatus",
   refreshToolStatus: "baseline:refreshToolStatus",
@@ -52,6 +54,7 @@ export type PreferencePatch = Partial<{
 
 export type BaselineAPI = {
   getSnapshot(): Promise<BaselineSnapshot>;
+  getAppMetadata(): Promise<AppMetadata>;
   getDiagnostics(): Promise<string>;
   getToolStatus(): Promise<ToolStatus>;
   refreshToolStatus(): Promise<void>;
@@ -77,4 +80,10 @@ export type BaselineAPI = {
   onHomebrewCommandEvent(callback: (event: HomebrewMaintenanceRunEvent) => void): () => void;
 };
 
-export type { BaselineSnapshot, HomebrewCaskDiscoveryItem, HomebrewManagedItem, ToolStatus };
+export type {
+  AppMetadata,
+  BaselineSnapshot,
+  HomebrewCaskDiscoveryItem,
+  HomebrewManagedItem,
+  ToolStatus
+};


### PR DESCRIPTION
## Summary

- add shared app metadata for version/build display
- write macOS CFBundleVersion from CI or an explicit build-number override
- show version/build metadata in Settings, About, and diagnostics

## Validation
- npm run typecheck
- npm test
- npm run lint
- BASELINE_BUILD_NUMBER=224 npm run build
- npm run test:electron
