### PR TITLE
Allow retry after failed Homebrew Discover installs

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1462,6 +1462,36 @@ describe("update store helpers", () => {
       vi.useRealTimers();
     }
   });
+
+  it("returns failed Homebrew Discover installs to retryable state after a short delay", async () => {
+    const item = {
+      id: "cask:retryable-discover",
+      kind: "cask" as const,
+      token: "retryable-discover",
+      displayName: "Retryable Discover",
+      presentation: "app" as const,
+      version: version("1.0.0")
+    };
+    const store = await makeStore({
+      runBrewCommand: async (_args, onOutputLine = () => undefined) => {
+        onOutputLine("Downloading retryable-discover");
+        return { success: false, status: 1, output: "Error: install failed" };
+      }
+    });
+
+    vi.useFakeTimers();
+    try {
+      await store.installHomebrewItem(item);
+
+      expect(store.getSnapshot().homebrewDiscoverFailedItemIDs).toContain(item.id);
+
+      vi.advanceTimersByTime(4000);
+      expect(store.getSnapshot().homebrewDiscoverFailedItemIDs).not.toContain(item.id);
+      expect(store.getSnapshot().homebrewDiscoverProgressByItemID[item.id]).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 async function makeStore({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -74,6 +74,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private autoRefreshTimer?: NodeJS.Timeout;
   private readonly homebrewBatchFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private readonly homebrewFallbackFailureClearTimers = new Map<string, NodeJS.Timeout>();
+  private readonly homebrewDiscoverFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
 
@@ -467,11 +468,16 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return;
     }
     const itemID = item.id;
+    this.clearHomebrewDiscoverFailureTimer(itemID);
     const command =
       item.kind === "cask" ? ["install", "--cask", item.token] : ["install", item.token];
     this.patch({
       homebrewDiscoverInstallingItemIDs: addToArray(
         this.state.homebrewDiscoverInstallingItemIDs,
+        itemID
+      ),
+      homebrewDiscoverFailedItemIDs: removeFromArray(
+        this.state.homebrewDiscoverFailedItemIDs,
         itemID
       ),
       homebrewDiscoverProgressByItemID: {
@@ -499,6 +505,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (success) {
       await this.holdSuccessfulUpdate();
       await this.refresh();
+    } else {
+      this.scheduleHomebrewDiscoverFailureClear(itemID);
     }
   }
 
@@ -999,6 +1007,28 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
   }
 
+  private scheduleHomebrewDiscoverFailureClear(itemID: string): void {
+    this.clearHomebrewDiscoverFailureTimer(itemID);
+    const timer = setTimeout(() => {
+      this.homebrewDiscoverFailureClearTimers.delete(itemID);
+      if (!this.state.homebrewDiscoverFailedItemIDs.includes(itemID)) {
+        return;
+      }
+      this.patch({
+        homebrewDiscoverFailedItemIDs: removeFromArray(
+          this.state.homebrewDiscoverFailedItemIDs,
+          itemID
+        ),
+        homebrewDiscoverProgressByItemID: removeRecordKey(
+          this.state.homebrewDiscoverProgressByItemID,
+          itemID
+        )
+      });
+    }, TRANSIENT_HOMEBREW_FAILURE_MS);
+    timer.unref?.();
+    this.homebrewDiscoverFailureClearTimers.set(itemID, timer);
+  }
+
   private clearHomebrewBatchFailureTimer(itemID: string): void {
     const timer = this.homebrewBatchFailureClearTimers.get(itemID);
     if (timer) {
@@ -1012,6 +1042,14 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (timer) {
       clearTimeout(timer);
       this.homebrewFallbackFailureClearTimers.delete(appID);
+    }
+  }
+
+  private clearHomebrewDiscoverFailureTimer(itemID: string): void {
+    const timer = this.homebrewDiscoverFailureClearTimers.get(itemID);
+    if (timer) {
+      clearTimeout(timer);
+      this.homebrewDiscoverFailureClearTimers.delete(itemID);
     }
   }
 


### PR DESCRIPTION
## Summary
- Clear stale Discover install failure state when a retry starts.
- Return failed Discover installs to a retryable state after the transient Homebrew failure delay.
- Add a regression test for failed Discover install recovery.

Fixes #97

## Validation
- npm test -- --run ElectronTests/updateStore.test.ts
