### PR TITLE
Overhaul settings navigation

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -435,10 +435,20 @@ describe("renderer button parity", () => {
     for (const label of ["General", "Appearance", "Diagnostics"]) {
       expect(within(container).getByRole("button", { name: label })).toBeInTheDocument();
     }
-    expect(screen.queryByRole("button", { name: "About" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Readiness" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Refresh" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Scan Directories" })).not.toBeInTheDocument();
+    const settingsNav = container.querySelector(".source-list");
+    expect(settingsNav).not.toBeNull();
+    expect(
+      within(settingsNav as HTMLElement).queryByRole("button", { name: "About" })
+    ).not.toBeInTheDocument();
+    expect(
+      within(settingsNav as HTMLElement).queryByRole("button", { name: "Readiness" })
+    ).not.toBeInTheDocument();
+    expect(
+      within(settingsNav as HTMLElement).queryByRole("button", { name: "Refresh" })
+    ).not.toBeInTheDocument();
+    expect(
+      within(settingsNav as HTMLElement).queryByRole("button", { name: "Scan Directories" })
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "All" })).not.toBeInTheDocument();
     expect(screen.queryByText("Stable App")).not.toBeInTheDocument();
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
@@ -1767,7 +1777,7 @@ describe("renderer button parity", () => {
   it("rechecks tool readiness from settings without running a refresh", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Check Again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 
     expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);
     expect(window.baseline.refresh).not.toHaveBeenCalled();
@@ -1801,7 +1811,10 @@ describe("renderer button parity", () => {
   it("updates the menu bar icon preference from settings", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
-    fireEvent.click(screen.getByLabelText("Show menu bar icon"));
+    const menuBarSwitch = screen.getByRole("switch", { name: "Show menu bar icon" });
+    expect(menuBarSwitch).toHaveAttribute("type", "checkbox");
+
+    fireEvent.click(menuBarSwitch);
 
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
       showMenuBarIcon: false

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -431,17 +431,14 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(within(container).getByRole("button", { name: "Back to App" })).toBeInTheDocument();
-    for (const label of [
-      "About",
-      "Readiness",
-      "Appearance",
-      "Refresh",
-      "Scan Directories",
-      "Diagnostics"
-    ]) {
+    expect(within(container).getByRole("button", { name: "Back to app" })).toBeInTheDocument();
+    for (const label of ["General", "Appearance", "Diagnostics"]) {
       expect(within(container).getByRole("button", { name: label })).toBeInTheDocument();
     }
+    expect(screen.queryByRole("button", { name: "About" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Readiness" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Refresh" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Scan Directories" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "All" })).not.toBeInTheDocument();
     expect(screen.queryByText("Stable App")).not.toBeInTheDocument();
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
@@ -450,7 +447,7 @@ describe("renderer button parity", () => {
   it("returns from settings to the main app route", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Back to App" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to app" }));
 
     expect(window.location.hash).toBe("#/main");
   });
@@ -1770,7 +1767,6 @@ describe("renderer button parity", () => {
   it("rechecks tool readiness from settings without running a refresh", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Readiness" }));
     fireEvent.click(screen.getByRole("button", { name: "Check Again" }));
 
     expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);
@@ -1780,6 +1776,7 @@ describe("renderer button parity", () => {
   it("shows app version and build number in settings", async () => {
     render(<SettingsView snapshot={snapshot()} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
     expect(await screen.findByText("0.1.0 (224)")).toBeInTheDocument();
     expect(screen.getByText("Build")).toBeInTheDocument();
     expect(screen.getByText("224")).toBeInTheDocument();
@@ -1804,7 +1801,6 @@ describe("renderer button parity", () => {
   it("updates the menu bar icon preference from settings", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     fireEvent.click(screen.getByLabelText("Show menu bar icon"));
 
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -438,6 +438,9 @@ describe("renderer button parity", () => {
     const settingsNav = container.querySelector(".source-list");
     expect(settingsNav).not.toBeNull();
     expect(
+      within(settingsNav as HTMLElement).queryByRole("button", { name: "Diagnostics" })
+    ).not.toBeInTheDocument();
+    expect(
       within(settingsNav as HTMLElement).queryByRole("button", { name: "About" })
     ).not.toBeInTheDocument();
     expect(
@@ -460,6 +463,15 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Back to app" }));
 
     expect(window.location.hash).toBe("#/main");
+  });
+
+  it("opens diagnostics from the settings sidebar footer", async () => {
+    render(<SettingsView snapshot={snapshot()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
+
+    expect(screen.getAllByRole("heading", { name: "Diagnostics" })).toHaveLength(2);
+    expect(await screen.findByText("0.1.0 (224)")).toBeInTheDocument();
   });
 
   it("uses the same short search placeholder on every tab", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1788,7 +1788,7 @@ describe("renderer button parity", () => {
   });
 
   it("rechecks tool readiness from settings without running a refresh", () => {
-    render(<SettingsView snapshot={snapshot()} />);
+    const { rerender } = render(<SettingsView snapshot={snapshot()} />);
 
     expect(screen.getByText("Enabled")).toBeInTheDocument();
     expect(screen.getByText("Not detected")).toBeInTheDocument();
@@ -1797,6 +1797,17 @@ describe("renderer button parity", () => {
         "Use the App Store helper when it is available. The mas helper is not detected on this Mac. Without mas, Baseline opens App Store links instead of installing App Store updates directly."
       )
     ).toBeInTheDocument();
+
+    rerender(
+      <SettingsView
+        snapshot={snapshot({
+          isMasInstalled: true,
+          useMasForAppStoreUpdates: false
+        })}
+      />
+    );
+    expect(screen.getByText("Not used")).toBeInTheDocument();
+    expect(screen.getByText("Use the App Store helper when it is available.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -472,7 +472,8 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
 
     expect(screen.getAllByRole("heading", { name: "Diagnostics" })).toHaveLength(2);
-    expect(await screen.findByText("0.1.0 (224)")).toBeInTheDocument();
+    expect(await screen.findByText("0.1.0")).toBeInTheDocument();
+    expect(screen.queryByText("0.1.0 (224)")).not.toBeInTheDocument();
   });
 
   it("uses the same short search placeholder on every tab", () => {
@@ -1864,16 +1865,11 @@ describe("renderer button parity", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
-    expect(screen.getByText("App version")).toBeInTheDocument();
-    expect(
-      screen.getByText("The Baseline release currently running on this Mac.")
-    ).toBeInTheDocument();
-    expect(await screen.findByText("0.1.0 (224)")).toBeInTheDocument();
-    expect(screen.getByText("Build number")).toBeInTheDocument();
-    expect(
-      screen.getByText("The internal build identifier for troubleshooting.")
-    ).toBeInTheDocument();
-    expect(screen.getByText("224")).toBeInTheDocument();
+    expect(screen.getByText("Current version")).toBeInTheDocument();
+    expect(await screen.findByText("0.1.0")).toBeInTheDocument();
+    expect(screen.queryByText("0.1.0 (224)")).not.toBeInTheDocument();
+    expect(screen.queryByText("Build number")).not.toBeInTheDocument();
+    expect(screen.queryByText("224")).not.toBeInTheDocument();
     expect(screen.getByText("Diagnostic report")).toBeInTheDocument();
   });
 

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1808,12 +1808,9 @@ describe("renderer button parity", () => {
     render(<SettingsView snapshot={snapshot({ appearancePreference: "light" })} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Appearance" }));
-    expect(screen.getByRole("button", { name: "Light Mode" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
+    expect(screen.getByRole("button", { name: "Light" })).toHaveAttribute("aria-pressed", "true");
 
-    fireEvent.click(screen.getByRole("button", { name: "Dark Mode" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dark" }));
 
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
       appearancePreference: "dark"

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1845,9 +1845,17 @@ describe("renderer button parity", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
+    expect(screen.getByText("App version")).toBeInTheDocument();
+    expect(
+      screen.getByText("The Baseline release currently running on this Mac.")
+    ).toBeInTheDocument();
     expect(await screen.findByText("0.1.0 (224)")).toBeInTheDocument();
-    expect(screen.getByText("Build")).toBeInTheDocument();
+    expect(screen.getByText("Build number")).toBeInTheDocument();
+    expect(
+      screen.getByText("The internal build identifier for troubleshooting.")
+    ).toBeInTheDocument();
     expect(screen.getByText("224")).toBeInTheDocument();
+    expect(screen.getByText("Diagnostic report")).toBeInTheDocument();
   });
 
   it("updates the appearance preference from settings", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -80,6 +80,7 @@ function snapshot(patch: Partial<BaselineSnapshot> = {}): BaselineSnapshot {
     homebrewDiscoverFailedItemIDs: [],
     homebrewDiscoverProgressByItemID: {},
     laggingHomebrewCaskTokens: [],
+    defaultScanDirectories: ["/Applications", "/Users/test/Applications"],
     ...patch
   };
 }
@@ -1795,6 +1796,51 @@ describe("renderer button parity", () => {
     expect(window.baseline.refresh).not.toHaveBeenCalled();
   });
 
+  it("edits refresh interval only when auto refresh is enabled", () => {
+    const { rerender } = render(
+      <SettingsView snapshot={snapshot({ autoRefreshEnabled: false })} />
+    );
+
+    const disabledInterval = screen.getByRole("textbox", { name: "Interval minutes" });
+    expect(disabledInterval).toHaveAttribute("type", "text");
+    expect(disabledInterval).toBeDisabled();
+
+    rerender(<SettingsView snapshot={snapshot({ autoRefreshEnabled: true })} />);
+
+    const enabledInterval = screen.getByRole("textbox", { name: "Interval minutes" });
+    fireEvent.change(enabledInterval, { target: { value: "30" } });
+
+    expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
+      refreshIntervalMinutes: 30
+    });
+  });
+
+  it("shows default scan directories when custom directories are present", () => {
+    const { rerender } = render(<SettingsView snapshot={snapshot()} />);
+
+    expect(screen.getByText("Default Applications folders")).toBeInTheDocument();
+    expect(
+      screen.getByText("Baseline scans the system and user Applications folders automatically.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("/Applications")).not.toBeInTheDocument();
+
+    rerender(
+      <SettingsView
+        snapshot={snapshot({
+          additionalDirectories: ["/Users/test/Extra Apps"]
+        })}
+      />
+    );
+
+    expect(screen.getByText("System Applications")).toBeInTheDocument();
+    expect(screen.getByText("User Applications")).toBeInTheDocument();
+    expect(screen.getByText("/Applications")).toBeInTheDocument();
+    expect(screen.getByText("/Users/test/Applications")).toBeInTheDocument();
+    expect(screen.getByText("Custom folder")).toBeInTheDocument();
+    expect(screen.getByText("/Users/test/Extra Apps")).toBeInTheDocument();
+    expect(screen.getAllByTitle("Remove")).toHaveLength(1);
+  });
+
   it("shows app version and build number in settings", async () => {
     render(<SettingsView snapshot={snapshot()} />);
 
@@ -1819,6 +1865,8 @@ describe("renderer button parity", () => {
 
   it("updates the menu bar icon preference from settings", () => {
     render(<SettingsView snapshot={snapshot()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Appearance" }));
 
     const menuBarSwitch = screen.getByRole("switch", { name: "Show menu bar icon" });
     expect(menuBarSwitch).toHaveAttribute("type", "checkbox");

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1790,6 +1790,14 @@ describe("renderer button parity", () => {
   it("rechecks tool readiness from settings without running a refresh", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    expect(screen.getByText("Not detected")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Use the App Store helper when it is available. The mas helper is not detected on this Mac. Without mas, Baseline opens App Store links instead of installing App Store updates directly."
+      )
+    ).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 
     expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -123,6 +123,7 @@ function installBaselineMock() {
 describe("renderer button parity", () => {
   beforeEach(() => {
     installBaselineMock();
+    window.location.hash = "";
   });
 
   it("shows app ignore/update actions and makes updating glyph non-clickable", () => {
@@ -404,7 +405,7 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
   });
 
-  it("keeps Settings sidebar badges fixed when a saved query is present", () => {
+  it("shows settings sections as sidebar tabs without search-filtered badges", () => {
     const installedApp: AppRecord = {
       ...app,
       id: "app:stable",
@@ -430,13 +431,28 @@ describe("renderer button parity", () => {
       />
     );
 
-    const [allButton, appsButton, homebrewButton] = Array.from(
-      container.querySelectorAll(".source-list button")
-    );
+    expect(within(container).getByRole("button", { name: "Back to App" })).toBeInTheDocument();
+    for (const label of [
+      "About",
+      "Readiness",
+      "Appearance",
+      "Refresh",
+      "Scan Directories",
+      "Diagnostics"
+    ]) {
+      expect(within(container).getByRole("button", { name: label })).toBeInTheDocument();
+    }
+    expect(screen.queryByRole("button", { name: "All" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Stable App")).not.toBeInTheDocument();
+    expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+  });
 
-    expect(within(allButton as HTMLElement).getByText("2")).toBeInTheDocument();
-    expect(within(appsButton as HTMLElement).getByText("1")).toBeInTheDocument();
-    expect(within(homebrewButton as HTMLElement).getByText("1")).toBeInTheDocument();
+  it("returns from settings to the main app route", () => {
+    render(<SettingsView snapshot={snapshot()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to App" }));
+
+    expect(window.location.hash).toBe("#/main");
   });
 
   it("uses the same short search placeholder on every tab", () => {
@@ -1754,6 +1770,7 @@ describe("renderer button parity", () => {
   it("rechecks tool readiness from settings without running a refresh", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Readiness" }));
     fireEvent.click(screen.getByRole("button", { name: "Check Again" }));
 
     expect(window.baseline.refreshToolStatus).toHaveBeenCalledTimes(1);
@@ -1771,6 +1788,7 @@ describe("renderer button parity", () => {
   it("updates the appearance preference from settings", () => {
     render(<SettingsView snapshot={snapshot({ appearancePreference: "light" })} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Appearance" }));
     expect(screen.getByRole("button", { name: "Light Mode" })).toHaveAttribute(
       "aria-pressed",
       "true"
@@ -1786,6 +1804,7 @@ describe("renderer button parity", () => {
   it("updates the menu bar icon preference from settings", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     fireEvent.click(screen.getByLabelText("Show menu bar icon"));
 
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -294,6 +294,36 @@ describe("update store helpers", () => {
     });
   });
 
+  it("scans default directories before additional directories", async () => {
+    const scannedDirectories: string[][] = [];
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        additionalDirectories: ["/Users/example/Extra Apps"]
+      },
+      clients: {
+        scanner: {
+          scanApplications: async (directories) => {
+            scannedDirectories.push(directories);
+            return [];
+          }
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().defaultScanDirectories).toEqual([
+      "/Applications",
+      path.join(os.homedir(), "Applications")
+    ]);
+    expect(scannedDirectories[0]).toEqual([
+      "/Applications",
+      path.join(os.homedir(), "Applications"),
+      "/Users/example/Extra Apps"
+    ]);
+  });
+
   it("passes Homebrew metadata update mode only for full refresh", async () => {
     const inventoryOptions: Array<{ updateMetadata?: boolean }> = [];
     const store = await makeStore({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -123,7 +123,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       homebrewDiscoverInstalledPendingRefreshItemIDs: [],
       homebrewDiscoverFailedItemIDs: [],
       homebrewDiscoverProgressByItemID: {},
-      laggingHomebrewCaskTokens: []
+      laggingHomebrewCaskTokens: [],
+      defaultScanDirectories: this.defaultScanDirectories()
     };
   }
 
@@ -659,13 +660,11 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   private scanDirectories(): string[] {
-    return [
-      ...new Set([
-        "/Applications",
-        path.join(os.homedir(), "Applications"),
-        ...this.state.additionalDirectories
-      ])
-    ];
+    return [...new Set([...this.defaultScanDirectories(), ...this.state.additionalDirectories])];
+  }
+
+  private defaultScanDirectories(): string[] {
+    return ["/Applications", path.join(os.homedir(), "Applications")];
   }
 
   private async routeExternalUpdate(appRecord: AppRecord, update: UpdateRecord): Promise<void> {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2573,7 +2573,10 @@ function SettingsPane({
             <PanelTitle title="Theme" />
             <div className="settings-panel-box">
               <div className="settings-row settings-row-action">
-                <p className="settings-row-subtext">Use light, dark, or match your system</p>
+                <SettingsRowText
+                  label="App theme"
+                  description="Use light, dark, or match your system."
+                />
                 <AppearanceSelector value={snapshot.appearancePreference} />
               </div>
             </div>
@@ -2597,28 +2600,34 @@ function SettingsPane({
           <section className="panel settings-panel">
             <PanelTitle title="About" />
             <div className="settings-panel-box">
-              <div className="settings-row settings-key-value-list">
-                <div>
-                  <span className="settings-row-subtext">Version</span>
-                  <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
-                </div>
-                {appMetadata?.buildNumber && (
-                  <div>
-                    <span className="settings-row-subtext">Build</span>
-                    <strong>{appMetadata.buildNumber}</strong>
-                  </div>
-                )}
+              <div className="settings-row settings-row-action">
+                <SettingsRowText
+                  label="App version"
+                  description="The Baseline release currently running on this Mac."
+                />
+                <strong className="settings-row-value">
+                  {appMetadata?.displayVersion ?? "Loading"}
+                </strong>
               </div>
+              {appMetadata?.buildNumber && (
+                <div className="settings-row settings-row-action">
+                  <SettingsRowText
+                    label="Build number"
+                    description="The internal build identifier for troubleshooting."
+                  />
+                  <strong className="settings-row-value">{appMetadata.buildNumber}</strong>
+                </div>
+              )}
             </div>
           </section>
           <section className="panel settings-panel">
             <PanelTitle title="Diagnostics" />
             <div className="settings-panel-box">
               <div className="settings-row settings-row-action">
-                <p className="settings-row-subtext">
-                  Copy a local report with counts, tool status, scan paths, and the latest
-                  non-sensitive refresh message.
-                </p>
+                <SettingsRowText
+                  label="Diagnostic report"
+                  description="Copy a local report with counts, tool status, scan paths, and the latest non-sensitive refresh message."
+                />
                 <button
                   className="primary-button wide"
                   onClick={() => {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2552,8 +2552,11 @@ function SettingsPane({
       );
     case "appearance":
       return (
-        <section className="panel settings-panel">
-          <PanelTitle title="Appearance" />
+        <section className="panel settings-panel theme-panel">
+          <div className="theme-panel-copy">
+            <PanelTitle title="Theme" />
+            <p className="muted theme-description">Use light, dark, or match your system</p>
+          </div>
           <AppearanceSelector value={snapshot.appearancePreference} />
         </section>
       );
@@ -2609,9 +2612,9 @@ const appearanceOptions: Array<{
   label: string;
   icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
 }> = [
-  { value: "system", label: "System Default", icon: Monitor },
-  { value: "light", label: "Light Mode", icon: Sun },
-  { value: "dark", label: "Dark Mode", icon: Moon }
+  { value: "system", label: "System", icon: Monitor },
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon }
 ];
 
 function AppearanceSelector({ value }: { value: AppearancePreference }) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -110,7 +110,8 @@ const initialSnapshot: BaselineSnapshot = {
   homebrewDiscoverInstalledPendingRefreshItemIDs: [],
   homebrewDiscoverFailedItemIDs: [],
   homebrewDiscoverProgressByItemID: {},
-  laggingHomebrewCaskTokens: []
+  laggingHomebrewCaskTokens: [],
+  defaultScanDirectories: []
 };
 
 function App() {
@@ -2472,7 +2473,7 @@ function SettingsPane({
         <>
           <section className="panel settings-panel">
             <PanelTitle
-              title="Readiness"
+              title="Update Tools"
               action={
                 <button
                   className="ghost-button small-button"
@@ -2493,6 +2494,12 @@ function SettingsPane({
                 description="Use the App Store helper when it is available."
                 ready={snapshot.isMasInstalled}
               />
+              <Toggle
+                label="Use mas for App Store updates"
+                description="Install App Store updates through mas before falling back to links."
+                value={snapshot.useMasForAppStoreUpdates}
+                patch="useMasForAppStoreUpdates"
+              />
             </div>
           </section>
           <section className="panel settings-panel">
@@ -2504,36 +2511,9 @@ function SettingsPane({
                 value={snapshot.autoRefreshEnabled}
                 patch="autoRefreshEnabled"
               />
-              <label className="settings-row settings-row-control">
-                <SettingsRowText
-                  label="Interval minutes"
-                  description="How often Baseline checks when auto refresh is on."
-                />
-                <input
-                  aria-label="Interval minutes"
-                  className="settings-number-input"
-                  type="number"
-                  min={5}
-                  max={1440}
-                  value={snapshot.refreshIntervalMinutes}
-                  onChange={(event) =>
-                    void window.baseline.updatePreferences({
-                      refreshIntervalMinutes: Number(event.currentTarget.value)
-                    })
-                  }
-                />
-              </label>
-              <Toggle
-                label="Use mas for App Store updates"
-                description="Install App Store updates through mas before falling back to links."
-                value={snapshot.useMasForAppStoreUpdates}
-                patch="useMasForAppStoreUpdates"
-              />
-              <Toggle
-                label="Show menu bar icon"
-                description="Keep the compact update popover available in the menu bar."
-                value={snapshot.showMenuBarIcon}
-                patch="showMenuBarIcon"
+              <RefreshIntervalInput
+                value={snapshot.refreshIntervalMinutes}
+                disabled={!snapshot.autoRefreshEnabled}
               />
             </div>
           </section>
@@ -2552,14 +2532,26 @@ function SettingsPane({
             />
             <div className="settings-panel-box">
               <div className="settings-row-list">
-                {snapshot.additionalDirectories.length === 0 && (
-                  <p className="settings-row settings-row-subtext settings-empty-row">
-                    Using default Applications folders.
-                  </p>
+                {snapshot.additionalDirectories.length === 0 ? (
+                  <div className="settings-row settings-empty-row">
+                    <SettingsRowText
+                      label="Default Applications folders"
+                      description="Baseline scans the system and user Applications folders automatically."
+                    />
+                  </div>
+                ) : (
+                  snapshot.defaultScanDirectories.map((directory) => (
+                    <div className="settings-row settings-row-action" key={`default:${directory}`}>
+                      <SettingsRowText
+                        label={defaultScanDirectoryLabel(directory)}
+                        description={directory}
+                      />
+                    </div>
+                  ))
                 )}
                 {snapshot.additionalDirectories.map((directory) => (
                   <div className="settings-row settings-row-action" key={directory}>
-                    <span>{directory}</span>
+                    <SettingsRowText label="Custom folder" description={directory} />
                     <button
                       className="toolbar-button"
                       onClick={() => void window.baseline.removeDirectory(directory)}
@@ -2576,15 +2568,28 @@ function SettingsPane({
       );
     case "appearance":
       return (
-        <section className="panel settings-panel">
-          <PanelTitle title="Theme" />
-          <div className="settings-panel-box">
-            <div className="settings-row settings-row-action">
-              <p className="settings-row-subtext">Use light, dark, or match your system</p>
-              <AppearanceSelector value={snapshot.appearancePreference} />
+        <>
+          <section className="panel settings-panel">
+            <PanelTitle title="Theme" />
+            <div className="settings-panel-box">
+              <div className="settings-row settings-row-action">
+                <p className="settings-row-subtext">Use light, dark, or match your system</p>
+                <AppearanceSelector value={snapshot.appearancePreference} />
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+          <section className="panel settings-panel">
+            <PanelTitle title="Menu Bar" />
+            <div className="settings-panel-box">
+              <Toggle
+                label="Show menu bar icon"
+                description="Keep the compact update popover available in the menu bar."
+                value={snapshot.showMenuBarIcon}
+                patch="showMenuBarIcon"
+              />
+            </div>
+          </section>
+        </>
       );
     case "diagnostics":
       return (
@@ -2669,6 +2674,57 @@ function AppearanceSelector({ value }: { value: AppearancePreference }) {
         );
       })}
     </div>
+  );
+}
+
+function defaultScanDirectoryLabel(directory: string): string {
+  if (directory === "/Applications") {
+    return "System Applications";
+  }
+  return "User Applications";
+}
+
+function RefreshIntervalInput({ value, disabled }: { value: number; disabled: boolean }) {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  return (
+    <label
+      className={
+        disabled
+          ? "settings-row settings-row-control settings-row-disabled"
+          : "settings-row settings-row-control"
+      }
+    >
+      <SettingsRowText
+        label="Interval minutes"
+        description="How often Baseline checks when auto refresh is on."
+      />
+      <input
+        aria-label="Interval minutes"
+        className="settings-number-input"
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        disabled={disabled}
+        value={draft}
+        onChange={(event) => {
+          const nextValue = event.currentTarget.value;
+          if (!/^\d*$/u.test(nextValue)) {
+            return;
+          }
+          setDraft(nextValue);
+          if (nextValue) {
+            void window.baseline.updatePreferences({
+              refreshIntervalMinutes: Number.parseInt(nextValue, 10)
+            });
+          }
+        }}
+      />
+    </label>
   );
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -84,6 +84,9 @@ const settingsSidebarItems: Array<{
   { id: "appearance", label: "Appearance", icon: Monitor },
   { id: "diagnostics", label: "Diagnostics", icon: Terminal }
 ];
+const primarySettingsSidebarItems = settingsSidebarItems.filter(
+  (item) => item.id !== "diagnostics"
+);
 
 const initialSnapshot: BaselineSnapshot = {
   ...defaultPersistedSnapshot(),
@@ -2423,7 +2426,7 @@ function SettingsSidebar({
         </button>
       </div>
       <nav className="source-list">
-        {settingsSidebarItems.map((item) => {
+        {primarySettingsSidebarItems.map((item) => {
           const Icon = item.icon;
           return (
             <button
@@ -2437,6 +2440,15 @@ function SettingsSidebar({
           );
         })}
       </nav>
+      <div className="sidebar-footer">
+        <button
+          className={selectedSection === "diagnostics" ? "selected" : ""}
+          onClick={() => onSelectSection("diagnostics")}
+        >
+          <Terminal size={16} strokeWidth={sidebarIconStrokeWidth} />
+          <span>Diagnostics</span>
+        </button>
+      </div>
     </aside>
   );
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2495,10 +2495,11 @@ function SettingsPane({
                 description="Use the App Store helper when it is available."
                 missingDetail="The mas helper is not detected on this Mac. Without mas, Baseline opens App Store links instead of installing App Store updates directly."
                 ready={snapshot.isMasInstalled}
+                enabled={snapshot.useMasForAppStoreUpdates}
               />
               <Toggle
                 label="Use mas for App Store updates"
-                description="Install App Store updates through mas before falling back to links."
+                description="When enabled, Baseline can install App Store updates directly. When disabled, it opens App Store links instead."
                 value={snapshot.useMasForAppStoreUpdates}
                 patch="useMasForAppStoreUpdates"
               />
@@ -2842,21 +2843,22 @@ function Readiness({
   label,
   description,
   missingDetail,
-  ready
+  ready,
+  enabled = true
 }: {
   label: string;
   description: string;
   missingDetail: string;
   ready: boolean;
+  enabled?: boolean;
 }) {
-  const statusLabel = ready ? "Enabled" : "Not detected";
+  const active = ready && enabled;
+  const statusLabel = ready ? (enabled ? "Enabled" : "Not used") : "Not detected";
+  const detail = ready ? description : `${description} ${missingDetail}`;
   return (
     <div className="settings-row settings-row-status">
-      <SettingsRowText
-        label={label}
-        description={ready ? description : `${description} ${missingDetail}`}
-      />
-      <span className={ready ? "settings-status-label enabled" : "settings-status-label muted"}>
+      <SettingsRowText label={label} description={detail} />
+      <span className={active ? "settings-status-label enabled" : "settings-status-label muted"}>
         <span className="settings-status-glyph" aria-hidden="true" />
         <span>{statusLabel}</span>
       </span>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import {
   AlertTriangle,
   AppWindowMac,
+  ArrowLeft,
   Beer,
   Check,
   CheckCircle2,
@@ -69,10 +70,29 @@ type RowUpdateMenuAction = {
   disabled?: boolean;
   onAction: () => void;
 };
+type SettingsSectionID =
+  | "about"
+  | "readiness"
+  | "appearance"
+  | "refresh"
+  | "scan-directories"
+  | "diagnostics";
 
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
 const toolbarIconStrokeWidth = 1.5;
+const settingsSidebarItems: Array<{
+  id: SettingsSectionID;
+  label: string;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+}> = [
+  { id: "about", label: "About", icon: AppWindowMac },
+  { id: "readiness", label: "Readiness", icon: CheckCircle2 },
+  { id: "appearance", label: "Appearance", icon: Monitor },
+  { id: "refresh", label: "Refresh", icon: RefreshCcw },
+  { id: "scan-directories", label: "Scan Directories", icon: FolderPlus },
+  { id: "diagnostics", label: "Diagnostics", icon: Terminal }
+];
 
 const initialSnapshot: BaselineSnapshot = {
   ...defaultPersistedSnapshot(),
@@ -2361,153 +2381,220 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
 }
 
 export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
+  const [selectedSection, setSelectedSection] = useState<SettingsSectionID>("about");
   const [diagnosticsCopied, setDiagnosticsCopied] = useState(false);
   const [appMetadata, setAppMetadata] = useState<AppMetadata>();
-  const derived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
+  const selectedItem = settingsSidebarItems.find((item) => item.id === selectedSection);
 
   useEffect(() => {
     void window.baseline.getAppMetadata().then(setAppMetadata);
   }, []);
 
   return (
-    <main className="app-shell">
-      <Sidebar snapshot={snapshot} derived={derived} route="settings" />
+    <main className="app-shell settings-shell">
+      <SettingsSidebar selectedSection={selectedSection} onSelectSection={setSelectedSection} />
       <section className="workspace">
         <header className="topbar">
           <div>
-            <h1>Settings</h1>
-            <p>Scan paths, optional tools, and refresh behavior</p>
+            <h1>{selectedItem?.label ?? "Settings"}</h1>
           </div>
-          <button
-            className="toolbar-button text-button"
-            onClick={() => (window.location.hash = "/main")}
-          >
-            Done
-          </button>
         </header>
 
-        <section className="settings-grid">
-          <section className="panel">
-            <PanelTitle title="About" />
-            <div className="metadata-list">
-              <div>
-                <span>Version</span>
-                <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
-              </div>
-              {appMetadata?.buildNumber && (
-                <div>
-                  <span>Build</span>
-                  <strong>{appMetadata.buildNumber}</strong>
-                </div>
-              )}
-            </div>
-          </section>
-
-          <section className="panel">
-            <PanelTitle title="Readiness" />
-            <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
-            <Readiness label="mas" ready={snapshot.isMasInstalled} />
-            <div className="settings-action">
-              <button
-                className="ghost-button wide"
-                onClick={() => void window.baseline.refreshToolStatus()}
-              >
-                Check Again
-              </button>
-            </div>
-          </section>
-
-          <section className="panel">
-            <PanelTitle title="Appearance" />
-            <AppearanceSelector value={snapshot.appearancePreference} />
-          </section>
-
-          <section className="panel">
-            <PanelTitle title="Refresh" />
-            <Toggle
-              label="Auto refresh"
-              value={snapshot.autoRefreshEnabled}
-              patch="autoRefreshEnabled"
+        <section className="content settings-content">
+          <section className="stack">
+            <SettingsPane
+              appMetadata={appMetadata}
+              diagnosticsCopied={diagnosticsCopied}
+              onDiagnosticsCopiedChange={setDiagnosticsCopied}
+              section={selectedSection}
+              snapshot={snapshot}
             />
-            <label className="field">
-              <span>Interval minutes</span>
-              <input
-                type="number"
-                min={5}
-                max={1440}
-                value={snapshot.refreshIntervalMinutes}
-                onChange={(event) =>
-                  void window.baseline.updatePreferences({
-                    refreshIntervalMinutes: Number(event.currentTarget.value)
-                  })
-                }
-              />
-            </label>
-            <Toggle
-              label="Use mas for App Store updates"
-              value={snapshot.useMasForAppStoreUpdates}
-              patch="useMasForAppStoreUpdates"
-            />
-            <Toggle
-              label="Show menu bar icon"
-              value={snapshot.showMenuBarIcon}
-              patch="showMenuBarIcon"
-            />
-          </section>
-
-          <section className="panel wide-panel">
-            <PanelTitle
-              title="Scan Directories"
-              action={
-                <button
-                  className="toolbar-button"
-                  onClick={() => void window.baseline.chooseDirectory()}
-                  title="Add directory"
-                >
-                  <FolderPlus size={15} />
-                </button>
-              }
-            />
-            <div className="directory-list">
-              {snapshot.additionalDirectories.length === 0 && (
-                <Empty text="Using default Applications folders." />
-              )}
-              {snapshot.additionalDirectories.map((directory) => (
-                <div className="directory-row" key={directory}>
-                  <span>{directory}</span>
-                  <button
-                    className="toolbar-button"
-                    onClick={() => void window.baseline.removeDirectory(directory)}
-                    title="Remove"
-                  >
-                    <XCircle size={15} />
-                  </button>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="panel">
-            <PanelTitle title="Diagnostics" />
-            <p className="muted panel-copy">
-              Copy a local report with counts, tool status, scan paths, and the latest non-sensitive
-              refresh message.
-            </p>
-            <div className="settings-action">
-              <button
-                className="primary-button wide"
-                onClick={() => {
-                  void window.baseline.copyDiagnostics().then(() => setDiagnosticsCopied(true));
-                }}
-              >
-                {diagnosticsCopied ? "Copied" : "Copy Report"}
-              </button>
-            </div>
           </section>
         </section>
       </section>
     </main>
   );
+}
+
+function SettingsSidebar({
+  selectedSection,
+  onSelectSection
+}: {
+  selectedSection: SettingsSectionID;
+  onSelectSection: (section: SettingsSectionID) => void;
+}) {
+  return (
+    <aside className="sidebar settings-sidebar">
+      <div className="settings-sidebar-header">
+        <button className="back-to-app-button" onClick={() => (window.location.hash = "/main")}>
+          <ArrowLeft size={15} strokeWidth={sidebarIconStrokeWidth} />
+          <span>Back to App</span>
+        </button>
+      </div>
+      <nav className="source-list">
+        {settingsSidebarItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <button
+              className={selectedSection === item.id ? "selected" : ""}
+              key={item.id}
+              onClick={() => onSelectSection(item.id)}
+            >
+              <Icon size={16} strokeWidth={sidebarIconStrokeWidth} />
+              <span>{item.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+function SettingsPane({
+  appMetadata,
+  diagnosticsCopied,
+  onDiagnosticsCopiedChange,
+  section,
+  snapshot
+}: {
+  appMetadata?: AppMetadata;
+  diagnosticsCopied: boolean;
+  onDiagnosticsCopiedChange: (copied: boolean) => void;
+  section: SettingsSectionID;
+  snapshot: BaselineSnapshot;
+}) {
+  switch (section) {
+    case "about":
+      return (
+        <section className="panel settings-panel">
+          <PanelTitle title="About" />
+          <div className="metadata-list">
+            <div>
+              <span>Version</span>
+              <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
+            </div>
+            {appMetadata?.buildNumber && (
+              <div>
+                <span>Build</span>
+                <strong>{appMetadata.buildNumber}</strong>
+              </div>
+            )}
+          </div>
+        </section>
+      );
+    case "readiness":
+      return (
+        <section className="panel settings-panel">
+          <PanelTitle title="Readiness" />
+          <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
+          <Readiness label="mas" ready={snapshot.isMasInstalled} />
+          <div className="settings-action">
+            <button
+              className="ghost-button wide"
+              onClick={() => void window.baseline.refreshToolStatus()}
+            >
+              Check Again
+            </button>
+          </div>
+        </section>
+      );
+    case "appearance":
+      return (
+        <section className="panel settings-panel">
+          <PanelTitle title="Appearance" />
+          <AppearanceSelector value={snapshot.appearancePreference} />
+        </section>
+      );
+    case "refresh":
+      return (
+        <section className="panel settings-panel">
+          <PanelTitle title="Refresh" />
+          <Toggle
+            label="Auto refresh"
+            value={snapshot.autoRefreshEnabled}
+            patch="autoRefreshEnabled"
+          />
+          <label className="field">
+            <span>Interval minutes</span>
+            <input
+              type="number"
+              min={5}
+              max={1440}
+              value={snapshot.refreshIntervalMinutes}
+              onChange={(event) =>
+                void window.baseline.updatePreferences({
+                  refreshIntervalMinutes: Number(event.currentTarget.value)
+                })
+              }
+            />
+          </label>
+          <Toggle
+            label="Use mas for App Store updates"
+            value={snapshot.useMasForAppStoreUpdates}
+            patch="useMasForAppStoreUpdates"
+          />
+          <Toggle
+            label="Show menu bar icon"
+            value={snapshot.showMenuBarIcon}
+            patch="showMenuBarIcon"
+          />
+        </section>
+      );
+    case "scan-directories":
+      return (
+        <section className="panel settings-panel">
+          <PanelTitle
+            title="Scan Directories"
+            action={
+              <button
+                className="toolbar-button"
+                onClick={() => void window.baseline.chooseDirectory()}
+                title="Add directory"
+              >
+                <FolderPlus size={15} />
+              </button>
+            }
+          />
+          <div className="directory-list">
+            {snapshot.additionalDirectories.length === 0 && (
+              <Empty text="Using default Applications folders." />
+            )}
+            {snapshot.additionalDirectories.map((directory) => (
+              <div className="directory-row" key={directory}>
+                <span>{directory}</span>
+                <button
+                  className="toolbar-button"
+                  onClick={() => void window.baseline.removeDirectory(directory)}
+                  title="Remove"
+                >
+                  <XCircle size={15} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      );
+    case "diagnostics":
+      return (
+        <section className="panel settings-panel">
+          <PanelTitle title="Diagnostics" />
+          <p className="muted panel-copy">
+            Copy a local report with counts, tool status, scan paths, and the latest non-sensitive
+            refresh message.
+          </p>
+          <div className="settings-action">
+            <button
+              className="primary-button wide"
+              onClick={() => {
+                void window.baseline.copyDiagnostics().then(() => onDiagnosticsCopiedChange(true));
+              }}
+            >
+              {diagnosticsCopied ? "Copied" : "Copy Report"}
+            </button>
+          </div>
+        </section>
+      );
+  }
 }
 
 type TogglePatch = Exclude<

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2487,11 +2487,13 @@ function SettingsPane({
               <Readiness
                 label="Homebrew"
                 description="Find updates for installed casks and formulae."
+                missingDetail="Homebrew is not detected on this Mac. Install Homebrew to enable this source."
                 ready={snapshot.isHomebrewInstalled}
               />
               <Readiness
                 label="mas"
                 description="Use the App Store helper when it is available."
+                missingDetail="The mas helper is not detected on this Mac. Without mas, Baseline opens App Store links instead of installing App Store updates directly."
                 ready={snapshot.isMasInstalled}
               />
               <Toggle
@@ -2765,11 +2767,20 @@ function Toggle({
   );
 }
 
-function SettingsRowText({ label, description }: { label: string; description: string }) {
+function SettingsRowText({
+  label,
+  description,
+  secondaryDescription
+}: {
+  label: string;
+  description: string;
+  secondaryDescription?: string;
+}) {
   return (
     <span className="settings-row-text">
       <span>{label}</span>
       <span className="settings-row-subtext">{description}</span>
+      {secondaryDescription && <span className="settings-row-subtext">{secondaryDescription}</span>}
     </span>
   );
 }
@@ -2830,20 +2841,25 @@ function VersionChange({ from, to }: { from: string; to: string }) {
 function Readiness({
   label,
   description,
+  missingDetail,
   ready
 }: {
   label: string;
   description: string;
+  missingDetail: string;
   ready: boolean;
 }) {
+  const statusLabel = ready ? "Enabled" : "Not detected";
   return (
     <div className="settings-row settings-row-status">
-      <SettingsRowText label={label} description={description} />
-      {ready ? (
-        <CheckCircle2 className="settings-status-icon good" size={20} />
-      ) : (
-        <XCircle className="settings-status-icon muted-icon" size={20} />
-      )}
+      <SettingsRowText
+        label={label}
+        description={ready ? description : `${description} ${missingDetail}`}
+      />
+      <span className={ready ? "settings-status-label enabled" : "settings-status-label muted"}>
+        <span className="settings-status-glyph" aria-hidden="true" />
+        <span>{statusLabel}</span>
+      </span>
     </div>
   );
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2483,8 +2483,16 @@ function SettingsPane({
               }
             />
             <div className="settings-panel-box">
-              <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
-              <Readiness label="mas" ready={snapshot.isMasInstalled} />
+              <Readiness
+                label="Homebrew"
+                description="Find updates for installed casks and formulae."
+                ready={snapshot.isHomebrewInstalled}
+              />
+              <Readiness
+                label="mas"
+                description="Use the App Store helper when it is available."
+                ready={snapshot.isMasInstalled}
+              />
             </div>
           </section>
           <section className="panel settings-panel">
@@ -2492,12 +2500,18 @@ function SettingsPane({
             <div className="settings-panel-box">
               <Toggle
                 label="Auto refresh"
+                description="Check for updates automatically in the background."
                 value={snapshot.autoRefreshEnabled}
                 patch="autoRefreshEnabled"
               />
-              <label className="field">
-                <span>Interval minutes</span>
+              <label className="settings-row settings-row-control">
+                <SettingsRowText
+                  label="Interval minutes"
+                  description="How often Baseline checks when auto refresh is on."
+                />
                 <input
+                  aria-label="Interval minutes"
+                  className="settings-number-input"
                   type="number"
                   min={5}
                   max={1440}
@@ -2511,11 +2525,13 @@ function SettingsPane({
               </label>
               <Toggle
                 label="Use mas for App Store updates"
+                description="Install App Store updates through mas before falling back to links."
                 value={snapshot.useMasForAppStoreUpdates}
                 patch="useMasForAppStoreUpdates"
               />
               <Toggle
                 label="Show menu bar icon"
+                description="Keep the compact update popover available in the menu bar."
                 value={snapshot.showMenuBarIcon}
                 patch="showMenuBarIcon"
               />
@@ -2535,12 +2551,14 @@ function SettingsPane({
               }
             />
             <div className="settings-panel-box">
-              <div className="directory-list">
+              <div className="settings-row-list">
                 {snapshot.additionalDirectories.length === 0 && (
-                  <Empty text="Using default Applications folders." />
+                  <p className="settings-row settings-row-subtext settings-empty-row">
+                    Using default Applications folders.
+                  </p>
                 )}
                 {snapshot.additionalDirectories.map((directory) => (
-                  <div className="directory-row" key={directory}>
+                  <div className="settings-row settings-row-action" key={directory}>
                     <span>{directory}</span>
                     <button
                       className="toolbar-button"
@@ -2558,11 +2576,11 @@ function SettingsPane({
       );
     case "appearance":
       return (
-        <section className="panel settings-panel theme-panel">
+        <section className="panel settings-panel">
           <PanelTitle title="Theme" />
-          <div className="settings-panel-box theme-panel-box">
-            <div className="theme-row">
-              <p className="muted theme-description">Use light, dark, or match your system</p>
+          <div className="settings-panel-box">
+            <div className="settings-row settings-row-action">
+              <p className="settings-row-subtext">Use light, dark, or match your system</p>
               <AppearanceSelector value={snapshot.appearancePreference} />
             </div>
           </div>
@@ -2574,14 +2592,14 @@ function SettingsPane({
           <section className="panel settings-panel">
             <PanelTitle title="About" />
             <div className="settings-panel-box">
-              <div className="metadata-list">
+              <div className="settings-row settings-key-value-list">
                 <div>
-                  <span>Version</span>
+                  <span className="settings-row-subtext">Version</span>
                   <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
                 </div>
                 {appMetadata?.buildNumber && (
                   <div>
-                    <span>Build</span>
+                    <span className="settings-row-subtext">Build</span>
                     <strong>{appMetadata.buildNumber}</strong>
                   </div>
                 )}
@@ -2591,11 +2609,11 @@ function SettingsPane({
           <section className="panel settings-panel">
             <PanelTitle title="Diagnostics" />
             <div className="settings-panel-box">
-              <p className="muted panel-copy">
-                Copy a local report with counts, tool status, scan paths, and the latest
-                non-sensitive refresh message.
-              </p>
-              <div className="settings-action">
+              <div className="settings-row settings-row-action">
+                <p className="settings-row-subtext">
+                  Copy a local report with counts, tool status, scan paths, and the latest
+                  non-sensitive refresh message.
+                </p>
                 <button
                   className="primary-button wide"
                   onClick={() => {
@@ -2654,11 +2672,23 @@ function AppearanceSelector({ value }: { value: AppearancePreference }) {
   );
 }
 
-function Toggle({ label, value, patch }: { label: string; value: boolean; patch: TogglePatch }) {
+function Toggle({
+  label,
+  description,
+  value,
+  patch
+}: {
+  label: string;
+  description: string;
+  value: boolean;
+  patch: TogglePatch;
+}) {
   return (
-    <label className="toggle">
-      <span>{label}</span>
+    <label className="settings-row settings-row-control">
+      <SettingsRowText label={label} description={description} />
       <input
+        aria-label={label}
+        className="settings-switch"
         type="checkbox"
         role="switch"
         checked={value}
@@ -2667,6 +2697,15 @@ function Toggle({ label, value, patch }: { label: string; value: boolean; patch:
         }
       />
     </label>
+  );
+}
+
+function SettingsRowText({ label, description }: { label: string; description: string }) {
+  return (
+    <span className="settings-row-text">
+      <span>{label}</span>
+      <span className="settings-row-subtext">{description}</span>
+    </span>
   );
 }
 
@@ -2723,16 +2762,23 @@ function VersionChange({ from, to }: { from: string; to: string }) {
   );
 }
 
-function Readiness({ label, ready }: { label: string; ready: boolean }) {
+function Readiness({
+  label,
+  description,
+  ready
+}: {
+  label: string;
+  description: string;
+  ready: boolean;
+}) {
   return (
-    <div className="ready-row">
+    <div className="settings-row settings-row-status">
+      <SettingsRowText label={label} description={description} />
       {ready ? (
-        <CheckCircle2 className="good" size={17} />
+        <CheckCircle2 className="settings-status-icon good" size={20} />
       ) : (
-        <XCircle className="muted-icon" size={17} />
+        <XCircle className="settings-status-icon muted-icon" size={20} />
       )}
-      <span>{label}</span>
-      <strong>{ready ? "Available" : "Not detected"}</strong>
     </div>
   );
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2459,17 +2459,19 @@ function SettingsPane({
       return (
         <>
           <section className="panel settings-panel">
-            <PanelTitle title="Readiness" />
+            <PanelTitle
+              title="Readiness"
+              action={
+                <button
+                  className="ghost-button small-button"
+                  onClick={() => void window.baseline.refreshToolStatus()}
+                >
+                  Refresh
+                </button>
+              }
+            />
             <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
             <Readiness label="mas" ready={snapshot.isMasInstalled} />
-            <div className="settings-action">
-              <button
-                className="ghost-button wide"
-                onClick={() => void window.baseline.refreshToolStatus()}
-              >
-                Check Again
-              </button>
-            </div>
           </section>
           <section className="panel settings-panel">
             <PanelTitle title="Refresh" />
@@ -2631,6 +2633,7 @@ function Toggle({ label, value, patch }: { label: string; value: boolean; patch:
       <span>{label}</span>
       <input
         type="checkbox"
+        role="switch"
         checked={value}
         onChange={(event) =>
           void window.baseline.updatePreferences({ [patch]: event.currentTarget.checked })

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -24,6 +24,7 @@ import {
   Search,
   Server,
   Settings,
+  ShieldCogCorner,
   Sun,
   Terminal,
   Trash2,
@@ -2446,7 +2447,7 @@ function SettingsSidebar({
           className={selectedSection === "diagnostics" ? "selected" : ""}
           onClick={() => onSelectSection("diagnostics")}
         >
-          <Terminal size={16} strokeWidth={sidebarIconStrokeWidth} />
+          <ShieldCogCorner size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Diagnostics</span>
         </button>
       </div>
@@ -2604,23 +2605,9 @@ function SettingsPane({
             <PanelTitle title="About" />
             <div className="settings-panel-box">
               <div className="settings-row settings-row-action">
-                <SettingsRowText
-                  label="App version"
-                  description="The Baseline release currently running on this Mac."
-                />
-                <strong className="settings-row-value">
-                  {appMetadata?.displayVersion ?? "Loading"}
-                </strong>
+                <span>Current version</span>
+                <strong className="settings-row-value">{appMetadata?.version ?? "Loading"}</strong>
               </div>
-              {appMetadata?.buildNumber && (
-                <div className="settings-row settings-row-action">
-                  <SettingsRowText
-                    label="Build number"
-                    description="The internal build identifier for troubleshooting."
-                  />
-                  <strong className="settings-row-value">{appMetadata.buildNumber}</strong>
-                </div>
-              )}
             </div>
           </section>
           <section className="panel settings-panel">

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -70,13 +70,7 @@ type RowUpdateMenuAction = {
   disabled?: boolean;
   onAction: () => void;
 };
-type SettingsSectionID =
-  | "about"
-  | "readiness"
-  | "appearance"
-  | "refresh"
-  | "scan-directories"
-  | "diagnostics";
+type SettingsSectionID = "general" | "appearance" | "diagnostics";
 
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
@@ -86,11 +80,8 @@ const settingsSidebarItems: Array<{
   label: string;
   icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
 }> = [
-  { id: "about", label: "About", icon: AppWindowMac },
-  { id: "readiness", label: "Readiness", icon: CheckCircle2 },
+  { id: "general", label: "General", icon: Settings },
   { id: "appearance", label: "Appearance", icon: Monitor },
-  { id: "refresh", label: "Refresh", icon: RefreshCcw },
-  { id: "scan-directories", label: "Scan Directories", icon: FolderPlus },
   { id: "diagnostics", label: "Diagnostics", icon: Terminal }
 ];
 
@@ -2381,7 +2372,7 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
 }
 
 export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
-  const [selectedSection, setSelectedSection] = useState<SettingsSectionID>("about");
+  const [selectedSection, setSelectedSection] = useState<SettingsSectionID>("general");
   const [diagnosticsCopied, setDiagnosticsCopied] = useState(false);
   const [appMetadata, setAppMetadata] = useState<AppMetadata>();
   const selectedItem = settingsSidebarItems.find((item) => item.id === selectedSection);
@@ -2428,7 +2419,7 @@ function SettingsSidebar({
       <div className="settings-sidebar-header">
         <button className="back-to-app-button" onClick={() => (window.location.hash = "/main")}>
           <ArrowLeft size={15} strokeWidth={sidebarIconStrokeWidth} />
-          <span>Back to App</span>
+          <span>Back to app</span>
         </button>
       </div>
       <nav className="source-list">
@@ -2464,39 +2455,86 @@ function SettingsPane({
   snapshot: BaselineSnapshot;
 }) {
   switch (section) {
-    case "about":
+    case "general":
       return (
-        <section className="panel settings-panel">
-          <PanelTitle title="About" />
-          <div className="metadata-list">
-            <div>
-              <span>Version</span>
-              <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
+        <>
+          <section className="panel settings-panel">
+            <PanelTitle title="Readiness" />
+            <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
+            <Readiness label="mas" ready={snapshot.isMasInstalled} />
+            <div className="settings-action">
+              <button
+                className="ghost-button wide"
+                onClick={() => void window.baseline.refreshToolStatus()}
+              >
+                Check Again
+              </button>
             </div>
-            {appMetadata?.buildNumber && (
-              <div>
-                <span>Build</span>
-                <strong>{appMetadata.buildNumber}</strong>
-              </div>
-            )}
-          </div>
-        </section>
-      );
-    case "readiness":
-      return (
-        <section className="panel settings-panel">
-          <PanelTitle title="Readiness" />
-          <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
-          <Readiness label="mas" ready={snapshot.isMasInstalled} />
-          <div className="settings-action">
-            <button
-              className="ghost-button wide"
-              onClick={() => void window.baseline.refreshToolStatus()}
-            >
-              Check Again
-            </button>
-          </div>
-        </section>
+          </section>
+          <section className="panel settings-panel">
+            <PanelTitle title="Refresh" />
+            <Toggle
+              label="Auto refresh"
+              value={snapshot.autoRefreshEnabled}
+              patch="autoRefreshEnabled"
+            />
+            <label className="field">
+              <span>Interval minutes</span>
+              <input
+                type="number"
+                min={5}
+                max={1440}
+                value={snapshot.refreshIntervalMinutes}
+                onChange={(event) =>
+                  void window.baseline.updatePreferences({
+                    refreshIntervalMinutes: Number(event.currentTarget.value)
+                  })
+                }
+              />
+            </label>
+            <Toggle
+              label="Use mas for App Store updates"
+              value={snapshot.useMasForAppStoreUpdates}
+              patch="useMasForAppStoreUpdates"
+            />
+            <Toggle
+              label="Show menu bar icon"
+              value={snapshot.showMenuBarIcon}
+              patch="showMenuBarIcon"
+            />
+          </section>
+          <section className="panel settings-panel">
+            <PanelTitle
+              title="Scan Directories"
+              action={
+                <button
+                  className="toolbar-button"
+                  onClick={() => void window.baseline.chooseDirectory()}
+                  title="Add directory"
+                >
+                  <FolderPlus size={15} />
+                </button>
+              }
+            />
+            <div className="directory-list">
+              {snapshot.additionalDirectories.length === 0 && (
+                <Empty text="Using default Applications folders." />
+              )}
+              {snapshot.additionalDirectories.map((directory) => (
+                <div className="directory-row" key={directory}>
+                  <span>{directory}</span>
+                  <button
+                    className="toolbar-button"
+                    onClick={() => void window.baseline.removeDirectory(directory)}
+                    title="Remove"
+                  >
+                    <XCircle size={15} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </section>
+        </>
       );
     case "appearance":
       return (
@@ -2505,94 +2543,44 @@ function SettingsPane({
           <AppearanceSelector value={snapshot.appearancePreference} />
         </section>
       );
-    case "refresh":
-      return (
-        <section className="panel settings-panel">
-          <PanelTitle title="Refresh" />
-          <Toggle
-            label="Auto refresh"
-            value={snapshot.autoRefreshEnabled}
-            patch="autoRefreshEnabled"
-          />
-          <label className="field">
-            <span>Interval minutes</span>
-            <input
-              type="number"
-              min={5}
-              max={1440}
-              value={snapshot.refreshIntervalMinutes}
-              onChange={(event) =>
-                void window.baseline.updatePreferences({
-                  refreshIntervalMinutes: Number(event.currentTarget.value)
-                })
-              }
-            />
-          </label>
-          <Toggle
-            label="Use mas for App Store updates"
-            value={snapshot.useMasForAppStoreUpdates}
-            patch="useMasForAppStoreUpdates"
-          />
-          <Toggle
-            label="Show menu bar icon"
-            value={snapshot.showMenuBarIcon}
-            patch="showMenuBarIcon"
-          />
-        </section>
-      );
-    case "scan-directories":
-      return (
-        <section className="panel settings-panel">
-          <PanelTitle
-            title="Scan Directories"
-            action={
-              <button
-                className="toolbar-button"
-                onClick={() => void window.baseline.chooseDirectory()}
-                title="Add directory"
-              >
-                <FolderPlus size={15} />
-              </button>
-            }
-          />
-          <div className="directory-list">
-            {snapshot.additionalDirectories.length === 0 && (
-              <Empty text="Using default Applications folders." />
-            )}
-            {snapshot.additionalDirectories.map((directory) => (
-              <div className="directory-row" key={directory}>
-                <span>{directory}</span>
-                <button
-                  className="toolbar-button"
-                  onClick={() => void window.baseline.removeDirectory(directory)}
-                  title="Remove"
-                >
-                  <XCircle size={15} />
-                </button>
-              </div>
-            ))}
-          </div>
-        </section>
-      );
     case "diagnostics":
       return (
-        <section className="panel settings-panel">
-          <PanelTitle title="Diagnostics" />
-          <p className="muted panel-copy">
-            Copy a local report with counts, tool status, scan paths, and the latest non-sensitive
-            refresh message.
-          </p>
-          <div className="settings-action">
-            <button
-              className="primary-button wide"
-              onClick={() => {
-                void window.baseline.copyDiagnostics().then(() => onDiagnosticsCopiedChange(true));
-              }}
-            >
-              {diagnosticsCopied ? "Copied" : "Copy Report"}
-            </button>
-          </div>
-        </section>
+        <>
+          <section className="panel settings-panel">
+            <PanelTitle title="About" />
+            <div className="metadata-list">
+              <div>
+                <span>Version</span>
+                <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
+              </div>
+              {appMetadata?.buildNumber && (
+                <div>
+                  <span>Build</span>
+                  <strong>{appMetadata.buildNumber}</strong>
+                </div>
+              )}
+            </div>
+          </section>
+          <section className="panel settings-panel">
+            <PanelTitle title="Diagnostics" />
+            <p className="muted panel-copy">
+              Copy a local report with counts, tool status, scan paths, and the latest non-sensitive
+              refresh message.
+            </p>
+            <div className="settings-action">
+              <button
+                className="primary-button wide"
+                onClick={() => {
+                  void window.baseline
+                    .copyDiagnostics()
+                    .then(() => onDiagnosticsCopiedChange(true));
+                }}
+              >
+                {diagnosticsCopied ? "Copied" : "Copy Report"}
+              </button>
+            </div>
+          </section>
+        </>
       );
   }
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2482,40 +2482,44 @@ function SettingsPane({
                 </button>
               }
             />
-            <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
-            <Readiness label="mas" ready={snapshot.isMasInstalled} />
+            <div className="settings-panel-box">
+              <Readiness label="Homebrew" ready={snapshot.isHomebrewInstalled} />
+              <Readiness label="mas" ready={snapshot.isMasInstalled} />
+            </div>
           </section>
           <section className="panel settings-panel">
             <PanelTitle title="Refresh" />
-            <Toggle
-              label="Auto refresh"
-              value={snapshot.autoRefreshEnabled}
-              patch="autoRefreshEnabled"
-            />
-            <label className="field">
-              <span>Interval minutes</span>
-              <input
-                type="number"
-                min={5}
-                max={1440}
-                value={snapshot.refreshIntervalMinutes}
-                onChange={(event) =>
-                  void window.baseline.updatePreferences({
-                    refreshIntervalMinutes: Number(event.currentTarget.value)
-                  })
-                }
+            <div className="settings-panel-box">
+              <Toggle
+                label="Auto refresh"
+                value={snapshot.autoRefreshEnabled}
+                patch="autoRefreshEnabled"
               />
-            </label>
-            <Toggle
-              label="Use mas for App Store updates"
-              value={snapshot.useMasForAppStoreUpdates}
-              patch="useMasForAppStoreUpdates"
-            />
-            <Toggle
-              label="Show menu bar icon"
-              value={snapshot.showMenuBarIcon}
-              patch="showMenuBarIcon"
-            />
+              <label className="field">
+                <span>Interval minutes</span>
+                <input
+                  type="number"
+                  min={5}
+                  max={1440}
+                  value={snapshot.refreshIntervalMinutes}
+                  onChange={(event) =>
+                    void window.baseline.updatePreferences({
+                      refreshIntervalMinutes: Number(event.currentTarget.value)
+                    })
+                  }
+                />
+              </label>
+              <Toggle
+                label="Use mas for App Store updates"
+                value={snapshot.useMasForAppStoreUpdates}
+                patch="useMasForAppStoreUpdates"
+              />
+              <Toggle
+                label="Show menu bar icon"
+                value={snapshot.showMenuBarIcon}
+                patch="showMenuBarIcon"
+              />
+            </div>
           </section>
           <section className="panel settings-panel">
             <PanelTitle
@@ -2530,22 +2534,24 @@ function SettingsPane({
                 </button>
               }
             />
-            <div className="directory-list">
-              {snapshot.additionalDirectories.length === 0 && (
-                <Empty text="Using default Applications folders." />
-              )}
-              {snapshot.additionalDirectories.map((directory) => (
-                <div className="directory-row" key={directory}>
-                  <span>{directory}</span>
-                  <button
-                    className="toolbar-button"
-                    onClick={() => void window.baseline.removeDirectory(directory)}
-                    title="Remove"
-                  >
-                    <XCircle size={15} />
-                  </button>
-                </div>
-              ))}
+            <div className="settings-panel-box">
+              <div className="directory-list">
+                {snapshot.additionalDirectories.length === 0 && (
+                  <Empty text="Using default Applications folders." />
+                )}
+                {snapshot.additionalDirectories.map((directory) => (
+                  <div className="directory-row" key={directory}>
+                    <span>{directory}</span>
+                    <button
+                      className="toolbar-button"
+                      onClick={() => void window.baseline.removeDirectory(directory)}
+                      title="Remove"
+                    >
+                      <XCircle size={15} />
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
           </section>
         </>
@@ -2553,11 +2559,13 @@ function SettingsPane({
     case "appearance":
       return (
         <section className="panel settings-panel theme-panel">
-          <div className="theme-panel-copy">
-            <PanelTitle title="Theme" />
-            <p className="muted theme-description">Use light, dark, or match your system</p>
+          <PanelTitle title="Theme" />
+          <div className="settings-panel-box theme-panel-box">
+            <div className="theme-row">
+              <p className="muted theme-description">Use light, dark, or match your system</p>
+              <AppearanceSelector value={snapshot.appearancePreference} />
+            </div>
           </div>
-          <AppearanceSelector value={snapshot.appearancePreference} />
         </section>
       );
     case "diagnostics":
@@ -2565,36 +2573,40 @@ function SettingsPane({
         <>
           <section className="panel settings-panel">
             <PanelTitle title="About" />
-            <div className="metadata-list">
-              <div>
-                <span>Version</span>
-                <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
-              </div>
-              {appMetadata?.buildNumber && (
+            <div className="settings-panel-box">
+              <div className="metadata-list">
                 <div>
-                  <span>Build</span>
-                  <strong>{appMetadata.buildNumber}</strong>
+                  <span>Version</span>
+                  <strong>{appMetadata?.displayVersion ?? "Loading"}</strong>
                 </div>
-              )}
+                {appMetadata?.buildNumber && (
+                  <div>
+                    <span>Build</span>
+                    <strong>{appMetadata.buildNumber}</strong>
+                  </div>
+                )}
+              </div>
             </div>
           </section>
           <section className="panel settings-panel">
             <PanelTitle title="Diagnostics" />
-            <p className="muted panel-copy">
-              Copy a local report with counts, tool status, scan paths, and the latest non-sensitive
-              refresh message.
-            </p>
-            <div className="settings-action">
-              <button
-                className="primary-button wide"
-                onClick={() => {
-                  void window.baseline
-                    .copyDiagnostics()
-                    .then(() => onDiagnosticsCopiedChange(true));
-                }}
-              >
-                {diagnosticsCopied ? "Copied" : "Copy Report"}
-              </button>
+            <div className="settings-panel-box">
+              <p className="muted panel-copy">
+                Copy a local report with counts, tool status, scan paths, and the latest
+                non-sensitive refresh message.
+              </p>
+              <div className="settings-action">
+                <button
+                  className="primary-button wide"
+                  onClick={() => {
+                    void window.baseline
+                      .copyDiagnostics()
+                      .then(() => onDiagnosticsCopiedChange(true));
+                  }}
+                >
+                  {diagnosticsCopied ? "Copied" : "Copy Report"}
+                </button>
+              </div>
             </div>
           </section>
         </>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1380,13 +1380,48 @@ button:disabled {
 }
 
 .toggle input {
-  width: 36px;
-  height: 20px;
-  accent-color: #34c759;
+  position: relative;
+  width: 38px;
+  height: 22px;
+  flex: 0 0 auto;
+  margin: 0;
+  border: 0;
+  border-radius: 999px;
+  appearance: none;
+  background: rgba(120, 120, 128, 0.28);
+  outline: 0;
+  transition: background 140ms ease;
+}
+
+.toggle input::after {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.2),
+    0 1px 5px rgba(0, 0, 0, 0.14);
+  content: "";
+  transition: transform 140ms ease;
+}
+
+.toggle input:checked {
+  background: #0169cc;
+}
+
+.toggle input:checked::after {
+  transform: translateX(16px);
+}
+
+.toggle input:focus-visible {
+  box-shadow: 0 0 0 3px rgba(var(--update-accent-rgb), 0.22);
 }
 
 .field input {
-  width: 92px;
+  width: 68px;
   height: 26px;
   padding: 0 8px;
   border: 1px solid rgba(60, 60, 67, 0.18);
@@ -1398,6 +1433,12 @@ button:disabled {
 .settings-action,
 .panel-copy {
   padding: 10px 12px;
+}
+
+.small-button {
+  min-height: 24px;
+  padding: 0 10px;
+  font-size: 12px;
 }
 
 .appearance-options {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -175,7 +175,8 @@ button:disabled {
 
 @media (hover: hover) {
   .source-list button:not(.selected):hover,
-  .sidebar-footer button:not(.selected):hover {
+  .sidebar-footer button:not(.selected):hover,
+  .back-to-app-button:hover {
     background: rgba(60, 60, 67, 0.08);
   }
 }
@@ -184,6 +185,41 @@ button:disabled {
   display: grid;
   margin-top: auto;
   -webkit-app-region: no-drag;
+}
+
+.settings-sidebar {
+  gap: 18px;
+}
+
+.settings-sidebar-header {
+  display: grid;
+  -webkit-app-region: no-drag;
+}
+
+.settings-sidebar .source-list button,
+.back-to-app-button {
+  grid-template-columns: 18px minmax(0, 1fr);
+}
+
+.back-to-app-button {
+  display: grid;
+  align-items: center;
+  gap: 7px;
+  min-height: 28px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: #2c2c2e;
+  font-size: 13px;
+  font-weight: 300;
+  text-align: left;
+}
+
+.back-to-app-button span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .workspace {
@@ -1319,6 +1355,14 @@ button:disabled {
   overflow: auto;
 }
 
+.settings-content {
+  display: block;
+}
+
+.settings-panel {
+  width: min(100%, 720px);
+}
+
 .wide-panel {
   grid-column: 1 / -1;
 }
@@ -1475,6 +1519,7 @@ button:disabled {
 
   .source-list button,
   .sidebar-footer button,
+  .back-to-app-button,
   .row-title strong,
   .toolbar-button,
   .icon-button,
@@ -1486,7 +1531,8 @@ button:disabled {
   }
 
   .source-list button,
-  .sidebar-footer button {
+  .sidebar-footer button,
+  .back-to-app-button {
     color: rgba(252, 252, 252, 0.7);
   }
 
@@ -1508,7 +1554,8 @@ button:disabled {
 
   @media (hover: hover) {
     .source-list button:not(.selected):hover,
-    .sidebar-footer button:not(.selected):hover {
+    .sidebar-footer button:not(.selected):hover,
+    .back-to-app-button:hover {
       background: rgba(235, 235, 245, 0.09);
     }
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1376,10 +1376,20 @@ button:disabled {
   padding: 0;
 }
 
-.theme-panel .panel-title h2 {
+.settings-panel .panel-title {
+  min-height: 0;
+  padding: 0 12px 10px;
+}
+
+.settings-panel.theme-panel .panel-title {
+  padding: 0;
+}
+
+.settings-panel .panel-title h2,
+.settings-panel .section-toggle {
   color: #1c1c1e;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .theme-description {
@@ -1705,7 +1715,8 @@ button:disabled {
     color: rgba(235, 235, 245, 0.78);
   }
 
-  .theme-panel .panel-title h2 {
+  .settings-panel .panel-title h2,
+  .settings-panel .section-toggle {
     color: #ffffff;
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1434,6 +1434,37 @@ button:disabled {
   flex: 0 0 auto;
 }
 
+.settings-status-label {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid rgba(60, 60, 67, 0.1);
+  border-radius: 999px;
+  background: rgba(60, 60, 67, 0.08);
+  color: #2c2c2e;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.settings-status-label.muted {
+  color: rgba(60, 60, 67, 0.64);
+}
+
+.settings-status-glyph {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: rgb(var(--update-accent-rgb));
+}
+
+.settings-status-label.muted .settings-status-glyph {
+  background: rgba(60, 60, 67, 0.42);
+}
+
 .settings-switch {
   position: relative;
   width: 38px;
@@ -1816,6 +1847,20 @@ button:disabled {
     border-color: rgba(235, 235, 245, 0.12);
     background: rgba(235, 235, 245, 0.1);
     color: rgba(255, 255, 255, 0.88);
+  }
+
+  .settings-status-label {
+    border-color: rgba(235, 235, 245, 0.12);
+    background: rgba(235, 235, 245, 0.1);
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .settings-status-label.muted {
+    color: rgba(235, 235, 245, 0.58);
+  }
+
+  .settings-status-label.muted .settings-status-glyph {
+    background: rgba(235, 235, 245, 0.42);
   }
 
   .toolbar-button.refresh-button,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1363,6 +1363,30 @@ button:disabled {
   width: min(100%, 720px);
 }
 
+.theme-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+}
+
+.theme-panel .panel-title {
+  min-height: 0;
+  padding: 0;
+}
+
+.theme-panel .panel-title h2 {
+  color: #1c1c1e;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.theme-description {
+  margin-top: 6px;
+  font-size: 12px;
+}
+
 .wide-panel {
   grid-column: 1 / -1;
 }
@@ -1442,13 +1466,13 @@ button:disabled {
 }
 
 .appearance-options {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 3px;
-  margin: 12px;
-  padding: 2px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
   border-radius: 8px;
-  background: rgba(118, 118, 128, 0.12);
 }
 
 .appearance-options button {
@@ -1458,22 +1482,25 @@ button:disabled {
   justify-content: center;
   gap: 6px;
   min-height: 30px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 6px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
   background: transparent;
   color: #2c2c2e;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   text-align: left;
 }
 
+.appearance-options button:not(.selected):hover {
+  border-color: rgba(60, 60, 67, 0.12);
+  background: rgba(60, 60, 67, 0.07);
+}
+
 .appearance-options button.selected {
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow:
-    0 0 0 0.5px rgba(60, 60, 67, 0.08),
-    0 1px 3px rgba(0, 0, 0, 0.1);
-  color: #0d0d0d;
+  border-color: rgba(60, 60, 67, 0.1);
+  background: rgba(60, 60, 67, 0.08);
+  color: #1c1c1e;
 }
 
 .appearance-options span {
@@ -1678,6 +1705,10 @@ button:disabled {
     color: rgba(235, 235, 245, 0.78);
   }
 
+  .theme-panel .panel-title h2 {
+    color: #ffffff;
+  }
+
   .section-toggle {
     color: rgba(235, 235, 245, 0.78);
   }
@@ -1744,20 +1775,19 @@ button:disabled {
     background: rgba(255, 255, 255, 0.08);
   }
 
-  .appearance-options {
-    background: rgba(118, 118, 128, 0.28);
-  }
-
   .appearance-options button {
     color: rgba(235, 235, 245, 0.78);
   }
 
+  .appearance-options button:not(.selected):hover {
+    border-color: rgba(235, 235, 245, 0.16);
+    background: rgba(235, 235, 245, 0.09);
+  }
+
   .appearance-options button.selected {
-    background: rgba(99, 99, 102, 0.78);
-    box-shadow:
-      0 0 0 0.5px rgba(255, 255, 255, 0.14),
-      0 1px 3px rgba(0, 0, 0, 0.4);
-    color: #ffffff;
+    border-color: rgba(235, 235, 245, 0.12);
+    background: rgba(235, 235, 245, 0.1);
+    color: rgba(255, 255, 255, 0.88);
   }
 
   .toolbar-button.refresh-button,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1314,7 +1314,7 @@ button:disabled {
   align-items: center;
   gap: 7px;
   min-height: 30px;
-  padding: 0 10px;
+  padding: 16px 10px;
   border-top: 1px solid rgba(60, 60, 67, 0.08);
   color: #0d0d0d;
   font-size: 12px;
@@ -1360,29 +1360,26 @@ button:disabled {
 }
 
 .settings-panel {
+  display: grid;
+  gap: 10px;
   width: min(100%, 720px);
 }
 
 .theme-panel {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 16px;
-  padding: 16px;
+  padding: 0;
 }
 
 .theme-panel .panel-title {
   min-height: 0;
-  padding: 0;
 }
 
 .settings-panel .panel-title {
   min-height: 0;
-  padding: 0 12px 10px;
+  padding: 0 12px;
 }
 
 .settings-panel.theme-panel .panel-title {
-  padding: 0;
+  padding: 0 12px;
 }
 
 .settings-panel .panel-title h2,
@@ -1393,8 +1390,29 @@ button:disabled {
 }
 
 .theme-description {
-  margin-top: 6px;
+  margin: 0;
   font-size: 12px;
+}
+
+.settings-panel-box {
+  overflow: hidden;
+  margin: 0 12px;
+  padding: 4px;
+  border: 1px solid rgba(60, 60, 67, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.34);
+}
+
+.theme-panel-box {
+  display: block;
+}
+
+.theme-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 12px;
 }
 
 .wide-panel {
@@ -1408,7 +1426,7 @@ button:disabled {
   justify-content: space-between;
   gap: 12px;
   min-height: 36px;
-  padding: 0 12px;
+  padding: 16px 12px;
   border-top: 1px solid rgba(60, 60, 67, 0.1);
   font-size: 13px;
 }
@@ -1452,6 +1470,18 @@ button:disabled {
 
 .toggle input:focus-visible {
   box-shadow: 0 0 0 3px rgba(var(--update-accent-rgb), 0.22);
+}
+
+.settings-panel-box > .ready-row:first-child,
+.settings-panel-box > .toggle:first-child,
+.settings-panel-box > .field:first-child,
+.directory-list > .directory-row:first-child {
+  border-top: 0;
+}
+
+.settings-panel-box > .metadata-list,
+.settings-panel-box > .empty {
+  padding: 16px 12px;
 }
 
 .field input {
@@ -1529,7 +1559,7 @@ button:disabled {
   align-items: center;
   gap: 8px;
   min-height: 38px;
-  padding: 0 10px 0 12px;
+  padding: 16px 10px 16px 12px;
   border-top: 1px solid rgba(60, 60, 67, 0.1);
   font-size: 12px;
 }
@@ -1726,11 +1756,16 @@ button:disabled {
 
   .stats div,
   .readiness,
+  .settings-panel-box,
   .ready-row,
   .toggle,
   .field,
   .directory-row {
     border-color: rgba(235, 235, 245, 0.1);
+  }
+
+  .settings-panel-box {
+    background: rgba(255, 255, 255, 0.04);
   }
 
   .row,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1617,8 +1617,13 @@ button:disabled {
   .muted,
   .empty,
   .stats dt,
+  .metadata-list span,
   .ready-row strong {
     color: rgba(235, 235, 245, 0.5);
+  }
+
+  .metadata-list strong {
+    color: rgba(255, 255, 255, 0.86);
   }
 
   .row-title span {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -685,6 +685,11 @@ button:disabled {
   padding-top: 16px;
 }
 
+.app-shell:not(.compact) .settings-content > .stack > .settings-panel + .settings-panel {
+  border-top: 0;
+  padding-top: 0;
+}
+
 .compact .row {
   grid-template-columns: 48px minmax(0, 1fr) auto;
   min-height: 68px;
@@ -795,12 +800,12 @@ button:disabled {
   padding: 14px 12px;
 }
 
-.metadata-list {
+.settings-key-value-list {
   display: grid;
   gap: 10px;
 }
 
-.metadata-list div {
+.settings-key-value-list div {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -808,13 +813,7 @@ button:disabled {
   min-width: 0;
 }
 
-.metadata-list span {
-  color: rgba(60, 60, 67, 0.5);
-  font-size: 12px;
-  font-weight: 300;
-}
-
-.metadata-list strong {
+.settings-key-value-list strong {
   min-width: 0;
   overflow-wrap: anywhere;
   color: #1c1c1e;
@@ -1303,39 +1302,12 @@ button:disabled {
   font-weight: 650;
 }
 
-.readiness {
+.settings-row-status {
   display: grid;
-  border-top: 1px solid rgba(60, 60, 67, 0.1);
-}
-
-.ready-row {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 7px;
-  min-height: 30px;
-  padding: 16px 10px;
-  border-top: 1px solid rgba(60, 60, 67, 0.08);
+  gap: 12px;
   color: #0d0d0d;
-  font-size: 12px;
-}
-
-.ready-row:first-child {
-  border-top: 0;
-}
-
-.ready-row strong {
-  color: rgba(60, 60, 67, 0.64);
-  font-size: 11px;
-  font-weight: 590;
-}
-
-.sidebar-footer .ready-row {
-  min-height: 26px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.34);
 }
 
 .good {
@@ -1359,18 +1331,14 @@ button:disabled {
   display: block;
 }
 
+.settings-content .stack {
+  gap: 40px;
+}
+
 .settings-panel {
   display: grid;
   gap: 10px;
   width: min(100%, 720px);
-}
-
-.theme-panel {
-  padding: 0;
-}
-
-.theme-panel .panel-title {
-  min-height: 0;
 }
 
 .settings-panel .panel-title {
@@ -1378,60 +1346,82 @@ button:disabled {
   padding: 0 12px;
 }
 
-.settings-panel.theme-panel .panel-title {
-  padding: 0 12px;
-}
-
 .settings-panel .panel-title h2,
 .settings-panel .section-toggle {
   color: #1c1c1e;
-  font-size: 13px;
-  font-weight: 400;
-}
-
-.theme-description {
-  margin: 0;
-  font-size: 12px;
+  font-size: 14px;
+  font-weight: 500;
 }
 
 .settings-panel-box {
+  --settings-row-divider: rgba(60, 60, 67, 0.1);
+  --settings-row-padding-block: 12px;
+  --settings-row-padding-inline: 12px;
+
+  display: grid;
   overflow: hidden;
   margin: 0 12px;
-  padding: 4px;
-  border: 1px solid rgba(60, 60, 67, 0.1);
+  padding: 0;
+  border: 1px solid var(--settings-row-divider);
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.34);
 }
 
-.theme-panel-box {
-  display: block;
-}
-
-.theme-row {
+.settings-row-action {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 16px;
-  padding: 16px 12px;
 }
 
 .wide-panel {
   grid-column: 1 / -1;
 }
 
-.toggle,
-.field {
+.settings-row-control {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.settings-row {
   min-height: 36px;
-  padding: 16px 12px;
-  border-top: 1px solid rgba(60, 60, 67, 0.1);
+  padding: var(--settings-row-padding-block) var(--settings-row-padding-inline);
+  border-top: 0;
   font-size: 13px;
 }
 
-.toggle input {
+.settings-row-text {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.settings-row-text > span:first-child {
+  color: #1c1c1e;
+  font-weight: 400;
+}
+
+.settings-row-subtext {
+  display: block;
+  margin: 0;
+  color: rgba(60, 60, 67, 0.5);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.45;
+}
+
+.settings-empty-row {
+  display: flex;
+  align-items: center;
+}
+
+.settings-status-icon {
+  flex: 0 0 auto;
+}
+
+.settings-switch {
   position: relative;
   width: 38px;
   height: 22px;
@@ -1445,7 +1435,7 @@ button:disabled {
   transition: background 140ms ease;
 }
 
-.toggle input::after {
+.settings-switch::after {
   position: absolute;
   top: 2px;
   left: 2px;
@@ -1460,31 +1450,24 @@ button:disabled {
   transition: transform 140ms ease;
 }
 
-.toggle input:checked {
+.settings-switch:checked {
   background: #0169cc;
 }
 
-.toggle input:checked::after {
+.settings-switch:checked::after {
   transform: translateX(16px);
 }
 
-.toggle input:focus-visible {
+.settings-switch:focus-visible {
   box-shadow: 0 0 0 3px rgba(var(--update-accent-rgb), 0.22);
 }
 
-.settings-panel-box > .ready-row:first-child,
-.settings-panel-box > .toggle:first-child,
-.settings-panel-box > .field:first-child,
-.directory-list > .directory-row:first-child {
-  border-top: 0;
+.settings-row + .settings-row,
+.settings-row-list > .settings-row + .settings-row {
+  border-top: 1px solid var(--settings-row-divider);
 }
 
-.settings-panel-box > .metadata-list,
-.settings-panel-box > .empty {
-  padding: 16px 12px;
-}
-
-.field input {
+.settings-number-input {
   width: 68px;
   height: 26px;
   padding: 0 8px;
@@ -1492,11 +1475,6 @@ button:disabled {
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.86);
   text-align: right;
-}
-
-.settings-action,
-.panel-copy {
-  padding: 10px 12px;
 }
 
 .small-button {
@@ -1549,22 +1527,7 @@ button:disabled {
   white-space: nowrap;
 }
 
-.directory-list {
-  display: grid;
-}
-
-.directory-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 8px;
-  min-height: 38px;
-  padding: 16px 10px 16px 12px;
-  border-top: 1px solid rgba(60, 60, 67, 0.1);
-  font-size: 12px;
-}
-
-.directory-row span {
+.settings-row-action > span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1629,12 +1592,13 @@ button:disabled {
   .sidebar-footer button,
   .back-to-app-button,
   .row-title strong,
+  .settings-row-text > span:first-child,
   .toolbar-button,
   .icon-button,
   .secondary-icon-button,
   .ghost-button,
   .stats dd,
-  .ready-row {
+  .settings-row-status {
     color: #fcfcfc;
   }
 
@@ -1684,12 +1648,11 @@ button:disabled {
   .muted,
   .empty,
   .stats dt,
-  .metadata-list span,
-  .ready-row strong {
+  .settings-row-subtext {
     color: rgba(235, 235, 245, 0.5);
   }
 
-  .metadata-list strong {
+  .settings-key-value-list strong {
     color: rgba(255, 255, 255, 0.86);
   }
 
@@ -1698,7 +1661,7 @@ button:disabled {
   }
 
   .search-box,
-  .field input {
+  .settings-number-input {
     border-color: rgba(235, 235, 245, 0.18);
     background: rgba(255, 255, 255, 0.08);
     color: rgba(235, 235, 245, 0.58);
@@ -1712,7 +1675,7 @@ button:disabled {
 
   .search-box input,
   .toolbar-search input,
-  .field input {
+  .settings-number-input {
     color: #fcfcfc;
   }
 
@@ -1754,17 +1717,13 @@ button:disabled {
     color: rgba(235, 235, 245, 0.78);
   }
 
-  .stats div,
-  .readiness,
-  .settings-panel-box,
-  .ready-row,
-  .toggle,
-  .field,
-  .directory-row {
+  .stats div {
     border-color: rgba(235, 235, 245, 0.1);
   }
 
   .settings-panel-box {
+    --settings-row-divider: rgba(235, 235, 245, 0.1);
+
     background: rgba(255, 255, 255, 0.04);
   }
 
@@ -1957,10 +1916,6 @@ button:disabled {
     border-color: rgba(255, 69, 58, 0.32);
     background: rgba(255, 69, 58, 0.13);
     color: #ffb4ae;
-  }
-
-  .sidebar-footer .ready-row {
-    background: rgba(255, 255, 255, 0.08);
   }
 
   .good {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -822,6 +822,14 @@ button:disabled {
   text-align: right;
 }
 
+.settings-row-value {
+  min-width: max-content;
+  color: #1c1c1e;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: right;
+}
+
 .version-token {
   letter-spacing: 0.05em;
 }
@@ -1410,6 +1418,7 @@ button:disabled {
   font-size: 13px;
   font-weight: 400;
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .settings-row-disabled {
@@ -1541,12 +1550,6 @@ button:disabled {
   white-space: nowrap;
 }
 
-.settings-row-action > span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .spin {
   animation: spin 0.8s linear infinite;
 }
@@ -1666,7 +1669,8 @@ button:disabled {
     color: rgba(235, 235, 245, 0.5);
   }
 
-  .settings-key-value-list strong {
+  .settings-key-value-list strong,
+  .settings-row-value {
     color: rgba(255, 255, 255, 0.86);
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -46,7 +46,7 @@ button:disabled {
   --scrollbar-thumb: rgba(60, 60, 60, 0.07);
   --scrollbar-thumb-hover: rgba(60, 60, 60, 0.16);
   --scrollbar-track: transparent;
-  --update-accent-rgb: 0, 122, 255;
+  --update-accent-rgb: 1, 105, 204;
 
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
@@ -1412,6 +1412,10 @@ button:disabled {
   line-height: 1.45;
 }
 
+.settings-row-disabled {
+  opacity: 0.48;
+}
+
 .settings-empty-row {
   display: flex;
   align-items: center;
@@ -1451,7 +1455,7 @@ button:disabled {
 }
 
 .settings-switch:checked {
-  background: #0169cc;
+  background: rgb(var(--update-accent-rgb));
 }
 
 .settings-switch:checked::after {
@@ -1474,7 +1478,17 @@ button:disabled {
   border: 1px solid rgba(60, 60, 67, 0.18);
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.86);
+  outline: 0;
   text-align: right;
+}
+
+.settings-number-input:focus-visible {
+  border-color: rgba(0, 0, 0, 0.72);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.18);
+}
+
+.settings-number-input:disabled {
+  cursor: not-allowed;
 }
 
 .small-button {
@@ -1677,6 +1691,11 @@ button:disabled {
   .toolbar-search input,
   .settings-number-input {
     color: #fcfcfc;
+  }
+
+  .settings-number-input:focus-visible {
+    border-color: rgba(255, 255, 255, 0.78);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
   }
 
   .search-box input::placeholder,

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -185,6 +185,7 @@ export type BaselineSnapshot = PersistedSnapshot &
     homebrewDiscoverFailedItemIDs: string[];
     homebrewDiscoverProgressByItemID: Record<string, number>;
     laggingHomebrewCaskTokens: string[];
+    defaultScanDirectories: string[];
   };
 
 export const emptyHomebrewCaskIndex: HomebrewCaskIndex = {


### PR DESCRIPTION
## Summary
- Split Settings into a dedicated in-app settings sidebar with General, Appearance, and Diagnostics sections.
- Group readiness, refresh, and scan directory controls under General, and include app version details in Diagnostics.
- Add a Back to app control and keep settings content aligned with the main tab padding/layout.
- Update renderer coverage for the new settings navigation and controls.

Fixes #4

## Validation
- npm run lint
- npm run typecheck
- npm test -- --run ElectronTests/rendererButtons.test.tsx ElectronTests/updateStore.test.ts
- npm run build
- npm run test:electron
