### PR TITLE
Show cask app update progress

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -146,6 +146,22 @@ describe("renderer button parity", () => {
     expect(window.baseline.performAppUpdate).not.toHaveBeenCalled();
   });
 
+  it("shows matched Homebrew cask progress on app update buttons", () => {
+    render(
+      <AppRow
+        app={app}
+        snapshot={snapshot({
+          homebrewUpdatingItemIDs: [cask.id],
+          homebrewBatchProgressByItemID: { [cask.id]: 0.4 }
+        })}
+        recentlyUpdated={false}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Updating" })).toBeInTheDocument();
+  });
+
   it("groups ignore and uninstall under row actions menu", () => {
     const { container, rerender } = render(
       <AppRow app={app} snapshot={snapshot()} recentlyUpdated={false} />

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -162,6 +162,23 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Updating" })).toBeInTheDocument();
   });
 
+  it("shows matched Homebrew cask success on app update buttons before refresh", () => {
+    render(
+      <AppRow
+        app={app}
+        snapshot={snapshot({
+          homebrewUpdatingItemIDs: [cask.id],
+          homebrewUpdatedPendingRefreshItemIDs: [cask.id],
+          homebrewBatchProgressByItemID: { [cask.id]: 1 }
+        })}
+        recentlyUpdated={false}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Updating" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Updated" })).toBeInTheDocument();
+  });
+
   it("groups ignore and uninstall under row actions menu", () => {
     const { container, rerender } = render(
       <AppRow app={app} snapshot={snapshot()} recentlyUpdated={false} />

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1248,6 +1248,7 @@ async function makeStore({
   runMasCommand = async () => ({ success: true, status: 0, output: "" }),
   openExternalURL = async () => true,
   openAppBundle = async () => undefined,
+  successRefreshDelayMS = 0,
   onUserData
 }: {
   persisted?: PersistedSnapshot;
@@ -1256,6 +1257,7 @@ async function makeStore({
   runMasCommand?: ConstructorParameters<typeof UpdateStore>[0]["runMasCommand"];
   openExternalURL?: ConstructorParameters<typeof UpdateStore>[0]["openExternalURL"];
   openAppBundle?: ConstructorParameters<typeof UpdateStore>[0]["openAppBundle"];
+  successRefreshDelayMS?: ConstructorParameters<typeof UpdateStore>[0]["successRefreshDelayMS"];
   onUserData?: (directory: string) => void;
 } = {}): Promise<UpdateStore> {
   const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-update-store-"));
@@ -1268,6 +1270,7 @@ async function makeStore({
     openAppBundle,
     runBrewCommand,
     runMasCommand,
+    successRefreshDelayMS,
     clients: {
       scanner: { scanApplications: async () => [] },
       appStore: { lookupOutcome: async () => ({ type: "completed" }) },

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -51,6 +51,8 @@ type StoreEvents = {
   homebrewCommand: [HomebrewMaintenanceRunEvent];
 };
 
+const successfulUpdateHoldMs = 2000;
+
 export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly persistence: SnapshotPersistence;
   private readonly scanner: Pick<BundleScannerClient, "scanApplications">;
@@ -66,6 +68,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly runMasCommand: typeof defaultRunMasCommand;
   private readonly openExternalURL: (url: string) => Promise<boolean>;
   private readonly openAppBundle: (bundlePath: string) => Promise<void>;
+  private readonly successRefreshDelayMS: number;
   private refreshTask?: Promise<void>;
   private autoRefreshTimer?: NodeJS.Timeout;
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
@@ -88,6 +91,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }>;
     runBrewCommand?: typeof defaultRunBrewCommand;
     runMasCommand?: typeof defaultRunMasCommand;
+    successRefreshDelayMS?: number;
   }) {
     super();
     this.persistence = options.persistence;
@@ -101,6 +105,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     this.runMasCommand = options.runMasCommand ?? defaultRunMasCommand;
     this.openExternalURL = options.openExternalURL;
     this.openAppBundle = options.openAppBundle;
+    this.successRefreshDelayMS = options.successRefreshDelayMS ?? successfulUpdateHoldMs;
     this.state = {
       ...options.persisted,
       isMasInstalled: false,
@@ -281,6 +286,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           this.patch({
             appUpdatedPendingRefreshIDs: addToArray(this.state.appUpdatedPendingRefreshIDs, appID)
           });
+          await this.holdSuccessfulUpdate();
           await this.refresh();
         } else {
           await this.routeExternalUpdate(appRecord, update);
@@ -335,6 +341,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             [itemID]: 1
           }
         });
+        await this.holdSuccessfulUpdate();
       } else {
         this.patch({
           refreshErrorMessage: `Homebrew update failed for ${item.name}.`,
@@ -414,6 +421,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         : this.state.homebrewUpdatedPendingRefreshItemIDs,
       refreshErrorMessage: success ? undefined : "Homebrew maintenance cycle failed."
     });
+    if (success) {
+      await this.holdSuccessfulUpdate();
+    }
     await this.refresh();
   }
 
@@ -453,6 +463,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       refreshErrorMessage: success ? undefined : `Homebrew install failed for ${item.displayName}.`
     });
     if (success) {
+      await this.holdSuccessfulUpdate();
       await this.refresh();
     }
   }
@@ -697,6 +708,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           ? undefined
           : `Homebrew update failed for ${appRecord.displayName}.`
       });
