### PR TITLE
Route unmanaged Homebrew-backed app updates externally

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -448,11 +448,18 @@ describe("update store helpers", () => {
       outdatedDetectionSucceeded: true,
       outdatedDetectionSucceededByKind: { formula: true, cask: true }
     }));
-    const runBrewCommand = vi.fn(async (command: string[]) => ({
-      success: command[0] !== "--version",
-      status: command[0] === "--version" ? null : 0,
-      output: ""
-    }));
+    let brewVersionChecks = 0;
+    const runBrewCommand = vi.fn(async (command: string[]) => {
+      if (command[0] === "--version") {
+        brewVersionChecks += 1;
+        return {
+          success: brewVersionChecks >= 2,
+          status: brewVersionChecks >= 2 ? 0 : null,
+          output: ""
+        };
+      }
+      return { success: true, status: 0, output: "" };
+    });
     const store = await makeStore({
       runBrewCommand,
       clients: {
@@ -2134,8 +2141,9 @@ describe("update store helpers", () => {
     await store.installHomebrewItem(item);
 
     const snapshot = store.getSnapshot();
-    expect(runBrewCommand).toHaveBeenCalledOnce();
-    expect(runBrewCommand).toHaveBeenCalledWith(["--version"]);
+    expect(runBrewCommand).toHaveBeenCalledTimes(2);
+    expect(runBrewCommand).toHaveBeenNthCalledWith(1, ["--version"]);
+    expect(runBrewCommand).toHaveBeenNthCalledWith(2, ["--version"]);
     expect(snapshot.isHomebrewInstalled).toBe(false);
     expect(snapshot.homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
     expect(snapshot.homebrewDiscoverFailedItemIDs).not.toContain(item.id);

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1886,6 +1886,47 @@ describe("update store helpers", () => {
     expect(openAppBundle).not.toHaveBeenCalled();
   });
 
+  it("derives external fallback URLs for persisted Homebrew-backed app updates without URLs", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Persisted Homebrew Match.app",
+      displayName: "Persisted Homebrew Match",
+      bundleIdentifier: "com.example.persisted-homebrew-match",
+      localVersion: version("1.0.0")
+    });
+    const openExternalURL = vi.fn(async () => true);
+    const openAppBundle = vi.fn(async () => undefined);
+    const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      openExternalURL,
+      openAppBundle,
+      runBrewCommand,
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "homebrew",
+            supportLevel: "limited",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            homebrewToken: "persisted-homebrew-match",
+            checkedAt: "2026-05-20T12:00:00.000Z"
+          }
+        ]
+      }
+    });
+
+    await store.performAppUpdate(app.id);
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(openExternalURL).toHaveBeenCalledWith(
+      "https://formulae.brew.sh/cask/persisted-homebrew-match"
+    );
+    expect(openAppBundle).not.toHaveBeenCalled();
+  });
+
   it("rejects unsafe Homebrew-backed app update tokens", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Unsafe Managed.app",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1641,6 +1641,66 @@ describe("update store helpers", () => {
     );
   });
 
