### PR TITLE
Add self-update toolbar shortcut

### DIFF
--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -3,11 +3,12 @@
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AppStoreLookupClient } from "../src/main/appStoreLookupClient";
 import { HomebrewCaskClient } from "../src/main/homebrewCaskClient";
 import { HomebrewFormulaClient } from "../src/main/homebrewFormulaClient";
 import { HomebrewInventoryParser } from "../src/main/homebrewInventoryClient";
+import { SelfUpdateClient } from "../src/main/selfUpdateClient";
 import { SparkleAppcastClient } from "../src/main/sparkleAppcastClient";
 import { version } from "../src/shared/version";
 
@@ -432,5 +433,31 @@ describe("ported clients", () => {
     const cursor = inventory.find((item) => item.token === "cursor");
     expect(cursor?.installedVersion.raw).toBe("3.2.11");
     expect(cursor?.latestVersion?.raw).toBe("3.2.16");
+  });
+
+  it("compares GitHub latest release metadata for Baseline self-updates", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          tag_name: "v0.2.0",
+          html_url: "https://github.com/arshiaghaf/Baseline/releases/tag/v0.2.0"
+        }),
+        { status: 200 }
+      )
+    );
+
+    try {
+      await expect(
+        new SelfUpdateClient().lookup(version("0.1.0"), "2026-05-31T12:00:00.000Z")
+      ).resolves.toMatchObject({
+        available: true,
+        currentVersion: version("0.1.0"),
+        latestVersion: version("v0.2.0"),
+        releaseURL: "https://github.com/arshiaghaf/Baseline/releases/tag/v0.2.0",
+        checkedAt: "2026-05-31T12:00:00.000Z"
+      });
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 });

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -460,4 +460,28 @@ describe("ported clients", () => {
       fetchMock.mockRestore();
     }
   });
+
+  it("does not offer self-updates to prerelease development builds for the same release", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          tag_name: "v0.2.0",
+          html_url: "https://github.com/arshiaghaf/Baseline/releases/tag/v0.2.0"
+        }),
+        { status: 200 }
+      )
+    );
+
+    try {
+      await expect(
+        new SelfUpdateClient().lookup(version("0.2.0-beta.1"), "2026-05-31T12:00:00.000Z")
+      ).resolves.toMatchObject({
+        available: false,
+        currentVersion: version("0.2.0-beta.1"),
+        latestVersion: version("v0.2.0")
+      });
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
 });

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -461,7 +461,7 @@ describe("ported clients", () => {
     }
   });
 