+      if (success) {
+        await this.holdSuccessfulUpdate();
+      }
       await this.refresh();
     });
   }
@@ -892,6 +906,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         homebrewUpdatingItemIDs: removeFromArray(this.state.homebrewUpdatingItemIDs, itemID)
       });
     }
+  }
+
+  private async holdSuccessfulUpdate(): Promise<void> {
+    if (this.successRefreshDelayMS <= 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, this.successRefreshDelayMS));
   }
 
   private restartAutoRefreshLoop(): void {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2186,7 +2186,7 @@ function RowMoreActionButton({
                   <ProgressRing value={updateAction.state.progress} />
                 )
               ) : updateAction.state.type === "done" ? (
-                <Check size={14} />
+                <Check className="done-glyph" size={14} />
               ) : (
                 <span className="failure-glyph">!</span>
               )}
@@ -2238,14 +2238,7 @@ function ProgressRing({ value }: { value: number }) {
 }
 
 function DoneTransitionGlyph() {
-  const [showCheckmark, setShowCheckmark] = useState(false);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setShowCheckmark(true), 320);
-    return () => window.clearTimeout(timer);
-  }, []);
-
-  return showCheckmark ? <Check size={15} /> : <ProgressRing value={1} />;
+  return <Check className="done-glyph" size={15} />;
 }
 
 function UninstallActionGlyph() {
@@ -2321,11 +2314,11 @@ function actionStateFromFlags({
   if (failed) {
     return { type: "failed" };
   }
-  if (updating) {
-    return progress === undefined ? { type: "updating" } : { type: "updating", progress };
-  }
   if (done) {
     return { type: "done" };
+  }
+  if (updating) {
+    return progress === undefined ? { type: "updating" } : { type: "updating", progress };
   }
   return { type: "ready" };
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -949,22 +949,13 @@ function AppSection({
 function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
-  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
   const isIgnored = snapshot.ignoredIDs.includes(app.id);
-  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
-  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
-  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
   const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
   const label = appSourceLabel(app, snapshot);
   const isUninstalling = uninstallableItem
     ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
     : false;
-  const actionState = actionStateFromFlags({
-    failed,
-    updating: isUpdating,
-    progress,
-    done
-  });
+  const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
 
   return (
     <article className={isIgnored ? "item-card update-card ignored-row" : "item-card update-card"}>
@@ -1170,21 +1161,12 @@ function CardGrid({
 function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
-  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
   const isIgnored = snapshot.ignoredIDs.includes(app.id);
-  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
-  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
-  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
   const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
   const isUninstalling = uninstallableItem
     ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
     : false;
-  const actionState = actionStateFromFlags({
-    failed,
-    updating: isUpdating,
-    progress,
-    done
-  });
+  const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
   const recentlyUpdatedRecord = snapshot.recentlyUpdated.find((record) => record.appID === app.id);
   const label = appSourceLabel(app, snapshot, recentlyUpdatedRecord);
 
@@ -1248,22 +1230,13 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
 function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
-  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
   const isIgnored = snapshot.ignoredIDs.includes(app.id);
-  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
-  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
-  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
   const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
   const label = appSourceLabel(app, snapshot);
   const isUninstalling = uninstallableItem
     ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
     : false;
-  const actionState = actionStateFromFlags({
-    failed,
-    updating: isUpdating,
-    progress,
-    done
-  });
+  const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
 
   return (
     <article className="item-card ignored-card ignored-row">
@@ -1340,21 +1313,12 @@ export function AppRow({
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
-  const isUpdating = snapshot.appUpdatingIDs.includes(app.id);
   const isIgnored = snapshot.ignoredIDs.includes(app.id);
-  const progress = snapshot.homebrewFallbackProgressByAppID[app.id];
-  const failed = snapshot.homebrewFallbackFailedAppIDs.includes(app.id);
-  const done = snapshot.appUpdatedPendingRefreshIDs.includes(app.id);
   const uninstallableItem = uninstallableHomebrewItemForApp(app, snapshot);
   const isUninstalling = uninstallableItem
     ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
     : false;
-  const actionState = actionStateFromFlags({
-    failed,
-    updating: isUpdating,
-    progress,
-    done
-  });
+  const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
   const recentlyUpdatedAt = recentlyUpdated
     ? snapshot.recentlyUpdated.find((record) => record.appID === app.id)?.updatedAt
     : undefined;
@@ -2374,6 +2338,46 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
     return "Updated";
   }
   return "Update failed";
+}
+
+function appUpdateActionState(
+  app: AppRecord,
+  snapshot: BaselineSnapshot
+): { state: ActionState; isUpdating: boolean } {
+  const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
+  const matchedHomebrewItem =
+    update?.source === "homebrew" ? uninstallableHomebrewItemForApp(app, snapshot) : undefined;
+  const isUpdating =
+    snapshot.appUpdatingIDs.includes(app.id) ||
+    Boolean(
+      matchedHomebrewItem && snapshot.homebrewUpdatingItemIDs.includes(matchedHomebrewItem.id)
+    );
+  const progress =
+    snapshot.homebrewFallbackProgressByAppID[app.id] ??
+    (matchedHomebrewItem
+      ? snapshot.homebrewBatchProgressByItemID[matchedHomebrewItem.id]
+      : undefined);
+  const failed =
+    snapshot.homebrewFallbackFailedAppIDs.includes(app.id) ||
+    Boolean(
+      matchedHomebrewItem && snapshot.homebrewBatchFailedItemIDs.includes(matchedHomebrewItem.id)
+    );
+  const done =
+    snapshot.appUpdatedPendingRefreshIDs.includes(app.id) ||
+    Boolean(
+      matchedHomebrewItem &&
+      snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(matchedHomebrewItem.id)
+    );
+
+  return {
+    isUpdating,
+    state: actionStateFromFlags({
+      failed,
+      updating: isUpdating,
+      progress,
+      done
+    })
+  };
 }
 
 export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2186,7 +2186,7 @@ function RowMoreActionButton({
                   <ProgressRing value={updateAction.state.progress} />
                 )
               ) : updateAction.state.type === "done" ? (
-                <Check className="done-glyph" size={14} />
+                <Check className="done-glyph" size={14} strokeWidth={3} />
               ) : (
                 <span className="failure-glyph">!</span>
               )}
@@ -2238,7 +2238,7 @@ function ProgressRing({ value }: { value: number }) {
 }
 
 function DoneTransitionGlyph() {
-  return <Check className="done-glyph" size={15} />;
+  return <Check className="done-glyph" size={15} strokeWidth={3} />;
 }
 
 function UninstallActionGlyph() {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1167,6 +1167,10 @@ button:disabled {
   line-height: 1;
 }
 
+.done-glyph {
+  animation: done-fade-in 180ms ease-out both;
+}
+
 .progress-ring {
   width: 16px;
   height: 16px;
@@ -1588,6 +1592,18 @@ button:disabled {
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes done-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.82);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- derive app update button state from matched Homebrew cask updates as well as app-level update state
- show cask progress, completion, and failure states on app rows/cards when an app update routes through Homebrew
- hold successful update/install states for two seconds before refresh moves rows into Recently Updated
- replace the completed progress ring with a faded-in check mark inside the same blue button
- add renderer regression coverage for matched cask progress and pre-refresh success states

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
