### PR TITLE
Refine renderer typography and settings dividers

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2057,7 +2057,11 @@ export function UpdateActionButton({
   if (state.type === "ready") {
     return (
       <button
-        className={readyVariant === "outline" ? "primary-button outline-button" : "primary-button"}
+        className={
+          readyVariant === "outline"
+            ? "primary-button outline-button update-action-button"
+            : "primary-button update-action-button"
+        }
         disabled={disabled}
         onClick={onAction}
       >

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1304,7 +1304,8 @@ button:disabled {
 }
 
 .settings-panel-box {
-  --settings-row-divider: rgba(60, 60, 67, 0.1);
+  --settings-panel-border: rgba(60, 60, 67, 0.1);
+  --settings-row-divider: rgba(60, 60, 67, 0.055);
   --settings-row-padding-block: 12px;
   --settings-row-padding-inline: 12px;
 
@@ -1312,7 +1313,7 @@ button:disabled {
   overflow: hidden;
   margin: 0 12px;
   padding: 0;
-  border: 1px solid var(--settings-row-divider);
+  border: 0.5px solid var(--settings-panel-border);
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.34);
 }
@@ -1450,7 +1451,7 @@ button:disabled {
 
 .settings-row + .settings-row,
 .settings-row-list > .settings-row + .settings-row {
-  border-top: 1px solid var(--settings-row-divider);
+  border-top: 0.5px solid var(--settings-row-divider);
 }
 
 .settings-number-input {
@@ -1708,7 +1709,8 @@ button:disabled {
   }
 
   .settings-panel-box {
-    --settings-row-divider: rgba(235, 235, 245, 0.1);
+    --settings-panel-border: rgba(235, 235, 245, 0.1);
+    --settings-row-divider: rgba(235, 235, 245, 0.06);
 
     background: rgba(255, 255, 255, 0.04);
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -262,7 +262,7 @@ button:disabled {
   margin: 0;
   font-size: 17px;
   line-height: 1.15;
-  font-weight: 680;
+  font-weight: 700;
   letter-spacing: 0;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -874,7 +874,7 @@ button:disabled {
   padding: 5px;
   border: 0;
   border-radius: 9px;
-  background: rgba(255, 255, 255, 0.96);
+  background: #ffffff;
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
 }
 
@@ -895,7 +895,7 @@ button:disabled {
   border-radius: 6px;
   background: transparent;
   color: #1c1c1e;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 400;
   text-align: left;
 }
@@ -1159,6 +1159,10 @@ button:disabled {
   border: 0;
   background: transparent;
   color: #007aff;
+}
+
+.update-action-button {
+  font-size: 13px;
 }
 
 .danger-button {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -647,7 +647,7 @@ button:disabled {
 .item-card-main {
   display: grid;
   align-content: end;
-  gap: 9px;
+  gap: 6px;
   min-width: 0;
   margin-top: 12px;
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -653,11 +653,12 @@ button:disabled {
 }
 
 .item-card .row-title strong {
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .item-card .row-title span {
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .item-card .row-main p {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -647,8 +647,22 @@ button:disabled {
 .item-card-main {
   display: grid;
   align-content: end;
+  gap: 9px;
   min-width: 0;
   margin-top: 12px;
+}
+
+.item-card .row-title strong {
+  font-size: 14px;
+}
+
+.item-card .row-title span {
+  font-size: 12px;
+}
+
+.item-card .row-main p {
+  margin-top: 0;
+  font-size: 13px;
 }
 
 .row {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -406,36 +406,6 @@ button:disabled {
   font-size: 13px;
 }
 
-.segmented {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  width: 260px;
-  height: 28px;
-  padding: 2px;
-  border-radius: 7px;
-  background: rgba(118, 118, 128, 0.16);
-}
-
-.compact .segmented {
-  width: 100%;
-}
-
-.segmented button {
-  border: 0;
-  border-radius: 5px;
-  background: transparent;
-  color: #3a3a3c;
-  font-size: 12px;
-  font-weight: 590;
-}
-
-.segmented button.selected {
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow:
-    0 0 0 0.5px rgba(0, 0, 0, 0.12),
-    0 1px 3px rgba(0, 0, 0, 0.12);
-}
-
 .content {
   display: block;
   min-height: 0;
@@ -975,15 +945,6 @@ button:disabled {
   color: rgba(60, 60, 67, 0.78);
 }
 
-.segmented button {
-  transition:
-    transform 150ms ease,
-    background-color 150ms ease,
-    color 150ms ease,
-    box-shadow 150ms ease,
-    opacity 150ms ease;
-}
-
 @media (hover: hover) {
   .toolbar-button:not(:disabled):hover,
   .icon-button:not(:disabled):hover,
@@ -993,8 +954,7 @@ button:disabled {
   .ghost-button:not(:disabled):hover,
   .primary-button:not(:disabled):hover,
   .danger-button:not(:disabled):hover,
-  .destructive-text-button:not(:disabled):hover,
-  .segmented button:not(:disabled):hover {
+  .destructive-text-button:not(:disabled):hover {
     transform: translateY(-1px) scale(1.035);
   }
 
@@ -1055,10 +1015,6 @@ button:disabled {
     background: #ff453a;
   }
 
-  .segmented button:not(:disabled):hover {
-    color: #007aff;
-  }
-
   .row-action-menu-popover button:not(:disabled):hover {
     background: rgba(60, 60, 67, 0.08);
   }
@@ -1072,8 +1028,7 @@ button:disabled {
 .ghost-button:not(:disabled):active,
 .primary-button:not(:disabled):active,
 .danger-button:not(:disabled):active,
-.destructive-text-button:not(:disabled):active,
-.segmented button:not(:disabled):active {
+.destructive-text-button:not(:disabled):active {
   transform: translateY(0) scale(0.97);
 }
 
@@ -1087,7 +1042,6 @@ button:disabled {
   .primary-button,
   .danger-button,
   .destructive-text-button,
-  .segmented button,
   .toolbar-search,
   .toolbar-search-field {
     transition: none;
@@ -1110,7 +1064,6 @@ button:disabled {
   .primary-button:not(:disabled):hover,
   .danger-button:not(:disabled):hover,
   .destructive-text-button:not(:disabled):hover,
-  .segmented button:not(:disabled):hover,
   .toolbar-button:not(:disabled):active,
   .icon-button:not(:disabled):active,
   .secondary-icon-button:not(:disabled):active,
@@ -1119,8 +1072,7 @@ button:disabled {
   .ghost-button:not(:disabled):active,
   .primary-button:not(:disabled):active,
   .danger-button:not(:disabled):active,
-  .destructive-text-button:not(:disabled):active,
-  .segmented button:not(:disabled):active {
+  .destructive-text-button:not(:disabled):active {
     transform: none;
   }
 }
@@ -1298,39 +1250,6 @@ button:disabled {
   align-content: start;
   gap: 12px;
   min-width: 0;
-}
-
-.stats {
-  display: grid;
-  gap: 0;
-  margin: 0;
-  padding: 0;
-}
-
-.stats div {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 34px;
-  padding: 0 12px;
-  border-top: 1px solid rgba(60, 60, 67, 0.1);
-}
-
-.stats div:first-child {
-  border-top: 0;
-}
-
-.stats dt {
-  color: rgba(60, 60, 67, 0.72);
-  font-size: 12px;
-  font-weight: 590;
-}
-
-.stats dd {
-  margin: 0;
-  color: #0d0d0d;
-  font-size: 13px;
-  font-weight: 650;
 }
 
 .settings-row-status {
@@ -1680,7 +1599,6 @@ button:disabled {
   .icon-button,
   .secondary-icon-button,
   .ghost-button,
-  .stats dd,
   .settings-row-status {
     color: #fcfcfc;
   }
@@ -1730,7 +1648,6 @@ button:disabled {
   .row-main p,
   .muted,
   .empty,
-  .stats dt,
   .settings-row-subtext {
     color: rgba(235, 235, 245, 0.5);
   }
@@ -1777,22 +1694,6 @@ button:disabled {
     color: rgba(235, 235, 245, 0.5);
   }
 
-  .segmented {
-    background: rgba(118, 118, 128, 0.28);
-  }
-
-  .segmented button {
-    color: rgba(235, 235, 245, 0.78);
-  }
-
-  .segmented button.selected {
-    background: rgba(99, 99, 102, 0.78);
-    box-shadow:
-      0 0 0 0.5px rgba(255, 255, 255, 0.14),
-      0 1px 3px rgba(0, 0, 0, 0.4);
-    color: #ffffff;
-  }
-
   .panel-title h2 {
     color: rgba(235, 235, 245, 0.78);
   }
@@ -1804,10 +1705,6 @@ button:disabled {
 
   .section-toggle {
     color: rgba(235, 235, 245, 0.78);
-  }
-
-  .stats div {
-    border-color: rgba(235, 235, 245, 0.1);
   }
 
   .settings-panel-box {


### PR DESCRIPTION
## Summary
- Align app card typography with Settings row scale, including card title, source label, version/detail text, and title/detail spacing.
- Normalize action menu and update button text sizing, and make action popovers fully opaque.
- Soften Settings panel borders and row separators while removing unused renderer CSS for stale segmented/stat styles.

## Validation
- `npm run typecheck`