-  it("does not offer self-updates to prerelease development builds for the same release", async () => {
+  it("does not offer self-updates when the local build is already at the release version", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -474,10 +474,34 @@ describe("ported clients", () => {
 
     try {
       await expect(
-        new SelfUpdateClient().lookup(version("0.2.0-beta.1"), "2026-05-31T12:00:00.000Z")
+        new SelfUpdateClient().lookup(version("0.2.0"), "2026-05-31T12:00:00.000Z")
       ).resolves.toMatchObject({
         available: false,
-        currentVersion: version("0.2.0-beta.1"),
+        currentVersion: version("0.2.0"),
+        latestVersion: version("v0.2.0")
+      });
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("does not offer self-updates when the local build is ahead of the latest release", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          tag_name: "v0.2.0",
+          html_url: "https://github.com/arshiaghaf/Baseline/releases/tag/v0.2.0"
+        }),
+        { status: 200 }
+      )
+    );
+
+    try {
+      await expect(
+        new SelfUpdateClient().lookup(version("0.3.0"), "2026-05-31T12:00:00.000Z")
+      ).resolves.toMatchObject({
+        available: false,
+        currentVersion: version("0.3.0"),
         latestVersion: version("v0.2.0")
       });
     } finally {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -247,6 +247,29 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
   });
 
+  it("shows the main-window self-update shortcut before search", () => {
+    const { container, rerender } = render(
+      <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={snapshot()} />
+    );
+    const toolbarButtons = within(container.querySelector(".topbar-actions") as HTMLElement)
+      .getAllByRole("button")
+      .map((button) => button.getAttribute("aria-label") ?? button.getAttribute("title"));
+
+    expect(toolbarButtons).toEqual(["New Baseline Update Available", "Search", "Refresh"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "New Baseline Update Available" }));
+
+    expect(window.baseline.openExternal).toHaveBeenCalledWith(
+      "https://github.com/arshiaghaf/Baseline/releases/latest"
+    );
+
+    rerender(<Dashboard compact onOpenSettings={() => undefined} snapshot={snapshot()} />);
+
+    expect(
+      screen.queryByRole("button", { name: "New Baseline Update Available" })
+    ).not.toBeInTheDocument();
+  });
+
   it("closes search mode on sidebar tab clicks without clearing the saved query", () => {
     const formula: HomebrewManagedItem = {
       id: "formula:obsidian-cli",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -32,6 +32,15 @@ const app: AppRecord = {
   sourceHint: "unknown"
 };
 
+const baselineApp: AppRecord = {
+  id: "app:baseline",
+  bundlePath: "/Applications/Baseline.app",
+  displayName: "Baseline",
+  bundleIdentifier: "com.arshiaghaf.baseline",
+  localVersion: version("0.1.0"),
+  sourceHint: "unknown"
+};
+
 const cask: HomebrewManagedItem = {
   id: "cask:example",
   token: "example",
@@ -50,6 +59,16 @@ const update: UpdateRecord = {
   localVersion: version("1.0.0"),
   remoteVersion: version("2.0.0"),
   homebrewToken: "example",
+  checkedAt: "2026-04-30T12:00:00.000Z"
+};
+
+const baselineUpdate: UpdateRecord = {
+  id: baselineApp.id,
+  appID: baselineApp.id,
+  source: "web",
+  supportLevel: "limited",
+  localVersion: version("0.1.0"),
+  remoteVersion: version("0.2.0"),
   checkedAt: "2026-04-30T12:00:00.000Z"
 };
 
@@ -119,6 +138,12 @@ function installBaselineMock() {
     onSnapshotChanged: vi.fn(() => () => undefined),
     onHomebrewCommandEvent: vi.fn(() => () => undefined)
   };
+}
+
+function toolbarButtonLabels(container: HTMLElement): Array<string | null> {
+  return within(container.querySelector(".topbar-actions") as HTMLElement)
+    .getAllByRole("button")
+    .map((button) => button.getAttribute("aria-label") ?? button.getAttribute("title"));
 }
 
 describe("renderer button parity", () => {
@@ -247,15 +272,29 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
   });
 
-  it("shows the main-window self-update shortcut before search", () => {
+  it("shows the main-window self-update shortcut only for Baseline updates", () => {
     const { container, rerender } = render(
       <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={snapshot()} />
     );
-    const toolbarButtons = within(container.querySelector(".topbar-actions") as HTMLElement)
-      .getAllByRole("button")
-      .map((button) => button.getAttribute("aria-label") ?? button.getAttribute("title"));
 
-    expect(toolbarButtons).toEqual(["New Baseline Update Available", "Search", "Refresh"]);
+    expect(toolbarButtonLabels(container)).toEqual(["Search", "Refresh"]);
+
+    rerender(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          apps: [app, baselineApp],
+          updates: [update, baselineUpdate]
+        })}
+      />
+    );
+
+    expect(toolbarButtonLabels(container)).toEqual([
+      "New Baseline Update Available",
+      "Search",
+      "Refresh"
+    ]);
 
     fireEvent.click(screen.getByRole("button", { name: "New Baseline Update Available" }));
 

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -32,15 +32,6 @@ const app: AppRecord = {
   sourceHint: "unknown"
 };
 
-const baselineApp: AppRecord = {
-  id: "app:baseline",
-  bundlePath: "/Applications/Baseline.app",
-  displayName: "Baseline",
-  bundleIdentifier: "com.arshiaghaf.baseline",
-  localVersion: version("0.1.0"),
-  sourceHint: "unknown"
-};
-
 const cask: HomebrewManagedItem = {
   id: "cask:example",
   token: "example",
@@ -59,16 +50,6 @@ const update: UpdateRecord = {
   localVersion: version("1.0.0"),
   remoteVersion: version("2.0.0"),
   homebrewToken: "example",
-  checkedAt: "2026-04-30T12:00:00.000Z"
-};
-
-const baselineUpdate: UpdateRecord = {
-  id: baselineApp.id,
-  appID: baselineApp.id,
-  source: "web",
-  supportLevel: "limited",
-  localVersion: version("0.1.0"),
-  remoteVersion: version("0.2.0"),
   checkedAt: "2026-04-30T12:00:00.000Z"
 };
 
@@ -272,7 +253,7 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
   });
 
-  it("shows the main-window self-update shortcut only for Baseline updates", () => {
+  it("shows the main-window self-update shortcut only when self-update is available", () => {
     const { container, rerender } = render(
       <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={snapshot()} />
     );
@@ -284,8 +265,13 @@ describe("renderer button parity", () => {
         compact={false}
         onOpenSettings={() => undefined}
         snapshot={snapshot({
-          apps: [app, baselineApp],
-          updates: [update, baselineUpdate]
+          selfUpdate: {
+            available: true,
+            currentVersion: version("0.1.0"),
+            latestVersion: version("0.2.0"),
+            releaseURL: "https://github.com/arshiaghaf/Baseline/releases/latest",
+            checkedAt: "2026-04-30T12:00:00.000Z"
+          }
         })}
       />
     );

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -347,6 +347,32 @@ describe("update store helpers", () => {
     expect(inventoryOptions).toEqual([{ updateMetadata: true }, { updateMetadata: false }]);
   });
 
+  it("surfaces GitHub release self-update availability during refresh", async () => {
+    const lookup = vi.fn(async (currentVersion: ReturnType<typeof version>, checkedAt: string) => ({
+      available: true,
+      currentVersion,
+      latestVersion: version("0.2.0"),
+      releaseURL: "https://github.com/arshiaghaf/Baseline/releases/latest",
+      checkedAt
+    }));
+    const store = await makeStore({
+      currentAppVersion: "0.1.0",
+      clients: {
+        selfUpdate: { lookup }
+      }
+    });
+
+    await store.refresh(false);
+
+    expect(lookup).toHaveBeenCalledWith(version("0.1.0"), expect.any(String));
+    expect(store.getSnapshot().selfUpdate).toMatchObject({
+      available: true,
+      currentVersion: version("0.1.0"),
+      latestVersion: version("0.2.0"),
+      releaseURL: "https://github.com/arshiaghaf/Baseline/releases/latest"
+    });
+  });
+
   it("preserves App Store, Sparkle, then Homebrew update source precedence", async () => {
     const precedenceApp = appRecord({
       bundlePath: "/Applications/Precedence.app",
@@ -1471,6 +1497,7 @@ async function makeStore({
   runMasCommand = async () => ({ success: true, status: 0, output: "" }),
   openExternalURL = async () => true,
   openAppBundle = async () => undefined,
+  currentAppVersion,
   successRefreshDelayMS = 0,
   onUserData
 }: {
@@ -1480,6 +1507,7 @@ async function makeStore({
   runMasCommand?: ConstructorParameters<typeof UpdateStore>[0]["runMasCommand"];
   openExternalURL?: ConstructorParameters<typeof UpdateStore>[0]["openExternalURL"];
   openAppBundle?: ConstructorParameters<typeof UpdateStore>[0]["openAppBundle"];
+  currentAppVersion?: ConstructorParameters<typeof UpdateStore>[0]["currentAppVersion"];
   successRefreshDelayMS?: ConstructorParameters<typeof UpdateStore>[0]["successRefreshDelayMS"];
   onUserData?: (directory: string) => void;
 } = {}): Promise<UpdateStore> {
@@ -1491,6 +1519,7 @@ async function makeStore({
     persisted,
     openExternalURL,
     openAppBundle,
+    currentAppVersion,
     runBrewCommand,
     runMasCommand,
     successRefreshDelayMS,
@@ -1512,6 +1541,14 @@ async function makeStore({
           items: [],
           outdatedDetectionSucceeded: true,
           outdatedDetectionSucceededByKind: { formula: true, cask: true }
+        })
+      },
+      selfUpdate: {
+        lookup: async (currentVersion, checkedAt) => ({
+          available: false,
+          currentVersion,
+          releaseURL: "https://github.com/arshiaghaf/Baseline/releases/latest",
+          checkedAt
         })
       },
       ...clients

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -87,7 +87,8 @@ if (hasSingleInstanceLock) {
       },
       openAppBundle: async (bundlePath) => {
         await shell.openPath(bundlePath);
-      }
+      },
+      currentAppVersion: metadata.version
     });
 
     createMainWindow("main");

--- a/src/main/selfUpdateClient.ts
+++ b/src/main/selfUpdateClient.ts
@@ -3,7 +3,7 @@
 
 import type { SelfUpdateRecord } from "../shared/domain";
 import { sanitizeExternalURL } from "../shared/security";
-import { isVersionGreater, version, type VersionValue } from "../shared/version";
+import { compareVersions, version, type VersionValue } from "../shared/version";
 
 const latestReleaseURL = "https://api.github.com/repos/arshiaghaf/Baseline/releases/latest";
 const fallbackReleasePageURL = "https://github.com/arshiaghaf/Baseline/releases/latest";
@@ -25,7 +25,7 @@ export class SelfUpdateClient {
       const latestVersion = version(latestVersionString(raw));
       const releaseURL = sanitizeExternalURL(raw?.html_url) ?? fallbackReleasePageURL;
       return {
-        available: isVersionGreater(latestVersion, currentVersion),
+        available: isSelfUpdateAvailable(latestVersion, currentVersion),
         currentVersion,
         latestVersion,
         releaseURL,
@@ -39,6 +39,15 @@ export class SelfUpdateClient {
 
 function latestVersionString(raw: any): string {
   return typeof raw?.tag_name === "string" ? raw.tag_name : "";
+}
+
+function isSelfUpdateAvailable(latestVersion: VersionValue, currentVersion: VersionValue): boolean {
+  return compareVersions(releaseCoreVersion(latestVersion), releaseCoreVersion(currentVersion)) > 0;
+}
+
+function releaseCoreVersion(value: VersionValue): VersionValue {
+  const releaseCore = value.raw.trim().match(/^v?(\d+(?:\.\d+)*)/)?.[1];
+  return version(releaseCore ?? value.raw);
 }
 
 function unavailableSelfUpdate(currentVersion: VersionValue, checkedAt: string): SelfUpdateRecord {

--- a/src/main/selfUpdateClient.ts
+++ b/src/main/selfUpdateClient.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { SelfUpdateRecord } from "../shared/domain";
+import { sanitizeExternalURL } from "../shared/security";
+import { isVersionGreater, version, type VersionValue } from "../shared/version";
+
+const latestReleaseURL = "https://api.github.com/repos/arshiaghaf/Baseline/releases/latest";
+const fallbackReleasePageURL = "https://github.com/arshiaghaf/Baseline/releases/latest";
+
+export class SelfUpdateClient {
+  async lookup(currentVersion: VersionValue, checkedAt: string): Promise<SelfUpdateRecord> {
+    try {
+      const response = await fetch(latestReleaseURL, {
+        headers: {
+          Accept: "application/vnd.github+json"
+        },
+        signal: AbortSignal.timeout(8000)
+      });
+      if (!response.ok) {
+        return unavailableSelfUpdate(currentVersion, checkedAt);
+      }
+
+      const raw = (await response.json()) as any;
+      const latestVersion = version(latestVersionString(raw));
+      const releaseURL = sanitizeExternalURL(raw?.html_url) ?? fallbackReleasePageURL;
+      return {
+        available: isVersionGreater(latestVersion, currentVersion),
+        currentVersion,
+        latestVersion,
+        releaseURL,
+        checkedAt
+      };
+    } catch {
+      return unavailableSelfUpdate(currentVersion, checkedAt);
+    }
+  }
+}
+
+function latestVersionString(raw: any): string {
+  return typeof raw?.tag_name === "string" ? raw.tag_name : "";
+}
+
+function unavailableSelfUpdate(currentVersion: VersionValue, checkedAt: string): SelfUpdateRecord {
+  return {
+    available: false,
+    currentVersion,
+    releaseURL: fallbackReleasePageURL,
+    checkedAt
+  };
+}

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -16,6 +16,7 @@ import type {
   HomebrewRecentlyUpdatedRecord,
   MenuTab,
   PersistedSnapshot,
+  SelfUpdateRecord,
   UpdateRecord
 } from "../shared/domain";
 import {
@@ -32,7 +33,13 @@ import {
 } from "../shared/homebrewProgress";
 import type { PreferencePatch } from "../shared/ipc";
 import { isAllowedExternalURL, isValidHomebrewToken } from "../shared/security";
-import { compareVersions, isVersionEmpty, isVersionGreater } from "../shared/version";
+import {
+  compareVersions,
+  isVersionEmpty,
+  isVersionGreater,
+  version,
+  type VersionValue
+} from "../shared/version";
 import { AppStoreLookupClient } from "./appStoreLookupClient";
 import { BundleScannerClient } from "./bundleScanner";
 import {
@@ -44,6 +51,7 @@ import { HomebrewCaskClient } from "./homebrewCaskClient";
 import { HomebrewFormulaClient } from "./homebrewFormulaClient";
 import { HomebrewInventoryClient } from "./homebrewInventoryClient";
 import { SnapshotPersistence } from "./persistence";
+import { SelfUpdateClient } from "./selfUpdateClient";
 import { SparkleAppcastClient } from "./sparkleAppcastClient";
 
 type StoreEvents = {
@@ -65,6 +73,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   >;
   private readonly homebrewFormula: Pick<HomebrewFormulaClient, "fetchIndex" | "searchFormulae">;
   private readonly homebrewInventory: Pick<HomebrewInventoryClient, "fetchInventory">;
+  private readonly selfUpdate: Pick<SelfUpdateClient, "lookup">;
+  private readonly currentAppVersion: VersionValue;
   private readonly runBrewCommand: typeof defaultRunBrewCommand;
   private readonly runMasCommand: typeof defaultRunMasCommand;
   private readonly openExternalURL: (url: string) => Promise<boolean>;
@@ -91,7 +101,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       homebrew: Pick<HomebrewCaskClient, "fetchIndex" | "lookupUpdate" | "searchCasks">;
       homebrewFormula: Pick<HomebrewFormulaClient, "fetchIndex" | "searchFormulae">;
       homebrewInventory: Pick<HomebrewInventoryClient, "fetchInventory">;
+      selfUpdate: Pick<SelfUpdateClient, "lookup">;
     }>;
+    currentAppVersion?: string;
     runBrewCommand?: typeof defaultRunBrewCommand;
     runMasCommand?: typeof defaultRunMasCommand;
     successRefreshDelayMS?: number;
@@ -104,6 +116,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     this.homebrew = options.clients?.homebrew ?? new HomebrewCaskClient();
     this.homebrewFormula = options.clients?.homebrewFormula ?? new HomebrewFormulaClient();
     this.homebrewInventory = options.clients?.homebrewInventory ?? new HomebrewInventoryClient();
+    this.selfUpdate = options.clients?.selfUpdate ?? new SelfUpdateClient();
+    this.currentAppVersion = version(options.currentAppVersion);
     this.runBrewCommand = options.runBrewCommand ?? defaultRunBrewCommand;
     this.runMasCommand = options.runMasCommand ?? defaultRunMasCommand;
     this.openExternalURL = options.openExternalURL;
@@ -550,12 +564,14 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
     const now = new Date().toISOString();
     try {
-      const [apps, homebrewIndex, homebrewFormulaIndex, homebrewInventory] = await Promise.all([
-        this.scanner.scanApplications(this.scanDirectories()),
-        this.homebrew.fetchIndex(),
-        this.homebrewFormula.fetchIndex(),
-        this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight })
-      ]);
+      const [apps, homebrewIndex, homebrewFormulaIndex, homebrewInventory, selfUpdate] =
+        await Promise.all([
+          this.scanner.scanApplications(this.scanDirectories()),
+          this.homebrew.fetchIndex(),
+          this.homebrewFormula.fetchIndex(),
+          this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight }),
+          this.lookupSelfUpdate(now)
+        ]);
       const homebrewItems = homebrewInventory.items;
       this.latestHomebrewIndex = homebrewIndex;
       this.latestHomebrewFormulaIndex = homebrewFormulaIndex;
@@ -662,6 +678,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         homebrewDiscoverInstallingItemIDs: [],
         homebrewDiscoverInstalledPendingRefreshItemIDs: [],
         homebrewDiscoverProgressByItemID: {},
+        selfUpdate,
         laggingHomebrewCaskTokens: detectLaggingHomebrewCaskTokens(
           homebrewItems,
           updates,
@@ -702,6 +719,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       installedFormulae
     );
     this.patch({ homebrewDiscoverItems: [...casks, ...formulae].slice(0, 18) });
+  }
+
+  private async lookupSelfUpdate(now: string): Promise<SelfUpdateRecord | undefined> {
+    if (isVersionEmpty(this.currentAppVersion)) {
+      return undefined;
+    }
+    return this.selfUpdate.lookup(this.currentAppVersion, now);
   }
 
   private scanDirectories(): string[] {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -76,7 +76,7 @@ type SettingsSectionID = "general" | "appearance" | "diagnostics";
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
 const toolbarIconStrokeWidth = 1.5;
-const showSelfUpdateToolbarButtonForTesting = true;
+const baselineBundleIdentifier = "com.arshiaghaf.baseline";
 const baselineLatestReleaseURL = "https://github.com/arshiaghaf/Baseline/releases/latest";
 const settingsSidebarItems: Array<{
   id: SettingsSectionID;
@@ -303,7 +303,7 @@ export function Dashboard({
               <h1>{title}</h1>
             </div>
             <div className="topbar-actions">
-              {showSelfUpdateToolbarButtonForTesting ? <SelfUpdateToolbarButton /> : null}
+              {hasBaselineSelfUpdate(snapshot) ? <SelfUpdateToolbarButton /> : null}
               <ToolbarSearch
                 open={toolbarSearchOpen}
                 snapshot={snapshot}
@@ -489,6 +489,15 @@ function Sidebar({
 
 function SidebarBadge({ count }: { count: number }) {
   return count > 0 ? <strong>{count}</strong> : null;
+}
+
+function hasBaselineSelfUpdate(snapshot: BaselineSnapshot): boolean {
+  const baselineAppIDs = new Set(
+    snapshot.apps
+      .filter((app) => app.bundleIdentifier?.toLowerCase() === baselineBundleIdentifier)
+      .map((app) => app.id)
+  );
+  return snapshot.updates.some((update) => baselineAppIDs.has(update.appID));
 }
 
 function SelfUpdateToolbarButton() {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -76,8 +76,6 @@ type SettingsSectionID = "general" | "appearance" | "diagnostics";
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
 const toolbarIconStrokeWidth = 1.5;
-const baselineBundleIdentifier = "com.arshiaghaf.baseline";
-const baselineLatestReleaseURL = "https://github.com/arshiaghaf/Baseline/releases/latest";
 const settingsSidebarItems: Array<{
   id: SettingsSectionID;
   label: string;
@@ -303,7 +301,9 @@ export function Dashboard({
               <h1>{title}</h1>
             </div>
             <div className="topbar-actions">
-              {hasBaselineSelfUpdate(snapshot) ? <SelfUpdateToolbarButton /> : null}
+              {snapshot.selfUpdate?.available && snapshot.selfUpdate.releaseURL ? (
+                <SelfUpdateToolbarButton releaseURL={snapshot.selfUpdate.releaseURL} />
+              ) : null}
               <ToolbarSearch
                 open={toolbarSearchOpen}
                 snapshot={snapshot}
@@ -491,20 +491,11 @@ function SidebarBadge({ count }: { count: number }) {
   return count > 0 ? <strong>{count}</strong> : null;
 }
 
-function hasBaselineSelfUpdate(snapshot: BaselineSnapshot): boolean {
-  const baselineAppIDs = new Set(
-    snapshot.apps
-      .filter((app) => app.bundleIdentifier?.toLowerCase() === baselineBundleIdentifier)
-      .map((app) => app.id)
-  );
-  return snapshot.updates.some((update) => baselineAppIDs.has(update.appID));
-}
-
-function SelfUpdateToolbarButton() {
+function SelfUpdateToolbarButton({ releaseURL }: { releaseURL: string }) {
   return (
     <button
       className="toolbar-button self-update-toolbar-button"
-      onClick={() => void window.baseline.openExternal(baselineLatestReleaseURL)}
+      onClick={() => void window.baseline.openExternal(releaseURL)}
       title="New Baseline Update Available"
       aria-label="New Baseline Update Available"
     >

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -76,6 +76,8 @@ type SettingsSectionID = "general" | "appearance" | "diagnostics";
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
 const toolbarIconStrokeWidth = 1.5;
+const showSelfUpdateToolbarButtonForTesting = true;
+const baselineLatestReleaseURL = "https://github.com/arshiaghaf/Baseline/releases/latest";
 const settingsSidebarItems: Array<{
   id: SettingsSectionID;
   label: string;
@@ -301,6 +303,7 @@ export function Dashboard({
               <h1>{title}</h1>
             </div>
             <div className="topbar-actions">
+              {showSelfUpdateToolbarButtonForTesting ? <SelfUpdateToolbarButton /> : null}
               <ToolbarSearch
                 open={toolbarSearchOpen}
                 snapshot={snapshot}
@@ -486,6 +489,19 @@ function Sidebar({
 
 function SidebarBadge({ count }: { count: number }) {
   return count > 0 ? <strong>{count}</strong> : null;
+}
+
+function SelfUpdateToolbarButton() {
+  return (
+    <button
+      className="toolbar-button self-update-toolbar-button"
+      onClick={() => void window.baseline.openExternal(baselineLatestReleaseURL)}
+      title="New Baseline Update Available"
+      aria-label="New Baseline Update Available"
+    >
+      <Download size={16} strokeWidth={2} />
+    </button>
+  );
 }
 
 function ToolbarSearch({

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -947,7 +947,7 @@ button:disabled {
 
 .self-update-toolbar-button {
   border-color: transparent;
-  background: rgb(var(--update-accent-rgb));
+  background: #007aff;
   color: white;
   box-shadow: none;
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -945,6 +945,13 @@ button:disabled {
   color: rgba(60, 60, 67, 0.78);
 }
 
+.self-update-toolbar-button {
+  border-color: transparent;
+  background: rgb(var(--update-accent-rgb));
+  color: white;
+  box-shadow: none;
+}
+
 @media (hover: hover) {
   .toolbar-button:not(:disabled):hover,
   .icon-button:not(:disabled):hover,
@@ -973,6 +980,13 @@ button:disabled {
     background: rgba(60, 60, 67, 0.08);
     box-shadow: none;
     color: #0d0d0d;
+  }
+
+  .self-update-toolbar-button:not(:disabled):hover {
+    border-color: transparent;
+    background: #0a84ff;
+    box-shadow: none;
+    color: white;
   }
 
   .compact .toolbar-button:not(:disabled):hover,
@@ -1802,6 +1816,13 @@ button:disabled {
     color: rgba(235, 235, 245, 0.78);
   }
 
+  .self-update-toolbar-button {
+    border-color: transparent;
+    background: #0a84ff;
+    color: white;
+    box-shadow: none;
+  }
+
   .compact .toolbar-button,
   .compact .toolbar-button.refresh-button,
   .compact .toolbar-search .toolbar-button {
@@ -1855,6 +1876,13 @@ button:disabled {
       background: rgba(255, 255, 255, 0.1);
       box-shadow: none;
       color: #fcfcfc;
+    }
+
+    .self-update-toolbar-button:not(:disabled):hover {
+      border-color: transparent;
+      background: #409cff;
+      box-shadow: none;
+      color: white;
     }
 
     .compact .toolbar-button:not(:disabled):hover,

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -130,6 +130,14 @@ export type HomebrewManagedItem = {
   appID?: string;
 };
 
+export type SelfUpdateRecord = {
+  available: boolean;
+  currentVersion: VersionValue;
+  latestVersion?: VersionValue;
+  releaseURL?: string;
+  checkedAt?: string;
+};
+
 export type PersistedSnapshot = {
   apps: AppRecord[];
   updates: UpdateRecord[];
@@ -186,6 +194,7 @@ export type BaselineSnapshot = PersistedSnapshot &
     homebrewDiscoverProgressByItemID: Record<string, number>;
     laggingHomebrewCaskTokens: string[];
     defaultScanDirectories: string[];
+    selfUpdate?: SelfUpdateRecord;
   };
 
 export const emptyHomebrewCaskIndex: HomebrewCaskIndex = {


### PR DESCRIPTION
## Summary
- Adds a main-window toolbar shortcut for Baseline self-updates, driven by a transient `selfUpdate` snapshot field instead of ordinary app-card updates.
- Checks GitHub Releases from the main process, compares the latest release tag to the running app version, and routes the shortcut to the release URL when an update is available.
- Styles the shortcut as a solid blue download glyph without shadow while keeping the compact menu bar window unchanged.

## Validation
- `npm test -- --run ElectronTests/clients.test.ts ElectronTests/updateStore.test.ts ElectronTests/rendererButtons.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
