### PR TITLE
Keep hidden app-backed casks out of brew batch updates

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -973,6 +973,11 @@ describe("renderer button parity", () => {
     expect(screen.getByText("14.1.0")).toBeInTheDocument();
     expect(screen.getByText("9.0.0")).toBeInTheDocument();
     expect(screen.getByText("10.0.0")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Update Brews" }));
+    expect(window.baseline.performHomebrewUpdateAll).toHaveBeenCalledWith([
+      "formula:fd",
+      "formula:ripgrep"
+    ]);
   });
 
   it("renders the Homebrew tab outdated section as a card grid", () => {
@@ -1035,6 +1040,46 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("Cask")).not.toBeInTheDocument();
     expect(screen.queryByText("1.0.0")).not.toBeInTheDocument();
     expect(screen.queryByText("2.0.0")).not.toBeInTheDocument();
+  });
+
+  it("updates the Homebrew rows currently visible in search results", () => {
+    const searchCask: HomebrewManagedItem = {
+      ...cask,
+      id: "cask:example-cli",
+      token: "example-cli",
+      name: "Example CLI"
+    };
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep-cli",
+      token: "ripgrep-cli",
+      name: "ripgrep-cli",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    };
+    render(
+      <Dashboard
+        compact={false}
+        toolbarSearchOpen
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          searchText: "cli",
+          updates: [{ ...update, homebrewToken: searchCask.token }],
+          homebrewItems: [searchCask, formula]
+        })}
+      />
+    );
+
+    expect(screen.getByText("Example CLI")).toBeInTheDocument();
+    expect(screen.queryByText("App Updates")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Brews" }));
+
+    expect(window.baseline.performHomebrewUpdateAll).toHaveBeenCalledWith([
+      searchCask.id,
+      formula.id
+    ]);
   });
 
   it("moves installed apps and Homebrew into the Installed sidebar item", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1082,6 +1082,40 @@ describe("renderer button parity", () => {
     ]);
   });
 
