### PR TITLE
Detect UIKit App Store Mac updates

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -180,6 +180,80 @@ describe("bundle scanner", () => {
     });
   });
 
+  it("marks App Store UIKit Mac bundles as App Store software lookup eligible", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    const appPath = path.join(root, "UIKit Mac App.app");
+    await writeAppPlist(appPath, {
+      displayName: "UIKit Mac App",
+      bundleIdentifier: "com.example.uikit-mac",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>CFBundleSupportedPlatforms</key>",
+        "  <array>",
+        "    <string>MacOSX</string>",
+        "  </array>",
+        "  <key>UIApplicationSceneManifest</key>",
+        "  <dict>",
+        "    <key>UIApplicationSupportsMultipleScenes</key>",
+        "    <false/>",
+        "  </dict>",
+        "  <key>UIDeviceFamily</key>",
+        "  <array>",
+        "    <integer>2</integer>",
+        "  </array>",
+        "  <key>UILaunchStoryboardName</key>",
+        "  <string>LaunchScreen</string>"
+      ].join("\n")
+    });
+    await mkdir(path.join(appPath, "Contents", "_MASReceipt"), { recursive: true });
+    await writeFile(path.join(appPath, "Contents", "_MASReceipt", "receipt"), "receipt");
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundlePath: appPath,
+      bundleIdentifier: "com.example.uikit-mac",
+      sourceHint: "appStore",
+      isIOSAppOnMac: true,
+      hasAppStoreEvidence: true
+    });
+  });
+
+  it("does not enable iOS software lookup for UIKit-style Mac bundles without App Store evidence", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    await writeAppPlist(path.join(root, "Sideloaded UIKit Mac App.app"), {
+      displayName: "Sideloaded UIKit Mac App",
+      bundleIdentifier: "com.example.sideloaded-uikit-mac",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>UIApplicationSceneManifest</key>",
+        "  <dict>",
+        "    <key>UIApplicationSupportsMultipleScenes</key>",
+        "    <false/>",
+        "  </dict>",
+        "  <key>UIDeviceFamily</key>",
+        "  <array>",
+        "    <integer>2</integer>",
+        "  </array>",
+        "  <key>UILaunchStoryboardName</key>",
+        "  <string>LaunchScreen</string>"
+      ].join("\n")
+    });
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundleIdentifier: "com.example.sideloaded-uikit-mac",
+      sourceHint: "unknown",
+      isIOSAppOnMac: false,
+      hasAppStoreEvidence: false
+    });
+  });
+
   it("scans App Store wrapper bundles for iOS-on-Mac apps", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
     tempDirs.push(root);

--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -221,7 +221,7 @@ describe("bundle scanner", () => {
     });
   });
 
