### PR TITLE
Dispatch Homebrew tap updates after releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,5 +65,4 @@ jobs:
           gh workflow run update-baseline-cask.yml \
             --repo arshiaghaf/homebrew-tap \
             --ref main \
-            -f tag="$GITHUB_REF_NAME" \
-            -f repository="$GITHUB_REPOSITORY"
+            -f tag="$GITHUB_REF_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,18 @@ jobs:
             "dist/Baseline-${VERSION}-unsigned.dmg.sha256" \
             --title "Baseline ${VERSION} unsigned preview" \
             --notes-file "dist/Baseline-${VERSION}-unsigned-release-notes.md"
+
+      - name: Dispatch Homebrew tap update
+        env:
+          GH_TOKEN: ${{ secrets.TAP_WORKFLOW_TOKEN }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::notice::TAP_WORKFLOW_TOKEN is not configured; skipping Homebrew tap update."
+            exit 0
+          fi
+
+          gh workflow run update-baseline-cask.yml \
+            --repo arshiaghaf/homebrew-tap \
+            --ref main \
+            -f tag="$GITHUB_REF_NAME" \
+            -f repository="$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,15 +54,60 @@ jobs:
             --notes-file "dist/Baseline-${VERSION}-unsigned-release-notes.md"
 
       - name: Dispatch Homebrew tap update
+        id: tap
         env:
-          GH_TOKEN: ${{ secrets.TAP_WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          if [[ -z "$GH_TOKEN" ]]; then
-            echo "::notice::TAP_WORKFLOW_TOKEN is not configured; skipping Homebrew tap update."
-            exit 0
-          fi
+          set -euo pipefail
+          test -n "$GH_TOKEN"
 
-          gh workflow run update-baseline-cask.yml \
-            --repo arshiaghaf/homebrew-tap \
-            --ref main \
-            -f tag="$GITHUB_REF_NAME"
+          request_id="baseline-${GITHUB_REF_NAME}-${GITHUB_RUN_ID}"
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+
+          for attempt in {1..6}; do
+            if gh workflow run update-baseline-cask.yml \
+              --repo arshiaghaf/homebrew-tap \
+              --ref main \
+              -f tag="$GITHUB_REF_NAME" \
+              -f request_id="$request_id"; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -eq 6 ]]; then
+              echo "Failed to dispatch Homebrew tap update after ${attempt} attempts." >&2
+              exit 1
+            fi
+
+            sleep $((attempt * 30))
+          done
+
+      - name: Wait for Homebrew tap update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          REQUEST_ID: ${{ steps.tap.outputs.request_id }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+
+          for _ in {1..20}; do
+            run_id="$(
+              gh run list \
+                --repo arshiaghaf/homebrew-tap \
+                --workflow update-baseline-cask.yml \
+                --json databaseId,displayTitle \
+                --jq '.[] | select(.displayTitle | contains(env.REQUEST_ID)) | .databaseId' \
+                2>/tmp/baseline-tap-run-list.err \
+                | head -n1 || true
+            )"
+
+            if [[ -n "$run_id" ]]; then
+              gh run watch "$run_id" --repo arshiaghaf/homebrew-tap --exit-status
+              exit 0
+            fi
+
+            cat /tmp/baseline-tap-run-list.err >&2 || true
+            sleep 5
+          done
+
+          echo "Timed out waiting for Homebrew tap workflow to appear." >&2
+          exit 1


### PR DESCRIPTION
## Summary
- dispatch the Homebrew tap cask update workflow after the unsigned DMG release is published
- require `HOMEBREW_TAP_TOKEN` so release failures surface when the tap cannot be updated
- retry dispatch and wait for the matching tap workflow run to finish

## Validation
- `actionlint .github/workflows/release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- GitHub Actions CI