+  it("hides ignored app-backed Homebrew casks from search results", () => {
+    const searchCask: HomebrewManagedItem = {
+      ...cask,
+      id: "cask:example-cli",
+      token: "example-cli",
+      name: "Example CLI"
+    };
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep-cli",
+      token: "ripgrep-cli",
+      name: "ripgrep-cli",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    };
+    render(
+      <Dashboard
+        compact={false}
+        toolbarSearchOpen
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          searchText: "cli",
+          ignoredIDs: [app.id],
+          updates: [{ ...update, homebrewToken: searchCask.token }],
+          homebrewItems: [searchCask, formula]
+        })}
+      />
+    );
+
+    expect(screen.queryByText("Example CLI")).not.toBeInTheDocument();
+    expect(screen.getByText("ripgrep-cli")).toBeInTheDocument();
+  });
+
   it("moves installed apps and Homebrew into the Installed sidebar item", () => {
     const installedApp: AppRecord = {
       ...app,

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1049,6 +1049,60 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("excludes hidden app-backed casks from batch Homebrew updates", async () => {
+    const ignoredApp = appRecord({
+      bundlePath: "/Applications/Managed.app",
+      displayName: "Managed",
+      bundleIdentifier: "com.example.managed",
+      localVersion: version("1.0.0")
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({
+      success: true,
+      status: 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [ignoredApp],
+        ignoredIDs: [ignoredApp.id],
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:managed",
+            token: "managed",
+            name: "Managed",
+            kind: "cask",
+            appID: ignoredApp.id,
+            installedVersion: version("1.0.0"),
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            installedVersion: version("14.0.0"),
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+  });
+
   it("does not run Homebrew maintenance when every outdated item is ignored", async () => {
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1103,6 +1103,80 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("uses a caller-provided visible Homebrew batch scope", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Managed.app",
+      displayName: "Managed",
+      bundleIdentifier: "com.example.managed",
+      localVersion: version("1.0.0")
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({
+      success: true,
+      status: 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "homebrew",
+            supportLevel: "supported",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            homebrewToken: "managed-cli",
+            checkedAt: "2026-04-30T12:00:00.000Z"
+          }
+        ],
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:managed-cli",
+            token: "managed-cli",
+            name: "Managed CLI",
+            kind: "cask",
+            installedVersion: version("1.0.0"),
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            installedVersion: version("14.0.0"),
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "formula:fd",
+            token: "fd",
+            name: "fd",
+            kind: "formula",
+            installedVersion: version("9.0.0"),
+            latestVersion: version("10.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll(["cask:managed-cli", "formula:ripgrep"]);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["upgrade", "--cask", "--greedy", "managed-cli"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+  });
+
   it("does not run Homebrew maintenance when every outdated item is ignored", async () => {
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1177,6 +1177,60 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("excludes ignored app-backed casks from caller-provided Homebrew batch scopes", async () => {
+    const ignoredApp = appRecord({
+      bundlePath: "/Applications/Managed.app",
+      displayName: "Managed",
+      bundleIdentifier: "com.example.managed",
+      localVersion: version("1.0.0")
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({
+      success: true,
+      status: 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [ignoredApp],
+        ignoredIDs: [ignoredApp.id],
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:managed-cli",
+            token: "managed-cli",
+            name: "Managed CLI",
+            kind: "cask",
+            appID: ignoredApp.id,
+            installedVersion: version("1.0.0"),
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            installedVersion: version("14.0.0"),
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll(["cask:managed-cli", "formula:ripgrep"]);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+  });
+
   it("does not run Homebrew maintenance when every outdated item is ignored", async () => {
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -378,7 +378,11 @@ function wireIpc(): void {
   ipcMain.handle(ipcChannels.performHomebrewUpdate, (_event, itemID: string) =>
     store.performHomebrewUpdate(String(itemID))
   );
-  ipcMain.handle(ipcChannels.performHomebrewUpdateAll, () => store.performHomebrewUpdateAll());
+  ipcMain.handle(ipcChannels.performHomebrewUpdateAll, (_event, itemIDs?: unknown) =>
+    store.performHomebrewUpdateAll(
+      Array.isArray(itemIDs) ? itemIDs.map((itemID) => String(itemID)) : undefined
+    )
+  );
   ipcMain.handle(ipcChannels.installHomebrewItem, (_event, item: HomebrewCaskDiscoveryItem) =>
     store.installHomebrewItem(item)
   );

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -23,7 +23,8 @@ const api: BaselineAPI = {
   performAppUpdate: (appID: string) => ipcRenderer.invoke(ipcChannels.performAppUpdate, appID),
   performHomebrewUpdate: (itemID: string) =>
     ipcRenderer.invoke(ipcChannels.performHomebrewUpdate, itemID),
-  performHomebrewUpdateAll: () => ipcRenderer.invoke(ipcChannels.performHomebrewUpdateAll),
+  performHomebrewUpdateAll: (itemIDs?: string[]) =>
+    ipcRenderer.invoke(ipcChannels.performHomebrewUpdateAll, itemIDs),
   installHomebrewItem: (item: HomebrewCaskDiscoveryItem) =>
     ipcRenderer.invoke(ipcChannels.installHomebrewItem, item),
   uninstallHomebrewItem: (itemID: string) =>

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -365,21 +365,24 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
   }
 
-  async performHomebrewUpdateAll(): Promise<void> {
+  async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
     if (this.state.isRunningHomebrewMaintenance) {
       return;
     }
 
+    const requestedItemIDs = itemIDs ? new Set(itemIDs) : undefined;
     const updatesByAppID = new Map(this.state.updates.map((update) => [update.appID, update]));
     const appsRepresentedOutsideHomebrew = this.state.apps.filter(
       (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
     );
     const affected = this.state.homebrewItems.filter(
       (item) =>
+        (!requestedItemIDs || requestedItemIDs.has(item.id)) &&
         item.isOutdated &&
         !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
         isValidHomebrewToken(item.token) &&
-        !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
+        (requestedItemIDs !== undefined ||
+          !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID))
     );
     if (affected.length === 0) {
       return;

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -375,14 +375,18 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     const appsRepresentedOutsideHomebrew = this.state.apps.filter(
       (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
     );
+    const ignoredApps = this.state.apps.filter((app) => this.state.ignoredIDs.includes(app.id));
     const affected = this.state.homebrewItems.filter(
       (item) =>
         (!requestedItemIDs || requestedItemIDs.has(item.id)) &&
         item.isOutdated &&
         !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
         isValidHomebrewToken(item.token) &&
-        (requestedItemIDs !== undefined ||
-          !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID))
+        !homebrewItemHasAppRepresentation(
+          item,
+          requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew,
+          updatesByAppID
+        )
     );
     if (affected.length === 0) {
       return;

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -30,6 +30,7 @@ import {
   HomebrewMaintenanceProgressStage,
   type HomebrewMaintenanceRunEvent
 } from "../shared/homebrewProgress";
+import { homebrewItemHasAppRepresentation } from "../shared/homebrewAppLinking";
 import type { PreferencePatch } from "../shared/ipc";
 import { isAllowedExternalURL, isValidHomebrewToken } from "../shared/security";
 import { compareVersions, isVersionEmpty, isVersionGreater } from "../shared/version";
@@ -369,11 +370,16 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return;
     }
 
+    const updatesByAppID = new Map(this.state.updates.map((update) => [update.appID, update]));
+    const appsRepresentedOutsideHomebrew = this.state.apps.filter(
+      (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
+    );
     const affected = this.state.homebrewItems.filter(
       (item) =>
         item.isOutdated &&
         !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
-        isValidHomebrewToken(item.token)
+        isValidHomebrewToken(item.token) &&
+        !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
     );
     if (affected.length === 0) {
       return;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -790,7 +790,7 @@ function AllUpdatesSection({
               }
               readyLabel="Update Brews"
               readyVariant="outline"
-              onAction={() => void window.baseline.performHomebrewUpdateAll()}
+              onAction={() => performHomebrewUpdateAllForItems(derived.allHomebrewOutdated)}
             />
           ) : undefined
         }
@@ -1621,7 +1621,7 @@ export function HomebrewSection({
               }
               readyLabel="Update Brews"
               readyVariant="outline"
-              onAction={() => void window.baseline.performHomebrewUpdateAll()}
+              onAction={() => performHomebrewUpdateAllForItems(items)}
             />
           ) : undefined
         }
@@ -2943,6 +2943,10 @@ function compareRecentRows(
 
 function combinedAvailableCount(derived: DerivedSections): number {
   return derived.availableApps.length + derived.allHomebrewOutdated.length;
+}
+
+function performHomebrewUpdateAllForItems(items: Pick<HomebrewManagedItem, "id">[]): void {
+  void window.baseline.performHomebrewUpdateAll(items.map((item) => item.id));
 }
 
 function toggleCollapsedSection(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3008,8 +3008,9 @@ function deriveSections(snapshot: BaselineSnapshot) {
     .filter((item) => item.isOutdated && !snapshot.ignoredHomebrewItemIDs.includes(item.id))
     .filter(homebrewFilter)
     .sort(sortHomebrewOutdated);
+  const ignoredAppsUnfiltered = snapshot.apps.filter((app) => snapshot.ignoredIDs.includes(app.id));
   const appsRepresentedOutsideHomebrew = term
-    ? [...availableApps, ...ignoredApps]
+    ? [...availableApps, ...ignoredAppsUnfiltered]
     : snapshot.apps.filter(
         (app) => updatesByAppID.has(app.id) || snapshot.ignoredIDs.includes(app.id)
       );

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -66,7 +66,7 @@ export type BaselineAPI = {
   toggleIgnoredHomebrew(itemID: string): Promise<void>;
   performAppUpdate(appID: string): Promise<void>;
   performHomebrewUpdate(itemID: string): Promise<void>;
-  performHomebrewUpdateAll(): Promise<void>;
+  performHomebrewUpdateAll(itemIDs?: string[]): Promise<void>;
   installHomebrewItem(item: HomebrewCaskDiscoveryItem): Promise<void>;
   uninstallHomebrewItem(itemID: string): Promise<void>;
   openApp(appID: string): Promise<void>;


### PR DESCRIPTION
## Summary
- Scope `Update Brews` batch requests to the Homebrew rows currently shown by the renderer.
- Keep hidden app-backed casks out of unscoped batch maintenance, and keep ignored app-backed casks hidden from search-backed batch scopes.
- Add store and renderer regressions for ignored app-backed casks, visible scoped casks, and search result batch behavior.

Fixes #102

## Validation
- npm test -- --run ElectronTests/updateStore.test.ts ElectronTests/rendererButtons.test.tsx
- npm run typecheck
- GitHub Actions CI: Build and test on macos-14, macos-15, macos-15-intel, macos-26, and macos-26-intel
