### PR TITLE
Include changelog entries in release notes

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,7 +7,7 @@ Unsigned DMGs are not notarized by Apple. macOS Gatekeeper may warn users before
 ## First Release Checklist
 
 1. Choose a version, for example `0.1.0`.
-2. Update `package.json` and `package-lock.json` to the release version, then update `CHANGELOG.md`.
+2. Update `package.json` and `package-lock.json` to the release version, then finalize the matching `CHANGELOG.md` section heading with the release date, for example `## 0.1.0 — 2026-05-31`.
 3. Run local validation:
 
 ```bash
@@ -33,15 +33,15 @@ git tag v0.1.0
 git push baseline v0.1.0
 ```
 
-8. The GitHub Actions release workflow builds the Electron unsigned DMG with the GitHub run number as the macOS build number, writes `dist/Baseline-0.1.0-unsigned.dmg.sha256`, creates the GitHub Release, and uploads both files.
+8. The GitHub Actions release workflow builds the Electron unsigned DMG with the GitHub run number as the macOS build number, writes `dist/Baseline-0.1.0-unsigned.dmg.sha256`, creates the GitHub Release with notes from the finalized changelog section, and uploads both files.
 9. Verify the GitHub Release contains:
    - `Baseline-0.1.0-unsigned.dmg`
    - `Baseline-0.1.0-unsigned.dmg.sha256`
-   - release notes that clearly label the artifact as unsigned.
+   - release notes that include the finalized changelog section and clearly label the artifact as unsigned.
 
 The release workflow accepts tags like `v0.1.0` and `v0.1.0-beta.1`.
 
-The user-facing app version maps to `CFBundleShortVersionString` and is sourced from `package.json`. Release artifact preparation fails if the requested release version does not match `package.json`. The build number in parentheses maps to `CFBundleVersion` and should be a monotonically increasing numeric value supplied by CI through `GITHUB_RUN_NUMBER` or overridden explicitly with `BASELINE_BUILD_NUMBER` for local artifact builds.
+The user-facing app version maps to `CFBundleShortVersionString` and is sourced from `package.json`. Release artifact preparation fails if the requested release version does not match `package.json`, `package-lock.json`, or a finalized `CHANGELOG.md` section heading for that version. The build number in parentheses maps to `CFBundleVersion` and should be a monotonically increasing numeric value supplied by CI through `GITHUB_RUN_NUMBER` or overridden explicitly with `BASELINE_BUILD_NUMBER` for local artifact builds.
 
 ## Future Signed Release Path
 

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -14,6 +14,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DMG_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned.dmg"
 CHECKSUM_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned.dmg.sha256"
 NOTES_PATH="$ROOT_DIR/dist/${APP_NAME}-${VERSION}-unsigned-release-notes.md"
+CHANGELOG_SECTION_PATH="$(mktemp)"
+
+trap 'rm -f "$CHANGELOG_SECTION_PATH"' EXIT
 
 if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
   echo "Version must look like 0.1.0 or 0.1.0-beta.1"
@@ -40,10 +43,53 @@ if [[ "$PACKAGE_LOCK_VERSION" != "$VERSION" ]]; then
   exit 1
 fi
 
-if ! grep -Eq '^## (Unreleased|[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)? — Unreleased)$' CHANGELOG.md; then
-  echo "CHANGELOG.md must contain an Unreleased section heading before preparing a release."
-  exit 1
-fi
+VERSION="$VERSION" CHANGELOG_SECTION_PATH="$CHANGELOG_SECTION_PATH" node <<'NODE'
+const fs = require("fs");
+
+const version = process.env.VERSION;
+const outputPath = process.env.CHANGELOG_SECTION_PATH;
+const changelog = fs.readFileSync("CHANGELOG.md", "utf8");
+const lines = changelog.split(/\r?\n/);
+const headingPattern = new RegExp(
+  `^## ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} — \\d{4}-\\d{2}-\\d{2}$`,
+);
+const headingIndex = lines.findIndex((line) => headingPattern.test(line));
+
+if (headingIndex === -1) {
+  console.error(
+    `CHANGELOG.md must contain a finalized section heading like "## ${version} — YYYY-MM-DD" before preparing a release.`,
+  );
+  process.exit(1);
+}
+
+let nextHeadingIndex = lines.findIndex(
+  (line, index) => index > headingIndex && line.startsWith("## "),
+);
+
+if (nextHeadingIndex === -1) {
+  nextHeadingIndex = lines.length;
+}
+
+const sectionLines = lines.slice(headingIndex + 1, nextHeadingIndex);
+
+while (sectionLines.length > 0 && sectionLines[0].trim() === "") {
+  sectionLines.shift();
+}
+
+while (
+  sectionLines.length > 0 &&
+  sectionLines[sectionLines.length - 1].trim() === ""
+) {
+  sectionLines.pop();
+}
+
+if (sectionLines.length === 0) {
+  console.error(`CHANGELOG.md section for ${version} must not be empty.`);
+  process.exit(1);
+}
+
+fs.writeFileSync(outputPath, `${sectionLines.join("\n")}\n`);
+NODE
 
 scripts/create-unsigned-dmg.sh "$VERSION"
 
@@ -60,6 +106,14 @@ cat > "$NOTES_PATH" <<NOTES
 # Baseline ${VERSION} unsigned preview
 
 This is an unsigned preview build. It is not notarized by Apple, and macOS may show an unidentified-developer warning.
+
+## What's Changed
+
+NOTES
+
+cat "$CHANGELOG_SECTION_PATH" >> "$NOTES_PATH"
+
+cat >> "$NOTES_PATH" <<NOTES
 
 ## Download
 


### PR DESCRIPTION
## Summary
- Release note generation now extracts the finalized `CHANGELOG.md` section for the tag version and includes it in unsigned preview release notes.
- Release documentation now requires a finalized changelog heading and describes changelog-backed release notes.

## Validation
- `bash -n scripts/prepare-unsigned-release.sh`
- `scripts/prepare-unsigned-release.sh 0.1.0` (expected failure while the current changelog heading is still `Unreleased`, exercising the finalized-heading guard)