+  it("uses external fallback for unmanaged Homebrew-backed app updates", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Manual Homebrew Match.app",
+      displayName: "Manual Homebrew Match",
+      bundleIdentifier: "com.example.manual-homebrew-match",
+      localVersion: version("1.0.0")
+    });
+    const fallbackURL = "https://formulae.brew.sh/cask/manual-homebrew-match";
+    const openExternalURL = vi.fn(async () => true);
+    const openAppBundle = vi.fn(async () => undefined);
+    const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      openExternalURL,
+      openAppBundle,
+      runBrewCommand,
+      clients: {
+        scanner: { scanApplications: async () => [app] },
+        homebrew: {
+          fetchIndex: async () => emptyHomebrewCaskIndex,
+          lookupUpdate: () => ({
+            remoteVersion: version("2.0.0"),
+            token: "manual-homebrew-match",
+            homepageURL: fallbackURL
+          }),
+          searchCasks: () => []
+        },
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "formula:manual-homebrew-match",
+                token: "manual-homebrew-match",
+                name: "manual-homebrew-match",
+                kind: "formula",
+                installedVersion: version("1.0.0"),
+                latestVersion: version("2.0.0"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await store.refresh(false);
+    expect(store.getSnapshot().updates[0]).toMatchObject({
+      source: "homebrew",
+      homebrewToken: "manual-homebrew-match",
+      updateURL: fallbackURL
+    });
+
+    await store.performAppUpdate(app.id);
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(openExternalURL).toHaveBeenCalledWith(fallbackURL);
+    expect(openAppBundle).not.toHaveBeenCalled();
+  });
+
   it("rejects unsafe Homebrew-backed app update tokens", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Unsafe Managed.app",
@@ -1845,75 +1905,6 @@ describe("update store helpers", () => {
       expect(store.getSnapshot().homebrewItems.find((item) => item.id === itemID)?.isOutdated).toBe(
         true
       );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("returns failed Homebrew app fallback updates to retryable state after a short delay", async () => {
-    const app = appRecord({
-      bundlePath: "/Applications/Homebrew Fallback.app",
-      displayName: "Homebrew Fallback",
-      bundleIdentifier: "com.example.homebrew-fallback",
-      localVersion: version("1.0.0")
-    });
-    const store = await makeStore({
-      persisted: {
-        ...defaultPersistedSnapshot(),
-        apps: [app],
-        updates: [
-          {
-            id: app.id,
-            appID: app.id,
-            source: "homebrew",
-            supportLevel: "limited",
-            localVersion: version("1.0.0"),
-            remoteVersion: version("2.0.0"),
-            homebrewToken: "homebrew-fallback",
-            checkedAt: "2026-05-20T12:00:00.000Z"
-          }
-        ]
-      },
-      clients: {
-        scanner: { scanApplications: async () => [app] },
-        appStore: { lookupOutcome: async () => ({ type: "completed" }) },
-        sparkle: { lookupOutcome: async () => ({ type: "completed" }) },
-        homebrew: {
-          fetchIndex: async () => emptyHomebrewCaskIndex,
-          lookupUpdate: () => ({
-            remoteVersion: version("2.0.0"),
-            token: "homebrew-fallback"
-          }),
-          searchCasks: () => []
-        },
-        homebrewFormula: {
-          fetchIndex: async () => emptyHomebrewFormulaIndex,
-          searchFormulae: () => []
-        },
-        homebrewInventory: {
-          fetchInventory: async () => ({
-            items: [],
-            outdatedDetectionSucceeded: true,
-            outdatedDetectionSucceededByKind: { formula: true, cask: true }
-          })
-        }
-      },
-      runBrewCommand: async (_args, onOutputLine = () => undefined) => {
-        onOutputLine("Downloading homebrew-fallback");
-        return { success: false, status: 1, output: "Error: update failed" };
-      }
-    });
-
-    vi.useFakeTimers();
-    try {
-      await store.performAppUpdate(app.id);
-
-      expect(store.getSnapshot().homebrewFallbackFailedAppIDs).toContain(app.id);
-
-      vi.advanceTimersByTime(4000);
-      expect(store.getSnapshot().homebrewFallbackFailedAppIDs).not.toContain(app.id);
-      expect(store.getSnapshot().homebrewFallbackProgressByAppID[app.id]).toBeUndefined();
-      expect(store.getSnapshot().updates.find((update) => update.appID === app.id)).toBeDefined();
     } finally {
       vi.useRealTimers();
     }

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1641,6 +1641,53 @@ describe("update store helpers", () => {
     );
   });
 
+  it("routes Homebrew-backed app updates through installed casks even when cask outdated metadata is missing", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Homebrew Managed.app",
+      displayName: "Homebrew Managed",
+      bundleIdentifier: "com.example.homebrew",
+      localVersion: version("1.0.0")
+    });
+    const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "homebrew",
+            supportLevel: "limited",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            homebrewToken: "homebrew-managed",
+            updateURL: "https://formulae.brew.sh/cask/homebrew-managed",
+            checkedAt: "2026-05-20T12:00:00.000Z"
+          }
+        ],
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:homebrew-managed",
+            token: "homebrew-managed",
+            name: "Homebrew Managed",
+            kind: "cask",
+            installedVersion: version("1.0.0"),
+            isOutdated: false
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performAppUpdate(app.id);
+
+    expect(runBrewCommand).toHaveBeenCalledWith(
+      ["upgrade", "--cask", "homebrew-managed"],
+      expect.any(Function)
+    );
+  });
+
   it("uses external fallback for unmanaged Homebrew-backed app updates", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Manual Homebrew Match.app",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -85,7 +85,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private refreshSequence = 0;
   private autoRefreshTimer?: NodeJS.Timeout;
   private readonly homebrewBatchFailureClearTimers = new Map<string, NodeJS.Timeout>();
-  private readonly homebrewFallbackFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private readonly homebrewDiscoverFailureClearTimers = new Map<string, NodeJS.Timeout>();
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
@@ -320,12 +319,18 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
 
     if (update.source === "homebrew" && update.homebrewToken) {
+      if (!isValidHomebrewToken(update.homebrewToken)) {
+        this.patch({
+          refreshErrorMessage: `Blocked unsafe Homebrew token for ${appRecord.displayName}.`
+        });
+        return;
+      }
       const item = this.matchingHomebrewItemForApp(appRecord);
       if (item?.isOutdated) {
         await this.performHomebrewUpdate(item.id);
         return;
       }
-      await this.runHomebrewAppFallback(appRecord, update.homebrewToken);
+      await this.routeExternalUpdate(appRecord, update);
       return;
     }
 
@@ -674,6 +679,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             localVersion: appRecord.localVersion,
             remoteVersion: homebrewUpdate.remoteVersion,
             homebrewToken: homebrewUpdate.token,
+            updateURL: homebrewUpdate.homepageURL,
             releaseNotesSummary: `Token: ${homebrewUpdate.token}`,
             checkedAt: now
           });
