### PR TITLE
Fix Homebrew outdated JSON parsing after wake

### DIFF
--- a/ElectronTests/homebrewInventoryClient.test.ts
+++ b/ElectronTests/homebrewInventoryClient.test.ts
@@ -5,7 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const commandMock = vi.hoisted(() => ({
   calls: [] as string[][],
-  results: new Map<string, { success: boolean; status: number | null; output: string }>()
+  results: new Map<
+    string,
+    { success: boolean; status: number | null; output: string; stdout?: string; stderr?: string }
+  >()
 }));
 
 vi.mock("../src/main/commandRunner", () => ({
@@ -87,6 +90,35 @@ describe("HomebrewInventoryClient", () => {
     expect(result.warning).toContain("cask outdated");
     expect(result.items.find((item) => item.token === "ripgrep")?.isOutdated).toBe(true);
     expect(result.items.find((item) => item.token === "notion")?.isOutdated).toBe(false);
+  });
+
+  it("parses outdated JSON from stdout when Homebrew writes warnings to stderr", async () => {
+    commandMock.results.set("outdated --formula --json=v2", {
+      success: true,
+      status: 0,
+      output:
+        "Warning: Another active Homebrew process is already in progress.\n" +
+        JSON.stringify({ formulae: [{ name: "ripgrep", current_version: "14.1.0" }] }),
+      stdout: JSON.stringify({ formulae: [{ name: "ripgrep", current_version: "14.1.0" }] }),
+      stderr: "Warning: Another active Homebrew process is already in progress.\n"
+    });
+    commandMock.results.set("outdated --cask --greedy --json=v2", {
+      success: true,
+      status: 0,
+      output:
+        "Warning: Another active Homebrew process is already in progress.\n" +
+        JSON.stringify({ casks: [{ token: "notion", current_version: "4.1.0" }] }),
+      stdout: JSON.stringify({ casks: [{ token: "notion", current_version: "4.1.0" }] }),
+      stderr: "Warning: Another active Homebrew process is already in progress.\n"
+    });
+    const { HomebrewInventoryClient } = await import("../src/main/homebrewInventoryClient");
+
+    const result = await new HomebrewInventoryClient().fetchInventory();
+
+    expect(result.outdatedDetectionSucceeded).toBe(true);
+    expect(result.warning).toBeUndefined();
+    expect(result.items.find((item) => item.token === "ripgrep")?.isOutdated).toBe(true);
+    expect(result.items.find((item) => item.token === "notion")?.isOutdated).toBe(true);
   });
 
   it("treats failed metadata updates as unreliable for both Homebrew kinds", async () => {

--- a/src/main/commandRunner.ts
+++ b/src/main/commandRunner.ts
@@ -14,6 +14,8 @@ export type CommandResult = {
   success: boolean;
   status: number | null;
   output: string;
+  stdout?: string;
+  stderr?: string;
 };
 
 export async function isExecutable(path: string): Promise<boolean> {
@@ -55,34 +57,57 @@ export async function runCommand(
       stdio: ["ignore", "pipe", "pipe"]
     });
     const output: string[] = [];
-    let buffered = "";
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let stdoutBuffered = "";
+    let stderrBuffered = "";
 
-    const append = (chunk: Buffer) => {
+    const append = (chunk: Buffer, stream: string[], buffer: string): string => {
       const text = chunk.toString("utf8");
       output.push(text);
-      buffered += text;
-      let newline = buffered.indexOf("\n");
+      stream.push(text);
+      buffer += text;
+      let newline = buffer.indexOf("\n");
       while (newline !== -1) {
-        const line = buffered.slice(0, newline).trim();
-        buffered = buffered.slice(newline + 1);
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
         if (line) {
           onOutputLine(line);
         }
-        newline = buffered.indexOf("\n");
+        newline = buffer.indexOf("\n");
       }
+      return buffer;
     };
 
-    child.stdout.on("data", append);
-    child.stderr.on("data", append);
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBuffered = append(chunk, stdout, stdoutBuffered);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrBuffered = append(chunk, stderr, stderrBuffered);
+    });
     child.on("error", () => {
-      resolve({ success: false, status: null, output: output.join("") });
+      resolve({
+        success: false,
+        status: null,
+        output: output.join(""),
+        stdout: stdout.join(""),
+        stderr: stderr.join("")
+      });
     });
     child.on("close", (status) => {
-      const line = buffered.trim();
-      if (line) {
-        onOutputLine(line);
+      for (const buffered of [stdoutBuffered, stderrBuffered]) {
+        const line = buffered.trim();
+        if (line) {
+          onOutputLine(line);
+        }
       }
-      resolve({ success: status === 0, status, output: output.join("") });
+      resolve({
+        success: status === 0,
+        status,
+        output: output.join(""),
+        stdout: stdout.join(""),
+        stderr: stderr.join("")
+      });
     });
   });
 }
@@ -93,7 +118,7 @@ export async function runBrewCommand(
 ): Promise<CommandResult> {
   const executable = await resolvedBrewExecutablePath();
   if (!executable) {
-    return { success: false, status: null, output: "" };
+    return { success: false, status: null, output: "", stdout: "", stderr: "" };
   }
   return runCommand(executable, args, onOutputLine);
 }
@@ -101,7 +126,7 @@ export async function runBrewCommand(
 export async function runMasCommand(args: string[]): Promise<CommandResult> {
   const executable = await resolvedMasExecutablePath();
   if (!executable) {
-    return { success: false, status: null, output: "" };
+    return { success: false, status: null, output: "", stdout: "", stderr: "" };
   }
   return runCommand(executable, args);
 }

--- a/src/main/homebrewInventoryClient.ts
+++ b/src/main/homebrewInventoryClient.ts
@@ -38,10 +38,10 @@ export class HomebrewInventoryClient {
 
     const metadataReady = !updateResult || updateResult.success;
     const parsed = this.parser.buildInventoryWithStatus(
-      formulaVersions.output,
-      caskVersions.output,
-      metadataReady && formulaOutdated.success ? formulaOutdated.output || "{}" : "{}",
-      metadataReady && caskOutdated.success ? caskOutdated.output || "{}" : "{}"
+      commandStdout(formulaVersions),
+      commandStdout(caskVersions),
+      metadataReady && formulaOutdated.success ? commandStdout(formulaOutdated) || "{}" : "{}",
+      metadataReady && caskOutdated.success ? commandStdout(caskOutdated) || "{}" : "{}"
     );
     const commandSucceeded =
       metadataReady &&
@@ -75,6 +75,10 @@ export class HomebrewInventoryClient {
       })
     };
   }
+}
+
+function commandStdout(result: CommandResult): string {
+  return result.stdout ?? result.output;
 }
 
 export class HomebrewInventoryParser {


### PR DESCRIPTION
## Summary

- Homebrew can write warnings to stderr while valid inventory and outdated data remain on stdout; combining both streams made Baseline treat valid outdated JSON as malformed after wake or concurrent Homebrew activity.
- Command execution now returns separate stdout and stderr fields while preserving the combined output stream for progress events, logs, and failure messages.
- Homebrew inventory parsing now consumes stdout for installed-version and outdated JSON data, with regression coverage for stderr warning text before valid JSON.

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npm run test:electron
- npm audit --omit=dev --audit-level=high
