### PR TITLE
Disable Discover installs when Homebrew is unavailable

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -925,6 +925,38 @@ describe("renderer button parity", () => {
     expect(window.baseline.installHomebrewItem).not.toHaveBeenCalled();
   });
 
+  it("disables discover installs when Homebrew is unavailable", () => {
+    const requestConfirmation = vi.fn();
+    const item: HomebrewCaskDiscoveryItem = {
+      id: "cask:raycast",
+      token: "raycast",
+      displayName: "Raycast",
+      kind: "cask",
+      version: version("1.2.3")
+    };
+
+    render(
+      <ActionConfirmationContext.Provider value={requestConfirmation}>
+        <DiscoverRow
+          item={item}
+          snapshot={snapshot({
+            isHomebrewInstalled: false,
+            homebrewDiscoverItems: [item]
+          })}
+        />
+      </ActionConfirmationContext.Provider>
+    );
+
+    const installButton = screen.getByRole("button", { name: "Needs Homebrew" });
+    expect(installButton).toBeDisabled();
+    expect(
+      screen.getByText("Homebrew is not installed. Install Homebrew to enable this source.")
+    ).toBeInTheDocument();
+    fireEvent.click(installButton);
+    expect(requestConfirmation).not.toHaveBeenCalled();
+    expect(window.baseline.installHomebrewItem).not.toHaveBeenCalled();
+  });
+
   it("orders discover actions as install then open page", () => {
     const item: HomebrewCaskDiscoveryItem = {
       id: "cask:raycast",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1948,6 +1948,32 @@ describe("update store helpers", () => {
       vi.useRealTimers();
     }
   });
+
+  it("does not run Discover installs when Homebrew is unavailable", async () => {
+    const item = {
+      id: "cask:missing-brew-discover",
+      kind: "cask" as const,
+      token: "missing-brew-discover",
+      displayName: "Missing Brew Discover",
+      presentation: "app" as const,
+      version: version("1.0.0")
+    };
+    const runBrewCommand = vi.fn(async () => ({ success: false, status: null, output: "" }));
+    const store = await makeStore({ runBrewCommand });
+
+    await store.refreshToolStatus();
+    await store.installHomebrewItem(item);
+
+    const snapshot = store.getSnapshot();
+    expect(runBrewCommand).toHaveBeenCalledOnce();
+    expect(runBrewCommand).toHaveBeenCalledWith(["--version"]);
+    expect(snapshot.isHomebrewInstalled).toBe(false);
+    expect(snapshot.homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
+    expect(snapshot.homebrewDiscoverFailedItemIDs).not.toContain(item.id);
+    expect(snapshot.refreshErrorMessage).toBe(
+      "Homebrew is not installed. Install Homebrew to install Discover items."
+    );
+  });
 });
 
 async function makeStore({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -89,6 +89,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly homebrewDiscoverFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
+  private hasCheckedHomebrewAvailability = false;
 
   private state: BaselineSnapshot;
 
@@ -183,6 +184,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.runMasCommand(["version"]),
       this.runBrewCommand(["--version"])
     ]);
+    this.hasCheckedHomebrewAvailability = true;
     this.patch({
       isMasInstalled: mas.success,
       isHomebrewInstalled: brew.success,
@@ -497,6 +499,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   async installHomebrewItem(item: HomebrewCaskDiscoveryItem): Promise<void> {
     if (!isValidHomebrewToken(item.token)) {
       this.patch({ refreshErrorMessage: `Blocked unsafe Homebrew token for ${item.displayName}.` });
+      return;
+    }
+    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
+      this.patch({
+        refreshErrorMessage:
+          "Homebrew is not installed. Install Homebrew to install Discover items."
+      });
       return;
     }
     const itemID = item.id;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1559,6 +1559,7 @@ export function DiscoverRow({
   const failed = snapshot.homebrewDiscoverFailedItemIDs.includes(item.id);
   const done = snapshot.homebrewDiscoverInstalledPendingRefreshItemIDs.includes(item.id);
   const progress = snapshot.homebrewDiscoverProgressByItemID[item.id];
+  const canInstall = snapshot.isHomebrewInstalled;
 
   return (
     <article className="row">
@@ -1568,13 +1569,22 @@ export function DiscoverRow({
           <strong>{item.displayName}</strong>
           <span>{homebrewPresentationLabel(item.kind, item.presentation)}</span>
         </div>
-        <p>{item.version.raw || item.token}</p>
+        <p>
+          {canInstall
+            ? item.version.raw || item.token
+            : "Homebrew is not installed. Install Homebrew to enable this source."}
+        </p>
       </div>
       <div className="row-actions">
         <UpdateActionButton
           state={actionStateFromFlags({ failed, updating: installing, progress, done })}
-          readyLabel="Install"
-          onAction={() => requestActionConfirmation({ type: "install", item })}
+          readyLabel={canInstall ? "Install" : "Needs Homebrew"}
+          disabled={!canInstall}
+          onAction={() => {
+            if (canInstall) {
+              requestActionConfirmation({ type: "install", item });
+            }
+          }}
         />
         {item.homepageURL && (
           <button


### PR DESCRIPTION
## Summary

- disable Homebrew Discover install controls when Homebrew is not detected
- show an explicit unavailable message on Discover rows instead of presenting them as installable
- guard the main-process Discover install path so stale renderer events cannot run `brew install` after Homebrew availability is checked as unavailable

Fixes #99

## Validation
- `npm test -- --run ElectronTests/rendererButtons.test.tsx ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm run lint`
