### PR TITLE
Skip ignored Homebrew items in batch updates

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -988,6 +988,98 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().refreshErrorMessage).toContain("Error: still running");
   });
 
+  it("updates only non-ignored Homebrew items in a batch run", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({
+      success: true,
+      status: 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        ignoredHomebrewItemIDs: ["formula:ignored-formula", "cask:ignored-cask"],
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "formula:ignored-formula",
+            token: "ignored-formula",
+            name: "ignored-formula",
+            kind: "formula",
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "cask:visual-studio-code",
+            token: "visual-studio-code",
+            name: "Visual Studio Code",
+            kind: "cask",
+            latestVersion: version("1.100.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "cask:ignored-cask",
+            token: "ignored-cask",
+            name: "Ignored Cask",
+            kind: "cask",
+            latestVersion: version("3.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["upgrade", "--cask", "--greedy", "visual-studio-code"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+  });
+
+  it("does not run Homebrew maintenance when every outdated item is ignored", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({
+      success: true,
+      status: 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        ignoredHomebrewItemIDs: ["formula:ripgrep"],
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+  });
+
   it("uses mas for App Store updates and falls back to safe external routes on failure", async () => {
     const app = appRecord({
       bundlePath: "/Applications/App Store Managed.app",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -362,8 +362,19 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
 
     const affected = this.state.homebrewItems.filter(
-      (item) => item.isOutdated && !this.state.ignoredHomebrewItemIDs.includes(item.id)
+      (item) =>
+        item.isOutdated &&
+        !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
+        isValidHomebrewToken(item.token)
     );
+    if (affected.length === 0) {
+      return;
+    }
+
+    const formulaTokens = affected
+      .filter((item) => item.kind === "formula")
+      .map((item) => item.token);
+    const caskTokens = affected.filter((item) => item.kind === "cask").map((item) => item.token);
     const affectedIDs = affected.map((item) => item.id);
     const affectedByToken = new Map<string, string[]>();
     for (const item of affected) {
@@ -392,8 +403,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     );
     const sequence = [
       ["update"],
-      ["upgrade"],
-      ["upgrade", "--cask", "--greedy"],
+      ...(formulaTokens.length > 0 ? [["upgrade", ...formulaTokens]] : []),
+      ...(caskTokens.length > 0 ? [["upgrade", "--cask", "--greedy", ...caskTokens]] : []),
       ["autoremove"],
       ["cleanup"]
     ];


### PR DESCRIPTION
## Summary
- `update brews` button was using broad `brew upgrade` commands after filtering the UI list, therefore ignoring the user's ignored items
- update batch maintenance to target only non-ignored, valid outdated Homebrew tokens
- add store regressions for mixed ignored/non-ignored items and all-ignored items

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
