### PR TITLE
Skip Homebrew inventory when Homebrew is unavailable

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -386,8 +386,54 @@ describe("update store helpers", () => {
     expect(fetchInventory).not.toHaveBeenCalled();
     expect(snapshot.homebrewItems).toEqual([]);
     expect(snapshot.lastRefreshNoticeMessage).toBeUndefined();
-    expect(runBrewCommand).toHaveBeenCalledOnce();
-    expect(runBrewCommand).toHaveBeenCalledWith(["--version"]);
+    expect(runBrewCommand).toHaveBeenCalledTimes(2);
+    expect(runBrewCommand).toHaveBeenNthCalledWith(1, ["--version"]);
+    expect(runBrewCommand).toHaveBeenNthCalledWith(2, ["--version"]);
+  });
+
+  it("rechecks Homebrew availability during refresh after Homebrew was absent", async () => {
+    const installedItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      installedVersion: version("14.1.0")
+    });
+    const fetchInventory = vi.fn(async () => ({
+      items: [installedItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    }));
+    let brewVersionChecks = 0;
+    const runBrewCommand = vi.fn(async (command: string[]) => {
+      if (command[0] === "--version") {
+        brewVersionChecks += 1;
+        return {
+          success: brewVersionChecks >= 3,
+          status: brewVersionChecks >= 3 ? 0 : null,
+          output: ""
+        };
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({
+      runBrewCommand,
+      clients: {
+        homebrewInventory: { fetchInventory }
+      }
+    });
+
+    await store.refreshToolStatus();
+    await store.refresh(false);
+
+    expect(store.getSnapshot().isHomebrewInstalled).toBe(false);
+    expect(fetchInventory).not.toHaveBeenCalled();
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().isHomebrewInstalled).toBe(true);
+    expect(fetchInventory).toHaveBeenCalledWith({ updateMetadata: true });
+    expect(store.getSnapshot().homebrewItems).toEqual([installedItem]);
+    expect(runBrewCommand).toHaveBeenCalledTimes(3);
   });
 
   it("refreshes Homebrew inventory after a successful install when Homebrew was previously absent", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -390,6 +390,48 @@ describe("update store helpers", () => {
     expect(runBrewCommand).toHaveBeenCalledWith(["--version"]);
   });
 
+  it("refreshes Homebrew inventory after a successful install when Homebrew was previously absent", async () => {
+    const installedItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      installedVersion: version("14.1.0")
+    });
+    const fetchInventory = vi.fn(async () => ({
+      items: [installedItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    }));
+    const runBrewCommand = vi.fn(async (command: string[]) => ({
+      success: command[0] !== "--version",
+      status: command[0] === "--version" ? null : 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      runBrewCommand,
+      clients: {
+        homebrewInventory: { fetchInventory }
+      }
+    });
+
+    await store.refreshToolStatus();
+    await store.installHomebrewItem({
+      id: "formula:ripgrep",
+      kind: "formula",
+      token: "ripgrep",
+      displayName: "ripgrep",
+      presentation: "formula",
+      version: version("14.1.0")
+    });
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.isHomebrewInstalled).toBe(true);
+    expect(fetchInventory).toHaveBeenCalledWith({ updateMetadata: true });
+    expect(snapshot.homebrewItems).toEqual([installedItem]);
+    expect(snapshot.homebrewDiscoverInstallingItemIDs).toEqual([]);
+    expect(snapshot.homebrewDiscoverInstalledPendingRefreshItemIDs).toEqual([]);
+  });
+
   it("does not let an older overlapping full refresh overwrite a newer snapshot", async () => {
     const olderApp = appRecord({
       bundlePath: "/Applications/Refresh Race.app",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -347,6 +347,49 @@ describe("update store helpers", () => {
     expect(inventoryOptions).toEqual([{ updateMetadata: true }, { updateMetadata: false }]);
   });
 
+  it("skips Homebrew inventory and warnings when Homebrew is absent", async () => {
+    const previousItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const fetchInventory = vi.fn(async () => ({
+      items: [],
+      outdatedDetectionSucceeded: false,
+      outdatedDetectionSucceededByKind: { formula: false, cask: false },
+      warning: "Homebrew outdated status could not be read reliably."
+    }));
+    const runBrewCommand = vi.fn(async () => ({
+      success: false,
+      status: null,
+      output: ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [previousItem]
+      },
+      runBrewCommand,
+      clients: {
+        homebrewInventory: { fetchInventory }
+      }
+    });
+
+    await store.refreshToolStatus();
+    await store.refresh(false);
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.isHomebrewInstalled).toBe(false);
+    expect(fetchInventory).not.toHaveBeenCalled();
+    expect(snapshot.homebrewItems).toEqual([]);
+    expect(snapshot.lastRefreshNoticeMessage).toBeUndefined();
+    expect(runBrewCommand).toHaveBeenCalledOnce();
+    expect(runBrewCommand).toHaveBeenCalledWith(["--version"]);
+  });
+
   it("does not let an older overlapping full refresh overwrite a newer snapshot", async () => {
     const olderApp = appRecord({
       bundlePath: "/Applications/Refresh Race.app",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -852,6 +852,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.emit("homebrewCommand", event);
       onEvent(event);
     });
+    if (result.success && !this.state.isHomebrewInstalled) {
+      this.hasCheckedHomebrewAvailability = true;
+      this.patch({ isHomebrewInstalled: true });
+    }
     const finished: HomebrewMaintenanceRunEvent = {
       type: "commandFinished",
       command,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -774,7 +774,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   private async fetchHomebrewInventory(lightweight: boolean): Promise<HomebrewInventoryResult> {
     if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
-      return emptyHomebrewInventoryResult();
+      const brew = await this.runBrewCommand(["--version"]);
+      this.hasCheckedHomebrewAvailability = true;
+      if (!brew.success) {
+        return emptyHomebrewInventoryResult();
+      }
+      this.patch({ isHomebrewInstalled: true });
     }
     return this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight });
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -50,7 +50,7 @@ import {
 } from "./commandRunner";
 import { HomebrewCaskClient } from "./homebrewCaskClient";
 import { HomebrewFormulaClient } from "./homebrewFormulaClient";
-import { HomebrewInventoryClient } from "./homebrewInventoryClient";
+import { HomebrewInventoryClient, type HomebrewInventoryResult } from "./homebrewInventoryClient";
 import { SnapshotPersistence } from "./persistence";
 import { SelfUpdateClient } from "./selfUpdateClient";
 import { SparkleAppcastClient } from "./sparkleAppcastClient";
@@ -89,6 +89,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly homebrewDiscoverFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
+  private hasCheckedHomebrewAvailability = false;
 
   private state: BaselineSnapshot;
 
@@ -183,6 +184,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.runMasCommand(["version"]),
       this.runBrewCommand(["--version"])
     ]);
+    this.hasCheckedHomebrewAvailability = true;
     this.patch({
       isMasInstalled: mas.success,
       isHomebrewInstalled: brew.success,
@@ -595,7 +597,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           this.scanner.scanApplications(this.scanDirectories()),
           this.homebrew.fetchIndex(),
           this.homebrewFormula.fetchIndex(),
-          this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight }),
+          this.fetchHomebrewInventory(lightweight),
           this.lookupSelfUpdate(now)
         ]);
       const homebrewItems = homebrewInventory.items;
@@ -768,6 +770,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return undefined;
     }
     return this.selfUpdate.lookup(this.currentAppVersion, now);
+  }
+
+  private async fetchHomebrewInventory(lightweight: boolean): Promise<HomebrewInventoryResult> {
+    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
+      return emptyHomebrewInventoryResult();
+    }
+    return this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight });
   }
 
   private scanDirectories(): string[] {
@@ -1188,6 +1197,14 @@ function removeRecordKey<T>(record: Record<string, T>, key: string): Record<stri
   const next = { ...record };
   delete next[key];
   return next;
+}
+
+function emptyHomebrewInventoryResult(): HomebrewInventoryResult {
+  return {
+    items: [],
+    outdatedDetectionSucceeded: true,
+    outdatedDetectionSucceededByKind: { formula: true, cask: true }
+  };
 }
 
 export function preservePreviousHomebrewOutdatedState(


### PR DESCRIPTION
## Summary

- skip Homebrew inventory refreshes after tool status confirms Homebrew is unavailable
- treat the unavailable Homebrew source as an empty successful inventory so missing `brew` does not surface an unreliable-status notice
- add a regression test covering persisted Homebrew state plus a missing Homebrew executable

Fixes #105

## Validation
- `npm test -- --run ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm run lint`