@@ -785,45 +791,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     await this.openAppBundle(appRecord.bundlePath);
   }
 
-  private async runHomebrewAppFallback(appRecord: AppRecord, token: string): Promise<void> {
-    if (!isValidHomebrewToken(token)) {
-      this.patch({
-        refreshErrorMessage: `Blocked unsafe Homebrew token for ${appRecord.displayName}.`
-      });
-      return;
-    }
-    await this.withAppUpdating(appRecord.id, async () => {
-      this.clearHomebrewFallbackFailureTimer(appRecord.id);
-      this.patch({
-        homebrewFallbackFailedAppIDs: removeFromArray(
-          this.state.homebrewFallbackFailedAppIDs,
-          appRecord.id
-        )
-      });
-      const parser = new HomebrewMaintenanceOutputParser([token.toLowerCase()]);
-      const success = await this.runBrewWithEvents(["upgrade", "--cask", token], (event) => {
-        this.applyHomebrewFallbackEvent(event, parser, appRecord.id, token.toLowerCase());
-      });
-      this.patch({
-        appUpdatedPendingRefreshIDs: success
-          ? addToArray(this.state.appUpdatedPendingRefreshIDs, appRecord.id)
-          : this.state.appUpdatedPendingRefreshIDs,
-        homebrewFallbackFailedAppIDs: success
-          ? removeFromArray(this.state.homebrewFallbackFailedAppIDs, appRecord.id)
-          : addToArray(this.state.homebrewFallbackFailedAppIDs, appRecord.id),
-        refreshErrorMessage: success
-          ? undefined
-          : `Homebrew update failed for ${appRecord.displayName}.`
-      });
-      if (!success) {
-        this.scheduleHomebrewFallbackFailureClear([appRecord.id]);
-      } else {
-        await this.holdSuccessfulUpdate();
-      }
-      await this.refresh();
-    });
-  }
-
   private async runBrewWithEvents(
     command: string[],
     onEvent: (event: HomebrewMaintenanceRunEvent) => void
@@ -917,36 +884,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
   }
 
-  private applyHomebrewFallbackEvent(
-    event: HomebrewMaintenanceRunEvent,
-    parser: HomebrewMaintenanceOutputParser,
-    appID: string,
-    token: string
-  ): void {
-    if (event.type !== "outputLine") {
-      return;
-    }
-    for (const parsed of parser.parse(event.line, event.command)) {
-      if (parsed.token !== token || parsed.kind.type !== "progress") {
-        continue;
-      }
-      this.patch({
-        homebrewFallbackProgressByAppID: {
-          ...this.state.homebrewFallbackProgressByAppID,
-          [appID]: Math.max(
-            this.state.homebrewFallbackProgressByAppID[appID] ?? 0,
-            parsed.kind.progress
-          )
-        }
-      });
-    }
-  }
-
   private matchingHomebrewItemForApp(appRecord: AppRecord): HomebrewManagedItem | undefined {
     const update = this.state.updates.find((candidate) => candidate.appID === appRecord.id);
     const token = update?.homebrewToken?.toLowerCase();
     return token
-      ? this.state.homebrewItems.find((item) => item.token.toLowerCase() === token)
+      ? this.state.homebrewItems.find(
+          (item) => item.kind === "cask" && item.token.toLowerCase() === token
+        )
       : undefined;
   }
 
@@ -1046,30 +990,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
   }
 