-  it("marks App Store UIKit Mac bundles with Mac idiom device family as lookup eligible", async () => {
+  it("does not enable iOS software lookup for App Store UIKit bundles with Mac idiom", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
     tempDirs.push(root);
 
@@ -252,7 +252,7 @@ describe("bundle scanner", () => {
     expect(records[0]).toMatchObject({
       bundleIdentifier: "com.example.uikit-mac-idiom",
       sourceHint: "appStore",
-      isIOSAppOnMac: true,
+      isIOSAppOnMac: false,
       hasAppStoreEvidence: true
     });
   });

--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -221,6 +221,76 @@ describe("bundle scanner", () => {
     });
   });
 
+  it("marks App Store UIKit Mac bundles with Mac idiom device family as lookup eligible", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    const appPath = path.join(root, "UIKit Mac Idiom App.app");
+    await writeAppPlist(appPath, {
+      displayName: "UIKit Mac Idiom App",
+      bundleIdentifier: "com.example.uikit-mac-idiom",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>UIApplicationSceneManifest</key>",
+        "  <dict>",
+        "    <key>UIApplicationSupportsMultipleScenes</key>",
+        "    <false/>",
+        "  </dict>",
+        "  <key>UIDeviceFamily</key>",
+        "  <array>",
+        "    <integer>6</integer>",
+        "  </array>",
+        "  <key>UILaunchStoryboardName</key>",
+        "  <string>LaunchScreen</string>"
+      ].join("\n")
+    });
+    await mkdir(path.join(appPath, "Contents", "_MASReceipt"), { recursive: true });
+    await writeFile(path.join(appPath, "Contents", "_MASReceipt", "receipt"), "receipt");
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundleIdentifier: "com.example.uikit-mac-idiom",
+      sourceHint: "appStore",
+      isIOSAppOnMac: true,
+      hasAppStoreEvidence: true
+    });
+  });
+
+  it("marks App Store UIKit Mac bundles with scalar device family as lookup eligible", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    const appPath = path.join(root, "UIKit Scalar Device Family.app");
+    await writeAppPlist(appPath, {
+      displayName: "UIKit Scalar Device Family",
+      bundleIdentifier: "com.example.uikit-scalar-device-family",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>UIApplicationSceneManifest</key>",
+        "  <dict>",
+        "    <key>UIApplicationSupportsMultipleScenes</key>",
+        "    <false/>",
+        "  </dict>",
+        "  <key>UIDeviceFamily</key>",
+        "  <integer>2</integer>",
+        "  <key>UILaunchStoryboardName</key>",
+        "  <string>LaunchScreen</string>"
+      ].join("\n")
+    });
+    await mkdir(path.join(appPath, "Contents", "_MASReceipt"), { recursive: true });
+    await writeFile(path.join(appPath, "Contents", "_MASReceipt", "receipt"), "receipt");
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundleIdentifier: "com.example.uikit-scalar-device-family",
+      sourceHint: "appStore",
+      isIOSAppOnMac: true,
+      hasAppStoreEvidence: true
+    });
+  });
+
   it("does not enable iOS software lookup for UIKit-style Mac bundles without App Store evidence", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
     tempDirs.push(root);

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -310,8 +310,7 @@ function isIOSAppOnMacInfo(info: InfoPlist): boolean {
 
 function isUIKitMacAppStoreInfo(info: InfoPlist): boolean {
   const deviceFamily = numberArrayValue(info.UIDeviceFamily);
-  const hasUIKitDeviceFamily =
-    deviceFamily.includes(1) || deviceFamily.includes(2) || deviceFamily.includes(6);
+  const hasUIKitDeviceFamily = deviceFamily.includes(1) || deviceFamily.includes(2);
   const hasUIKitLifecycle =
     recordValue(info.UIApplicationSceneManifest) !== undefined ||
     stringValue(info.UIMainStoryboardFile) !== undefined ||

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -292,6 +292,9 @@ function stringArrayValue(value: unknown): string[] {
 }
 
 function numberArrayValue(value: unknown): number[] {
+  if (typeof value === "number") {
+    return [value];
+  }
   return Array.isArray(value)
     ? value.filter((item): item is number => typeof item === "number")
     : [];
@@ -307,7 +310,8 @@ function isIOSAppOnMacInfo(info: InfoPlist): boolean {
 
 function isUIKitMacAppStoreInfo(info: InfoPlist): boolean {
   const deviceFamily = numberArrayValue(info.UIDeviceFamily);
-  const hasUIKitDeviceFamily = deviceFamily.includes(1) || deviceFamily.includes(2);
+  const hasUIKitDeviceFamily =
+    deviceFamily.includes(1) || deviceFamily.includes(2) || deviceFamily.includes(6);
   const hasUIKitLifecycle =
     recordValue(info.UIApplicationSceneManifest) !== undefined ||
     stringValue(info.UIMainStoryboardFile) !== undefined ||

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -133,10 +133,12 @@ export class BundleScannerClient {
   private async readAppBundleInfo(appPath: string): Promise<AppBundleInfo | undefined> {
     const info = await this.readInfoPlist(appPath);
     if (info) {
+      const hasAppStoreEvidence = await this.hasMasReceipt(appPath);
       return {
         info,
-        isIOSAppOnMac: isIOSAppOnMacInfo(info),
-        hasAppStoreEvidence: await this.hasMasReceipt(appPath),
+        isIOSAppOnMac:
+          isIOSAppOnMacInfo(info) || (hasAppStoreEvidence && isUIKitMacAppStoreInfo(info)),
+        hasAppStoreEvidence,
         iconResourcesPath: path.join(appPath, "Contents", "Resources")
       };
     }
@@ -289,12 +291,28 @@ function stringArrayValue(value: unknown): string[] {
     : [];
 }
 
+function numberArrayValue(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is number => typeof item === "number")
+    : [];
+}
+
 function isIOSAppOnMacInfo(info: InfoPlist): boolean {
   return (
     info.LSRequiresIPhoneOS === true ||
     info.UIDesignRequiresCompatibility === true ||
     stringArrayValue(info.CFBundleSupportedPlatforms).includes("iPhoneOS")
   );
+}
+
+function isUIKitMacAppStoreInfo(info: InfoPlist): boolean {
+  const deviceFamily = numberArrayValue(info.UIDeviceFamily);
+  const hasUIKitDeviceFamily = deviceFamily.includes(1) || deviceFamily.includes(2);
+  const hasUIKitLifecycle =
+    recordValue(info.UIApplicationSceneManifest) !== undefined ||
+    stringValue(info.UIMainStoryboardFile) !== undefined ||
+    stringValue(info.UILaunchStoryboardName) !== undefined;
+  return hasUIKitDeviceFamily && hasUIKitLifecycle;
 }
 
 function iconCandidatePaths(resourcesPath: string, info: InfoPlist): string[] {


### PR DESCRIPTION
## Summary
- Follow-up to #121: direct Mac App Store bundles with UIKit/iPad-style metadata can now use the iOS `software` App Store lookup path when they also have local App Store receipt evidence.
- Keeps Mac-idiom UIKit/Catalyst App Store bundles on the Mac App Store lookup path so shared bundle IDs do not prefer iOS `software` results.
- Keeps sideloaded UIKit-style Mac bundles excluded from iOS software lookup without App Store evidence.
- Adds generic bundle scanner regression coverage for App Store-backed, Mac-idiom, scalar device-family, and no-evidence cases.

## Validation
- `npm test -- --run ElectronTests/bundleScanner.test.ts ElectronTests/updateStore.test.ts ElectronTests/clients.test.ts`
- `npm run typecheck`
- `npm run lint`
