### PR TITLE
Avoid repeated Electron window setup on reuse

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -509,12 +509,12 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
   });
 
-  it("returns from settings to the main app route", () => {
+  it("returns from settings through the main window bridge", () => {
     render(<SettingsView snapshot={snapshot()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Back to app" }));
 
-    expect(window.location.hash).toBe("#/main");
+    expect(window.baseline.showMainWindow).toHaveBeenCalledTimes(1);
   });
 
   it("opens diagnostics from the settings sidebar footer", async () => {

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -142,6 +142,51 @@ test("persists preferences across Electron relaunches", async () => {
   await closeApp(secondApp);
 });
 
+test("reuses the main window without duplicate setup", async () => {
+  const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-e2e-"));
+  const app = await launchBaseline({ userData });
+  const page = await app.firstWindow();
+  await expect(page.locator("h1")).toContainText("All");
+
+  const ownMainCloseListenerCount = () =>
+    app.evaluate(
+      ({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows()[0]
+          ?.rawListeners("close")
+          .filter((listener) => listener.name === "handleMainWindowClose").length
+    );
+
+  const initialCloseListeners = await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) {
+      throw new Error("Expected a main window.");
+    }
+    (globalThis as typeof globalThis & { __baselineLoadCount?: number }).__baselineLoadCount = 0;
+    window.webContents.on("did-start-loading", () => {
+      const globals = globalThis as typeof globalThis & { __baselineLoadCount?: number };
+      globals.__baselineLoadCount = (globals.__baselineLoadCount ?? 0) + 1;
+    });
+    return window
+      .rawListeners("close")
+      .filter((listener) => listener.name === "handleMainWindowClose").length;
+  });
+
+  await page.evaluate(async () => {
+    await window.baseline.showMainWindow();
+    await window.baseline.showMainWindow();
+  });
+  await page.waitForTimeout(250);
+
+  await expect(ownMainCloseListenerCount()).resolves.toBe(initialCloseListeners);
+  await expect(
+    app.evaluate(
+      () => (globalThis as typeof globalThis & { __baselineLoadCount?: number }).__baselineLoadCount
+    )
+  ).resolves.toBe(0);
+
+  await closeApp(app);
+});
+
 test("launches the packaged Electron app after build", async () => {
   const app = await launchBaseline({ packaged: true });
   const page = await app.firstWindow();

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -187,6 +187,28 @@ test("reuses the main window without duplicate setup", async () => {
   await closeApp(app);
 });
 
+test("reopens settings after renderer-side back navigation", async () => {
+  const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-e2e-"));
+  const app = await launchBaseline({ userData });
+  const page = await app.firstWindow();
+  await expect(page.locator("h1")).toContainText("All");
+
+  await page.evaluate(async () => {
+    await window.baseline.showSettings();
+  });
+  await expect(page.locator("h1")).toContainText("General");
+
+  await page.getByRole("button", { name: "Back to app" }).click();
+  await expect(page.locator("h1")).toContainText("All");
+
+  await page.evaluate(async () => {
+    await window.baseline.showSettings();
+  });
+  await expect(page.locator("h1")).toContainText("General");
+
+  await closeApp(app);
+});
+
 test("launches the packaged Electron app after build", async () => {
   const app = await launchBaseline({ packaged: true });
   const page = await app.firstWindow();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -33,6 +33,7 @@ declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
 let mainWindow: BrowserWindow | undefined;
+let mainWindowRoute: "main" | "settings" | undefined;
 let menuWindow: BrowserWindow | undefined;
 let tray: Tray | undefined;
 let trayBaseIcon: Electron.NativeImage | undefined;
@@ -117,67 +118,74 @@ app.on("before-quit", () => {
 app.on("did-resign-active", hideMenuWindowForNativeDismissal);
 
 function createMainWindow(route: "main" | "settings"): BrowserWindow {
-  mainWindow =
-    mainWindow ??
-    new BrowserWindow({
-      width: 1020,
-      height: 760,
-      minWidth: 660,
-      minHeight: 620,
-      title: "Baseline",
-      titleBarStyle: "hiddenInset",
-      trafficLightPosition: { x: 14, y: 14 },
-      vibrancy: "sidebar",
-      visualEffectState: "active",
-      transparent: true,
-      backgroundColor: "#00000000",
-      show: false,
-      webPreferences: {
-        preload: path.join(__dirname, "preload.js"),
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: false
-      }
-    });
+  if (mainWindow) {
+    return mainWindow;
+  }
 
-  mainWindow.on("close", (event) => {
-    if (!isQuitting) {
-      event.preventDefault();
-      mainWindow?.hide();
+  mainWindow = new BrowserWindow({
+    width: 1020,
+    height: 760,
+    minWidth: 660,
+    minHeight: 620,
+    title: "Baseline",
+    titleBarStyle: "hiddenInset",
+    trafficLightPosition: { x: 14, y: 14 },
+    vibrancy: "sidebar",
+    visualEffectState: "active",
+    transparent: true,
+    backgroundColor: "#00000000",
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false
     }
   });
 
+  mainWindow.on("close", handleMainWindowClose);
+  mainWindow.on("closed", () => {
+    mainWindow = undefined;
+    mainWindowRoute = undefined;
+  });
+
+  mainWindowRoute = route;
   void loadRenderer(mainWindow, route);
   mainWindow.once("ready-to-show", () => showWindow(mainWindow));
   return mainWindow;
 }
 
 function createMenuWindow(): BrowserWindow {
-  menuWindow =
-    menuWindow ??
-    new BrowserWindow({
-      width: 440,
-      height: 560,
-      resizable: false,
-      movable: true,
-      title: "Baseline",
-      vibrancy: "popover",
-      visualEffectState: "active",
-      transparent: true,
-      backgroundColor: "#00000000",
-      show: false,
-      frame: false,
-      fullscreenable: false,
-      skipTaskbar: true,
-      webPreferences: {
-        preload: path.join(__dirname, "preload.js"),
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: false
-      }
-    });
+  if (menuWindow) {
+    return menuWindow;
+  }
+
+  menuWindow = new BrowserWindow({
+    width: 440,
+    height: 560,
+    resizable: false,
+    movable: true,
+    title: "Baseline",
+    vibrancy: "popover",
+    visualEffectState: "active",
+    transparent: true,
+    backgroundColor: "#00000000",
+    show: false,
+    frame: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false
+    }
+  });
 
   menuWindow.on("blur", hideMenuWindowForNativeDismissal);
+  menuWindow.on("closed", () => {
+    menuWindow = undefined;
+  });
 
   void loadRenderer(menuWindow, "menubar");
   return menuWindow;
@@ -249,9 +257,19 @@ function hideMenuWindowForNativeDismissal(): void {
   }
 }
 
+function handleMainWindowClose(event: Electron.Event): void {
+  if (!isQuitting) {
+    event.preventDefault();
+    mainWindow?.hide();
+  }
+}
+
 function showMainWindow(route: "main" | "settings"): void {
   const window = createMainWindow(route);
-  void loadRenderer(window, route);
+  if (mainWindowRoute !== route) {
+    mainWindowRoute = route;
+    void loadRenderer(window, route);
+  }
   showWindow(window);
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -148,6 +148,8 @@ function createMainWindow(route: "main" | "settings"): BrowserWindow {
     mainWindow = undefined;
     mainWindowRoute = undefined;
   });
+  mainWindow.webContents.on("did-finish-load", () => syncMainWindowRoute(mainWindow));
+  mainWindow.webContents.on("did-navigate-in-page", () => syncMainWindowRoute(mainWindow));
 
   mainWindowRoute = route;
   void loadRenderer(mainWindow, route);
@@ -264,9 +266,32 @@ function handleMainWindowClose(event: Electron.Event): void {
   }
 }
 
+function syncMainWindowRoute(window?: BrowserWindow): void {
+  const route = mainWindowRouteFromURL(window?.webContents.getURL());
+  if (route) {
+    mainWindowRoute = route;
+  }
+}
+
+function mainWindowRouteFromURL(url?: string): "main" | "settings" | undefined {
+  if (!url) {
+    return undefined;
+  }
+  try {
+    const route = new URL(url).hash.replace(/^#\/?/u, "");
+    if (route === "main" || route === "settings") {
+      return route;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 function showMainWindow(route: "main" | "settings"): void {
   const window = createMainWindow(route);
-  if (mainWindowRoute !== route) {
+  const currentRoute = mainWindowRouteFromURL(window.webContents.getURL()) ?? mainWindowRoute;
+  if (currentRoute !== route) {
     mainWindowRoute = route;
     void loadRenderer(window, route);
   }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -152,11 +152,7 @@ function App() {
       onToolbarSearchOpenChange={setToolbarSearchOpen}
       onOpenSettings={() => {
         setToolbarSearchOpen(false);
-        if (route === "menubar") {
-          void window.baseline.showSettings();
-        } else {
-          window.location.hash = "/settings";
-        }
+        void window.baseline.showSettings();
       }}
     />
   );
@@ -473,7 +469,7 @@ function Sidebar({
           className={route === "settings" ? "selected" : ""}
           onClick={() => {
             onNavigate?.();
-            window.location.hash = "/settings";
+            void window.baseline.showSettings();
           }}
         >
           <Settings size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -2427,7 +2423,10 @@ function SettingsSidebar({
   return (
     <aside className="sidebar settings-sidebar">
       <div className="settings-sidebar-header">
-        <button className="back-to-app-button" onClick={() => (window.location.hash = "/main")}>
+        <button
+          className="back-to-app-button"
+          onClick={() => void window.baseline.showMainWindow()}
+        >
           <ArrowLeft size={15} strokeWidth={sidebarIconStrokeWidth} />
           <span>Back to app</span>
         </button>


### PR DESCRIPTION
## Summary
- Run BrowserWindow construction, renderer loading, and listener wiring only when creating a new main or menu window.
- Track the active main-window route and sync it from the actual window URL so repeated show requests do not reload the same route while Settings/Main transitions remain correct.
- Route top-level Main and Settings navigation through the typed preload bridge instead of renderer-only hash writes.
- Add Electron regressions covering repeated main-window show requests and reopening Settings after Back to app navigation.

Fixes #100

## Validation
- npm run typecheck
- npm test -- --run ElectronTests/rendererButtons.test.tsx
- npm run build
- npx playwright test e2e/electron-smoke.spec.ts -g "reuses the main window without duplicate setup|reopens settings after renderer-side back navigation"