-  private scheduleHomebrewFallbackFailureClear(appIDs: string[]): void {
-    for (const appID of appIDs) {
-      this.clearHomebrewFallbackFailureTimer(appID);
-      const timer = setTimeout(() => {
-        this.homebrewFallbackFailureClearTimers.delete(appID);
-        if (!this.state.homebrewFallbackFailedAppIDs.includes(appID)) {
-          return;
-        }
-        this.patch({
-          homebrewFallbackFailedAppIDs: removeFromArray(
-            this.state.homebrewFallbackFailedAppIDs,
-            appID
-          ),
-          homebrewFallbackProgressByAppID: removeRecordKey(
-            this.state.homebrewFallbackProgressByAppID,
-            appID
-          )
-        });
-      }, TRANSIENT_HOMEBREW_FAILURE_MS);
-      timer.unref?.();
-      this.homebrewFallbackFailureClearTimers.set(appID, timer);
-    }
-  }
-
   private scheduleHomebrewDiscoverFailureClear(itemID: string): void {
     this.clearHomebrewDiscoverFailureTimer(itemID);
     const timer = setTimeout(() => {
@@ -1097,14 +1017,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (timer) {
       clearTimeout(timer);
       this.homebrewBatchFailureClearTimers.delete(itemID);
-    }
-  }
-
-  private clearHomebrewFallbackFailureTimer(appID: string): void {
-    const timer = this.homebrewFallbackFailureClearTimers.get(appID);
-    if (timer) {
-      clearTimeout(timer);
-      this.homebrewFallbackFailureClearTimers.delete(appID);
     }
   }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -33,7 +33,11 @@ import {
 } from "../shared/homebrewProgress";
 import { homebrewItemHasAppRepresentation } from "../shared/homebrewAppLinking";
 import type { PreferencePatch } from "../shared/ipc";
-import { isAllowedExternalURL, isValidHomebrewToken } from "../shared/security";
+import {
+  isAllowedExternalURL,
+  isValidHomebrewToken,
+  sanitizeExternalURL
+} from "../shared/security";
 import {
   compareVersions,
   isVersionEmpty,
@@ -332,7 +336,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         await this.performHomebrewItemUpdate(item);
         return;
       }
-      await this.routeExternalUpdate(appRecord, update);
+      await this.routeExternalUpdate(appRecord, {
+        ...update,
+        updateURL: update.updateURL ?? homebrewCaskPageURL(update.homebrewToken)
+      });
       return;
     }
 
@@ -1117,6 +1124,10 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     showMenuBarIcon: snapshot.showMenuBarIcon,
     lastRefreshDate: snapshot.lastRefreshDate
   };
+}
+
+function homebrewCaskPageURL(token: string): string | undefined {
+  return sanitizeExternalURL(`https://formulae.brew.sh/cask/${token}`);
 }
 
 function toggleSet(set: Set<string>, value: string): void {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -326,8 +326,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         return;
       }
       const item = this.matchingHomebrewItemForApp(appRecord);
-      if (item?.isOutdated) {
-        await this.performHomebrewUpdate(item.id);
+      if (item) {
+        await this.performHomebrewItemUpdate(item);
         return;
       }
       await this.routeExternalUpdate(appRecord, update);
@@ -342,7 +342,14 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (!item?.isOutdated || !isValidHomebrewToken(item.token)) {
       return;
     }
+    await this.performHomebrewItemUpdate(item);
+  }
 
+  private async performHomebrewItemUpdate(item: HomebrewManagedItem): Promise<void> {
+    if (!isValidHomebrewToken(item.token)) {
+      return;
+    }
+    const itemID = item.id;
     const command =
       item.kind === "cask" ? ["upgrade", "--cask", item.token] : ["upgrade", item.token];
     await this.withHomebrewUpdating(itemID, async () => {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -514,11 +514,16 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return;
     }
     if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
-      this.patch({
-        refreshErrorMessage:
-          "Homebrew is not installed. Install Homebrew to install Discover items."
-      });
-      return;
+      const brew = await this.runBrewCommand(["--version"]);
+      this.hasCheckedHomebrewAvailability = true;
+      if (!brew.success) {
+        this.patch({
+          refreshErrorMessage:
+            "Homebrew is not installed. Install Homebrew to install Discover items."
+        });
+        return;
+      }
+      this.patch({ isHomebrewInstalled: true });
     }
     const itemID = item.id;
     this.clearHomebrewDiscoverFailureTimer(itemID);
@@ -556,6 +561,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       refreshErrorMessage: success ? undefined : `Homebrew install failed for ${item.displayName}.`
     });
     if (success) {
+      this.hasCheckedHomebrewAvailability = true;
+      this.patch({ isHomebrewInstalled: true });
       await this.holdSuccessfulUpdate();
       await this.refresh();
     } else {


### PR DESCRIPTION
## Summary

- carry Homebrew cask lookup fallback URLs into app update records
- derive canonical cask fallback URLs for pre-change persisted Homebrew app update records that lack `updateURL`
- route Homebrew-backed app rows to the external cask page unless installed cask inventory proves the app is managed
- remove the unmanaged `brew upgrade --cask` fallback command path and keep direct Homebrew upgrades limited to installed casks

Fixes #107

## Validation
- `npm test -- --run ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm run lint`
