### PR TITLE
Hide zero sidebar update badges

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -439,6 +439,24 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
   });
 
+  it("hides sidebar update badges when counts are zero", () => {
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({ apps: [], updates: [], homebrewItems: [] })}
+      />
+    );
+
+    const [allButton, appsButton, homebrewButton] = Array.from(
+      container.querySelectorAll(".source-list button")
+    );
+
+    expect(within(allButton as HTMLElement).queryByText("0")).not.toBeInTheDocument();
+    expect(within(appsButton as HTMLElement).queryByText("0")).not.toBeInTheDocument();
+    expect(within(homebrewButton as HTMLElement).queryByText("0")).not.toBeInTheDocument();
+  });
+
   it("shows settings sections as sidebar tabs without search-filtered badges", () => {
     const installedApp: AppRecord = {
       ...app,

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -88,9 +88,9 @@ test("launches the Electron shell and renders the dashboard", async () => {
   const page = await app.firstWindow();
   await expect(page).toHaveTitle("Baseline");
   await expect(page.locator("h1")).toContainText("All");
-  await expect(page.getByRole("button", { name: /^All\s+\d+$/u })).toBeVisible();
-  await expect(page.getByRole("button", { name: /^Apps\s+\d+$/u })).toBeVisible();
-  await expect(page.getByRole("button", { name: /^Homebrew\s+\d+$/u })).toBeVisible();
+  await expect(page.getByRole("button", { name: "All", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Apps", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Homebrew", exact: true })).toBeVisible();
   await expect.poll(() => page.evaluate(() => typeof window.baseline)).toBe("object");
   await expect(
     page.evaluate(() => typeof (window as Window & { require?: unknown }).require)

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -433,7 +433,7 @@ function Sidebar({
         >
           <Server size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>All</span>
-          <strong>{combinedAvailableCount(derived)}</strong>
+          <SidebarBadge count={combinedAvailableCount(derived)} />
         </button>
         <button
           className={route === "main" && snapshot.selectedTab === "apps" ? "selected" : ""}
@@ -441,7 +441,7 @@ function Sidebar({
         >
           <AppWindowMac size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Apps</span>
-          <strong>{derived.availableApps.length}</strong>
+          <SidebarBadge count={derived.availableApps.length} />
         </button>
         <button
           className={route === "main" && snapshot.selectedTab === "homebrew" ? "selected" : ""}
@@ -449,7 +449,7 @@ function Sidebar({
         >
           <Beer size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Homebrew</span>
-          <strong>{derived.allHomebrewOutdated.length}</strong>
+          <SidebarBadge count={derived.allHomebrewOutdated.length} />
         </button>
       </nav>
       <nav className="source-list secondary-source-list">
@@ -482,6 +482,10 @@ function Sidebar({
       </div>
     </aside>
   );
+}
+
+function SidebarBadge({ count }: { count: number }) {
+  return count > 0 ? <strong>{count}</strong> : null;
 }
 
 function ToolbarSearch({


### PR DESCRIPTION
## Summary
- Hide sidebar update badges when the count is zero.
- Add renderer coverage for empty All, Apps, and Homebrew sidebar badge states.

## Validation
- npm test -- --run ElectronTests/rendererButtons.test.tsx
- npm run typecheck
- npm run lint
