### PR TITLE
Detect Sparkle updates when build versions advance

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -123,6 +123,26 @@ describe("bundle scanner", () => {
     expect(records.map((record) => record.displayName)).toEqual(["Manifested"]);
   });
 
+  it("keeps the bundle build version alongside the marketing version", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    await writeAppPlist(path.join(root, "Build Versioned.app"), {
+      displayName: "Build Versioned",
+      bundleIdentifier: "com.example.build-versioned",
+      version: "1.0",
+      extraKeys: ["  <key>CFBundleVersion</key>", "  <string>100</string>"].join("\n")
+    });
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      displayName: "Build Versioned",
+      localVersion: { raw: "1.0" },
+      bundleVersion: { raw: "100" }
+    });
+  });
+
   it("detects grayscale icon conversion output", () => {
     expect(testingExports.isGrayscaleSipsOutput("  space: Gray\n")).toBe(true);
     expect(testingExports.isGrayscaleSipsOutput("  space: RGB\n")).toBe(false);

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -43,6 +43,7 @@ describe("ported clients", () => {
 
     const result = new SparkleAppcastClient().parseAppcast(data, version("1.0"), version("100"));
     expect(result?.remoteVersion.raw).toBe("1.0");
+    expect(result?.remoteBuildVersion?.raw).toBe("101");
     expect(result?.updateURL).toBe("https://example.com/download/1.0-build-101.zip");
     expect(
       new SparkleAppcastClient().parseAppcast(data, version("1.0"), version("101"))

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -28,6 +28,27 @@ describe("ported clients", () => {
     expect(result?.updateURL).toBe("https://example.com/download/2.0.0.zip");
   });
 
+  it("detects Sparkle updates when only the build version advances", () => {
+    const data = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0-build-101.zip"
+        sparkle:version="101"
+        sparkle:shortVersionString="1.0" />
+    </item>
+  </channel>
+</rss>`);
+
+    const result = new SparkleAppcastClient().parseAppcast(data, version("1.0"), version("100"));
+    expect(result?.remoteVersion.raw).toBe("1.0");
+    expect(result?.updateURL).toBe("https://example.com/download/1.0-build-101.zip");
+    expect(
+      new SparkleAppcastClient().parseAppcast(data, version("1.0"), version("101"))
+    ).toBeUndefined();
+  });
+
   it("parses Homebrew cask schema drift fixtures", () => {
     const data = readFileSync(path.join(fixtures, "homebrew_cask_drift.json"));
     const index = new HomebrewCaskClient().parseIndex(data);

--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -131,6 +131,19 @@ describe("snapshot persistence", () => {
       ...defaultPersistedSnapshot(),
       ignoredIDs: ["app:ignored"],
       ignoredHomebrewItemIDs: ["formula:ripgrep"],
+      updates: [
+        {
+          id: "app:example",
+          appID: "app:example",
+          source: "sparkle",
+          supportLevel: "limited",
+          localVersion: version("1.0.0"),
+          remoteVersion: version("1.0.0"),
+          localBuildVersion: version("100"),
+          remoteBuildVersion: version("101"),
+          checkedAt: "2026-04-30T12:00:00.000Z"
+        }
+      ],
       recentlyUpdated: [
         {
           id: "app:example",
@@ -139,6 +152,8 @@ describe("snapshot persistence", () => {
           source: "sparkle",
           fromVersion: version("1.0.0"),
           toVersion: version("2.0.0"),
+          fromBuildVersion: version("100"),
+          toBuildVersion: version("101"),
           updatedAt: "2026-04-30T12:00:00.000Z"
         }
       ],
@@ -159,12 +174,24 @@ describe("snapshot persistence", () => {
     await expect(persistence.load()).resolves.toMatchObject({
       ignoredIDs: ["app:ignored"],
       ignoredHomebrewItemIDs: ["formula:ripgrep"],
+      updates: [
+        {
+          appID: "app:example",
+          source: "sparkle",
+          localVersion: { raw: "1.0.0" },
+          remoteVersion: { raw: "1.0.0" },
+          localBuildVersion: { raw: "100" },
+          remoteBuildVersion: { raw: "101" }
+        }
+      ],
       recentlyUpdated: [
         {
           appID: "app:example",
           source: "sparkle",
           fromVersion: { raw: "1.0.0" },
-          toVersion: { raw: "2.0.0" }
+          toVersion: { raw: "2.0.0" },
+          fromBuildVersion: { raw: "100" },
+          toBuildVersion: { raw: "101" }
         }
       ],
       homebrewRecentlyUpdated: [

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -146,6 +146,38 @@ describe("renderer button parity", () => {
     expect(window.baseline.performAppUpdate).not.toHaveBeenCalled();
   });
 
+  it("shows Sparkle build-only update versions in app rows", () => {
+    const buildOnlyApp = {
+      ...app,
+      bundleVersion: version("100")
+    };
+    render(
+      <AppRow
+        app={buildOnlyApp}
+        snapshot={snapshot({
+          apps: [buildOnlyApp],
+          updates: [
+            {
+              id: buildOnlyApp.id,
+              appID: buildOnlyApp.id,
+              source: "sparkle",
+              supportLevel: "limited",
+              localVersion: version("1.0"),
+              remoteVersion: version("1.0"),
+              localBuildVersion: version("100"),
+              remoteBuildVersion: version("101"),
+              checkedAt: "2026-04-30T12:00:00.000Z"
+            }
+          ]
+        })}
+        recentlyUpdated={false}
+      />
+    );
+
+    expect(screen.getByText("1.0 (100)")).toBeInTheDocument();
+    expect(screen.getByText("1.0 (101)")).toBeInTheDocument();
+  });
+
   it("shows matched Homebrew cask progress on app update buttons", () => {
     render(
       <AppRow

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -435,6 +435,67 @@ describe("update store helpers", () => {
     });
   });
 
+  it("preserves Sparkle build-only update versions through update and recent history", async () => {
+    const installedApp = appRecord({
+      bundlePath: "/Applications/Build Only.app",
+      displayName: "Build Only",
+      bundleIdentifier: "com.example.build-only",
+      sparkleFeedURL: "https://updates.example.com/appcast.xml",
+      localVersion: version("1.0"),
+      bundleVersion: version("100")
+    });
+    const refreshedApp = {
+      ...installedApp,
+      bundleVersion: version("101")
+    };
+    let scanCount = 0;
+    const store = await makeStore({
+      clients: {
+        scanner: {
+          scanApplications: async () => {
+            scanCount += 1;
+            return scanCount === 1 ? [installedApp] : [refreshedApp];
+          }
+        },
+        appStore: { lookupOutcome: async () => ({ type: "completed" }) },
+        sparkle: {
+          lookupOutcome: async () =>
+            scanCount === 1
+              ? {
+                  type: "completed",
+                  value: {
+                    remoteVersion: version("1.0"),
+                    remoteBuildVersion: version("101"),
+                    updateURL: "https://updates.example.com/download"
+                  }
+                }
+              : { type: "completed" }
+        }
+      }
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().updates[0]).toMatchObject({
+      source: "sparkle",
+      localVersion: version("1.0"),
+      remoteVersion: version("1.0"),
+      localBuildVersion: version("100"),
+      remoteBuildVersion: version("101")
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().updates).toEqual([]);
+    expect(store.getSnapshot().recentlyUpdated[0]).toMatchObject({
+      source: "sparkle",
+      fromVersion: version("1.0"),
+      toVersion: version("1.0"),
+      fromBuildVersion: version("100"),
+      toBuildVersion: version("101")
+    });
+  });
+
   it("surfaces unreliable Homebrew outdated detection and preserves previous outdated items", async () => {
     const previousItem = homebrewItem({
       id: "formula:ripgrep",

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -96,8 +96,8 @@ export class BundleScannerClient {
       stringValue(info.CFBundleName) ??
       path.basename(appPath, ".app");
     const bundleIdentifier = stringValue(info.CFBundleIdentifier);
-    const rawVersion =
-      stringValue(info.CFBundleShortVersionString) ?? stringValue(info.CFBundleVersion);
+    const rawBundleVersion = stringValue(info.CFBundleVersion);
+    const rawVersion = stringValue(info.CFBundleShortVersionString) ?? rawBundleVersion;
     const sparkleFeedURL = this.sparkleFeedURL(info);
     const sourceHint: UpdateSource = (await this.hasMasReceipt(appPath))
       ? "appStore"
@@ -111,6 +111,7 @@ export class BundleScannerClient {
       displayName,
       bundleIdentifier,
       localVersion: version(rawVersion),
+      bundleVersion: rawBundleVersion ? version(rawBundleVersion) : undefined,
       sourceHint,
       sparkleFeedURL,
       iconDataURL: await this.appIconDataURL(appPath)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -39,7 +39,8 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
     apps: (input.apps ?? []).map((app) => ({
       ...app,
       id: app.id ?? app.bundlePath,
-      localVersion: version(app.localVersion?.raw)
+      localVersion: version(app.localVersion?.raw),
+      bundleVersion: app.bundleVersion ? version(app.bundleVersion.raw) : undefined
     })),
     updates: (input.updates ?? []).map((update) => ({
       ...update,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -46,13 +46,21 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
       ...update,
       id: update.id ?? update.appID,
       localVersion: version(update.localVersion?.raw),
-      remoteVersion: version(update.remoteVersion?.raw)
+      remoteVersion: version(update.remoteVersion?.raw),
+      localBuildVersion: update.localBuildVersion
+        ? version(update.localBuildVersion.raw)
+        : undefined,
+      remoteBuildVersion: update.remoteBuildVersion
+        ? version(update.remoteBuildVersion.raw)
+        : undefined
     })),
     recentlyUpdated: (input.recentlyUpdated ?? []).map((record) => ({
       ...record,
       id: record.id ?? record.appID,
       fromVersion: version(record.fromVersion?.raw),
-      toVersion: version(record.toVersion?.raw)
+      toVersion: version(record.toVersion?.raw),
+      fromBuildVersion: record.fromBuildVersion ? version(record.fromBuildVersion.raw) : undefined,
+      toBuildVersion: record.toBuildVersion ? version(record.toBuildVersion.raw) : undefined
     })),
     homebrewItems: (input.homebrewItems ?? []).map((item) => ({
       ...item,

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -93,6 +93,7 @@ export class SparkleAppcastClient {
 
     return {
       remoteVersion: best.parsedVersion,
+      remoteBuildVersion: isVersionEmpty(best.buildVersion) ? undefined : best.buildVersion,
       updateURL,
       releaseNotesURL,
       releaseDate: best.item.publicationDate

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -4,7 +4,13 @@
 import { XMLParser } from "fast-xml-parser";
 import type { SparkleLookupResult } from "../shared/domain";
 import { byteLimits, isAllowedFeedURL, sanitizeExternalURL } from "../shared/security";
-import { isVersionEmpty, isVersionGreater, type VersionValue, version } from "../shared/version";
+import {
+  compareVersions,
+  isVersionEmpty,
+  isVersionGreater,
+  type VersionValue,
+  version
+} from "../shared/version";
 import type { LookupOutcome } from "./appStoreLookupClient";
 
 type AppcastItem = {
@@ -24,7 +30,8 @@ const parser = new XMLParser({
 export class SparkleAppcastClient {
   async lookupOutcome(
     feedURL: string,
-    localVersion: VersionValue
+    localVersion: VersionValue,
+    localBuildVersion?: VersionValue
   ): Promise<LookupOutcome<SparkleLookupResult>> {
     if (!isAllowedFeedURL(feedURL)) {
       return { type: "completed" };
@@ -39,13 +46,20 @@ export class SparkleAppcastClient {
       if (buffer.byteLength > byteLimits.sparkleAppcastMaxBytes) {
         return { type: "completed" };
       }
-      return { type: "completed", value: this.parseAppcast(buffer, localVersion) };
+      return {
+        type: "completed",
+        value: this.parseAppcast(buffer, localVersion, localBuildVersion)
+      };
     } catch {
       return { type: "transientFailure" };
     }
   }
 
-  parseAppcast(data: Buffer, localVersion: VersionValue): SparkleLookupResult | undefined {
+  parseAppcast(
+    data: Buffer,
+    localVersion: VersionValue,
+    localBuildVersion?: VersionValue
+  ): SparkleLookupResult | undefined {
     if (data.byteLength > byteLimits.sparkleAppcastMaxBytes) {
       return undefined;
     }
@@ -61,14 +75,13 @@ export class SparkleAppcastClient {
     const best = items
       .map((item) => ({
         item,
+        buildVersion: version(item.buildVersion),
         parsedVersion: version(item.shortVersionString ?? item.buildVersion)
       }))
       .filter(({ parsedVersion }) => !isVersionEmpty(parsedVersion))
-      .sort(
-        (lhs, rhs) => -1 * (isVersionGreater(lhs.parsedVersion, rhs.parsedVersion) ? 1 : -1)
-      )[0];
+      .sort((lhs, rhs) => -1 * compareAppcastItems(lhs, rhs))[0];
 
-    if (!best || !isVersionGreater(best.parsedVersion, localVersion)) {
+    if (!best || !isAppcastItemNewer(best, localVersion, localBuildVersion)) {
       return undefined;
     }
 
@@ -85,6 +98,37 @@ export class SparkleAppcastClient {
       releaseDate: best.item.publicationDate
     };
   }
+}
+
+function compareAppcastItems(
+  lhs: { parsedVersion: VersionValue; buildVersion: VersionValue },
+  rhs: { parsedVersion: VersionValue; buildVersion: VersionValue }
+): number {
+  const versionComparison = compareVersions(lhs.parsedVersion, rhs.parsedVersion);
+  if (versionComparison !== 0) {
+    return versionComparison;
+  }
+  return compareVersions(lhs.buildVersion, rhs.buildVersion);
+}
+
+function isAppcastItemNewer(
+  item: { parsedVersion: VersionValue; buildVersion: VersionValue },
+  localVersion: VersionValue,
+  localBuildVersion?: VersionValue
+): boolean {
+  const marketingVersionComparison = compareVersions(item.parsedVersion, localVersion);
+  if (marketingVersionComparison > 0) {
+    return true;
+  }
+  if (
+    marketingVersionComparison < 0 ||
+    !localBuildVersion ||
+    isVersionEmpty(localBuildVersion) ||
+    isVersionEmpty(item.buildVersion)
+  ) {
+    return false;
+  }
+  return isVersionGreater(item.buildVersion, localBuildVersion);
 }
 
 function normalizeItem(item: any): AppcastItem {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -588,7 +588,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         if (appRecord.sparkleFeedURL) {
           const outcome = await this.sparkle.lookupOutcome(
             appRecord.sparkleFeedURL,
-            appRecord.localVersion
+            appRecord.localVersion,
+            appRecord.bundleVersion
           );
           if (outcome.type === "completed" && outcome.value) {
             updates.push({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -599,6 +599,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
               supportLevel: "limited",
               localVersion: appRecord.localVersion,
               remoteVersion: outcome.value.remoteVersion,
+              localBuildVersion: appRecord.bundleVersion,
+              remoteBuildVersion: outcome.value.remoteBuildVersion,
               updateURL: outcome.value.updateURL,
               releaseNotesURL: outcome.value.releaseNotesURL,
               releaseDate: outcome.value.releaseDate,
@@ -909,6 +911,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         source: previousUpdate.source,
         fromVersion: previousUpdate.localVersion,
         toVersion: appRecord.localVersion,
+        fromBuildVersion: previousUpdate.localBuildVersion,
+        toBuildVersion: previousUpdate.localBuildVersion ? appRecord.bundleVersion : undefined,
         updatedAt: now
       });
     }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -54,6 +54,7 @@ import {
   isCask,
   normalizedHomebrewAppName
 } from "../shared/homebrewAppLinking";
+import { compareVersions } from "../shared/version";
 import "./styles.css";
 
 type Route = "main" | "menubar" | "settings";
@@ -1011,8 +1012,8 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
         <p>
           {update ? (
             <VersionChange
-              from={app.localVersion.raw || "unknown"}
-              to={update.remoteVersion.raw || "unknown"}
+              from={appUpdateVersionChange(update).from}
+              to={appUpdateVersionChange(update).to}
             />
           ) : (
             app.localVersion.raw || "unknown"
@@ -1294,8 +1295,8 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
         <p>
           {update ? (
             <VersionChange
-              from={app.localVersion.raw || "unknown"}
-              to={update.remoteVersion.raw || "unknown"}
+              from={appUpdateVersionChange(update).from}
+              to={appUpdateVersionChange(update).to}
             />
           ) : (
             app.localVersion.raw || "unknown"
@@ -1357,8 +1358,8 @@ export function AppRow({
         <p>
           {update ? (
             <VersionChange
-              from={app.localVersion.raw || "unknown"}
-              to={update.remoteVersion.raw || "unknown"}
+              from={appUpdateVersionChange(update).from}
+              to={appUpdateVersionChange(update).to}
             />
           ) : recentlyUpdatedAt ? (
             updatedRelativeLabel(recentlyUpdatedAt)
@@ -2829,6 +2830,34 @@ function VersionChange({ from, to }: { from: string; to: string }) {
       <span className="version-token">{to}</span>
     </>
   );
+}
+
+function appUpdateVersionChange(update: UpdateRecord): { from: string; to: string } {
+  if (shouldShowAppBuildVersion(update)) {
+    return {
+      from: versionLabelWithBuild(update.localVersion.raw, update.localBuildVersion?.raw),
+      to: versionLabelWithBuild(update.remoteVersion.raw, update.remoteBuildVersion?.raw)
+    };
+  }
+  return {
+    from: update.localVersion.raw || "unknown",
+    to: update.remoteVersion.raw || "unknown"
+  };
+}
+
+function shouldShowAppBuildVersion(update: UpdateRecord): boolean {
+  return Boolean(
+    update.localBuildVersion?.raw.trim() &&
+    update.remoteBuildVersion?.raw.trim() &&
+    compareVersions(update.localVersion, update.remoteVersion) === 0 &&
+    compareVersions(update.localBuildVersion, update.remoteBuildVersion) !== 0
+  );
+}
+
+function versionLabelWithBuild(versionRaw: string, buildRaw?: string): string {
+  const displayVersion = versionRaw.trim() || "unknown";
+  const buildVersion = buildRaw?.trim();
+  return buildVersion ? `${displayVersion} (${buildVersion})` : displayVersion;
 }
 
 function ToolStatus({

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -16,6 +16,7 @@ export type AppRecord = {
   displayName: string;
   bundleIdentifier?: string;
   localVersion: VersionValue;
+  bundleVersion?: VersionValue;
   sourceHint: UpdateSource;
   sparkleFeedURL?: string;
   iconDataURL?: string;

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -32,6 +32,7 @@ export type AppStoreLookupResult = {
 
 export type SparkleLookupResult = {
   remoteVersion: VersionValue;
+  remoteBuildVersion?: VersionValue;
   updateURL?: string;
   releaseNotesURL?: string;
   releaseDate?: string;
@@ -87,6 +88,8 @@ export type UpdateRecord = {
   supportLevel: SupportLevel;
   localVersion: VersionValue;
   remoteVersion: VersionValue;
+  localBuildVersion?: VersionValue;
+  remoteBuildVersion?: VersionValue;
   updateURL?: string;
   appStoreItemID?: number;
   homebrewToken?: string;
@@ -103,6 +106,8 @@ export type RecentlyUpdatedRecord = {
   source?: UpdateSource;
   fromVersion: VersionValue;
   toVersion: VersionValue;
+  fromBuildVersion?: VersionValue;
+  toBuildVersion?: VersionValue;
   updatedAt: string;
 };
 


### PR DESCRIPTION
## Summary
- Preserve `CFBundleVersion` on scanned app records alongside the marketing `localVersion`.
- Pass bundle build versions into Sparkle lookup and treat a higher appcast `sparkle:version` as an update when the marketing version is unchanged.
- Carry Sparkle build versions through update records, persistence, recently updated history, and app update labels so build-only updates render with the actual build delta.
- Add regressions for scanner build-version retention, Sparkle build-only detection, update-store history, persistence, and renderer display.

Fixes #104

## Validation
- npm run typecheck
- npm test -- --run ElectronTests/clients.test.ts ElectronTests/bundleScanner.test.ts
- npm test -- ElectronTests/clients.test.ts ElectronTests/updateStore.test.ts ElectronTests/persistence.test.ts ElectronTests/rendererButtons.test.tsx
- npm run lint
- GitHub Actions CI passed
