### PR TITLE
Serialize Homebrew commands and queue updates

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -64,6 +64,7 @@ function snapshot(patch: Partial<BaselineSnapshot> = {}): BaselineSnapshot {
     isRefreshing: false,
     searchText: "",
     isRunningHomebrewMaintenance: false,
+    isHomebrewCommandLocked: false,
     appUpdatingIDs: [],
     appUpdatedPendingRefreshIDs: [],
     homebrewUpdatingItemIDs: [],
@@ -1357,6 +1358,43 @@ describe("renderer button parity", () => {
           snapshot={snapshot({
             isRunningHomebrewMaintenance: true,
             homebrewDiscoverItems: [item]
+          })}
+        />
+      </ActionConfirmationContext.Provider>
+    );
+
+    const busyButton = screen.getByRole("button", { name: "Busy" });
+    expect(busyButton).toBeDisabled();
+    fireEvent.click(busyButton);
+    expect(requestConfirmation).not.toHaveBeenCalled();
+    expect(window.baseline.installHomebrewItem).not.toHaveBeenCalled();
+  });
+
+  it("disables other discover installs while a Homebrew command lock is active", () => {
+    const requestConfirmation = vi.fn();
+    const doneItem: HomebrewCaskDiscoveryItem = {
+      id: "formula:fd",
+      token: "fd",
+      displayName: "fd",
+      kind: "formula",
+      version: version("10.0.0")
+    };
+    const otherItem: HomebrewCaskDiscoveryItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      displayName: "ripgrep",
+      kind: "formula",
+      version: version("14.1.0")
+    };
+
+    render(
+      <ActionConfirmationContext.Provider value={requestConfirmation}>
+        <DiscoverRow
+          item={otherItem}
+          snapshot={snapshot({
+            isHomebrewCommandLocked: true,
+            homebrewDiscoverItems: [doneItem, otherItem],
+            homebrewDiscoverInstalledPendingRefreshItemIDs: [doneItem.id]
           })}
         />
       </ActionConfirmationContext.Provider>

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1451,6 +1451,41 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Update Brews" })).toBeInTheDocument();
   });
 
+  it("disables Homebrew update actions while a Discover install is active", () => {
+    const second: HomebrewManagedItem = {
+      ...cask,
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula"
+    };
+
+    render(
+      <HomebrewSection
+        sectionID="outdated"
+        title="Outdated"
+        items={[cask, second]}
+        snapshot={snapshot({
+          homebrewItems: [cask, second],
+          homebrewDiscoverInstallingItemIDs: ["formula:fd"]
+        })}
+        empty="No updates."
+        showUpdateAll
+      />
+    );
+
+    const batchButton = screen.getByRole("button", { name: "Updating" });
+    expect(batchButton).toBeDisabled();
+    fireEvent.click(batchButton);
+    expect(window.baseline.performHomebrewUpdateAll).not.toHaveBeenCalled();
+
+    for (const updateButton of screen.getAllByRole("button", { name: "Update" })) {
+      expect(updateButton).toBeDisabled();
+      fireEvent.click(updateButton);
+    }
+    expect(window.baseline.performHomebrewUpdate).not.toHaveBeenCalled();
+  });
+
   it("renders full-window update sections as card grids with inline update actions", () => {
     const formula: HomebrewManagedItem = {
       id: "formula:ripgrep",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -218,7 +218,7 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Updated" })).toBeInTheDocument();
   });
 
-  it("disables Homebrew app updates during active Homebrew commands without an uninstallable cask", () => {
+  it("keeps Homebrew app updates clickable during active Homebrew commands", () => {
     const sparkleBackedApp: AppRecord = {
       ...app,
       id: "app:sparkle-homebrew-fallback",
@@ -248,9 +248,9 @@ describe("renderer button parity", () => {
     );
 
     const updateButton = screen.getByRole("button", { name: "Update" });
-    expect(updateButton).toBeDisabled();
+    expect(updateButton).toBeEnabled();
     fireEvent.click(updateButton);
-    expect(window.baseline.performAppUpdate).not.toHaveBeenCalled();
+    expect(window.baseline.performAppUpdate).toHaveBeenCalledWith(sparkleBackedApp.id);
   });
 
   it("groups ignore and uninstall under row actions menu", () => {
@@ -1524,7 +1524,7 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Update Brews" })).toBeInTheDocument();
   });
 
-  it("disables Homebrew update actions while a Discover install is active", () => {
+  it("keeps individual Homebrew update actions clickable while a Discover install is active", () => {
     const second: HomebrewManagedItem = {
       ...cask,
       id: "formula:ripgrep",
@@ -1553,10 +1553,10 @@ describe("renderer button parity", () => {
     expect(window.baseline.performHomebrewUpdateAll).not.toHaveBeenCalled();
 
     for (const updateButton of screen.getAllByRole("button", { name: "Update" })) {
-      expect(updateButton).toBeDisabled();
+      expect(updateButton).toBeEnabled();
       fireEvent.click(updateButton);
     }
-    expect(window.baseline.performHomebrewUpdate).not.toHaveBeenCalled();
+    expect(window.baseline.performHomebrewUpdate).toHaveBeenCalledTimes(2);
   });
 
   it("renders full-window update sections as card grids with inline update actions", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -218,6 +218,41 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Updated" })).toBeInTheDocument();
   });
 
+  it("disables Homebrew app updates during active Homebrew commands without an uninstallable cask", () => {
+    const sparkleBackedApp: AppRecord = {
+      ...app,
+      id: "app:sparkle-homebrew-fallback",
+      displayName: "Sparkle Homebrew Fallback",
+      sourceHint: "sparkle"
+    };
+    const sparkleBackedUpdate: UpdateRecord = {
+      ...update,
+      id: sparkleBackedApp.id,
+      appID: sparkleBackedApp.id,
+      source: "homebrew",
+      supportLevel: "limited",
+      homebrewToken: "sparkle-homebrew-fallback"
+    };
+
+    render(
+      <AppRow
+        app={sparkleBackedApp}
+        snapshot={snapshot({
+          apps: [sparkleBackedApp],
+          updates: [sparkleBackedUpdate],
+          homebrewItems: [],
+          isHomebrewCommandLocked: true
+        })}
+        recentlyUpdated={false}
+      />
+    );
+
+    const updateButton = screen.getByRole("button", { name: "Update" });
+    expect(updateButton).toBeDisabled();
+    fireEvent.click(updateButton);
+    expect(window.baseline.performAppUpdate).not.toHaveBeenCalled();
+  });
+
   it("groups ignore and uninstall under row actions menu", () => {
     const { container, rerender } = render(
       <AppRow app={app} snapshot={snapshot()} recentlyUpdated={false} />

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1340,6 +1340,35 @@ describe("renderer button parity", () => {
     expect(window.baseline.installHomebrewItem).not.toHaveBeenCalled();
   });
 
+  it("disables discover installs while Homebrew maintenance is active", () => {
+    const requestConfirmation = vi.fn();
+    const item: HomebrewCaskDiscoveryItem = {
+      id: "cask:raycast",
+      token: "raycast",
+      displayName: "Raycast",
+      kind: "cask",
+      version: version("1.2.3")
+    };
+
+    render(
+      <ActionConfirmationContext.Provider value={requestConfirmation}>
+        <DiscoverRow
+          item={item}
+          snapshot={snapshot({
+            isRunningHomebrewMaintenance: true,
+            homebrewDiscoverItems: [item]
+          })}
+        />
+      </ActionConfirmationContext.Provider>
+    );
+
+    const busyButton = screen.getByRole("button", { name: "Busy" });
+    expect(busyButton).toBeDisabled();
+    fireEvent.click(busyButton);
+    expect(requestConfirmation).not.toHaveBeenCalled();
+    expect(window.baseline.installHomebrewItem).not.toHaveBeenCalled();
+  });
+
   it("orders discover actions as install then open page", () => {
     const item: HomebrewCaskDiscoveryItem = {
       id: "cask:raycast",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -68,6 +68,7 @@ function snapshot(patch: Partial<BaselineSnapshot> = {}): BaselineSnapshot {
     appUpdatingIDs: [],
     appUpdatedPendingRefreshIDs: [],
     homebrewUpdatingItemIDs: [],
+    homebrewQueuedItemIDs: [],
     homebrewUninstallingItemIDs: [],
     homebrewUpdatedPendingRefreshItemIDs: [],
     homebrewBatchProgressByItemID: {},
@@ -199,6 +200,24 @@ describe("renderer button parity", () => {
 
     expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Updating" })).toBeInTheDocument();
+  });
+
+  it("shows matched Homebrew cask queued state on app update buttons", () => {
+    render(
+      <AppRow
+        app={app}
+        snapshot={snapshot({
+          homebrewUpdatingItemIDs: [cask.id],
+          homebrewQueuedItemIDs: [cask.id],
+          homebrewBatchProgressByItemID: { [cask.id]: 0 }
+        })}
+        recentlyUpdated={false}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Updating" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Queued" })).toBeInTheDocument();
   });
 
   it("shows matched Homebrew cask success on app update buttons before refresh", () => {
@@ -1296,6 +1315,26 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("menuitem", { name: "Ignore" })).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: "Updating" }));
     expect(window.baseline.performHomebrewUpdate).not.toHaveBeenCalled();
+  });
+
+  it("uses a queued state for queued Homebrew row updates", () => {
+    render(
+      <HomebrewRow
+        item={cask}
+        snapshot={snapshot({
+          homebrewUpdatingItemIDs: [cask.id],
+          homebrewQueuedItemIDs: [cask.id],
+          homebrewBatchProgressByItemID: { [cask.id]: 0 }
+        })}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Updating" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    expect(screen.getByRole("button", { name: "Queued" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Queued" })).not.toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Uninstall" })).toBeDisabled();
+    expect(screen.getByRole("menuitem", { name: "Ignore" })).toBeEnabled();
   });
 
   it("disables Homebrew ignore/update while uninstalling", () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3060,6 +3060,62 @@ describe("update store helpers", () => {
     await install;
   });
 
+  it("skips Homebrew inventory during unrelated refreshes while a Discover install is active", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    const existingItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "install") {
+        return await new Promise((resolve) => {
+          resolveInstall = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const fetchInventory = vi.fn(async () => ({
+      items: [existingItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [existingItem]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const install = store.installHomebrewItem(discoverItem);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
+
+    await store.refresh(false);
+    expect(fetchInventory).not.toHaveBeenCalled();
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+
+    expect(fetchInventory).toHaveBeenCalledOnce();
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3489,6 +3489,77 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
   });
 
+  it("starts queued Homebrew updates after a superseded refresh inventory releases the lock", async () => {
+    const item = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(async () => {
+      if (fetchInventory.mock.calls.length > 1) {
+        return {
+          items: [item],
+          outdatedDetectionSucceeded: true,
+          outdatedDetectionSucceededByKind: { formula: true, cask: true }
+        };
+      }
+      return await new Promise<{
+        items: HomebrewManagedItem[];
+        outdatedDetectionSucceeded: boolean;
+        outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+      }>((resolve) => {
+        resolveInventory = resolve;
+      });
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [item]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const staleRefresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+
+    const update = store.performHomebrewUpdate(item.id);
+    await Promise.resolve();
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain(item.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(item.id);
+
+    await store.refresh(false);
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(item.id);
+
+    resolveInventory({
+      items: [item],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await staleRefresh;
+    await update;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
+  });
+
   it("skips stale queued Homebrew updates after refresh inventory marks them current", async () => {
     const outdatedItem = homebrewItem({
       id: "formula:ripgrep",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3062,6 +3062,64 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
   });
 
+  it("keeps the Homebrew command lock visible during a successful Discover install hold", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    const existingItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [existingItem]
+      },
+      runBrewCommand,
+      successRefreshDelayMS: 100
+    });
+
+    vi.useFakeTimers();
+    try {
+      const install = store.installHomebrewItem(discoverItem);
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().homebrewDiscoverInstalledPendingRefreshItemIDs).toContain(
+          discoverItem.id
+        );
+      });
+      expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+
+      await store.refresh(false);
+      expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+      expect(store.getSnapshot().homebrewDiscoverInstalledPendingRefreshItemIDs).toContain(
+        discoverItem.id
+      );
+
+      await store.performHomebrewUpdate("formula:ripgrep");
+      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
+
+      await vi.advanceTimersByTimeAsync(100);
+      await install;
+
+      expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("skips Homebrew inventory during unrelated refreshes while a Discover install is active", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2901,6 +2901,65 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
   });
 
+  it("suppresses duplicate Discover installs while rechecking Homebrew availability", async () => {
+    const item = {
+      id: "formula:ripgrep",
+      kind: "formula" as const,
+      token: "ripgrep",
+      displayName: "ripgrep",
+      presentation: "formula" as const,
+      version: version("14.1.0")
+    };
+    let resolveAvailability!: (result: {
+      success: boolean;
+      status: number | null;
+      output: string;
+    }) => void;
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "--version") {
+        if (runBrewCommand.mock.calls.length === 1) {
+          return { success: false, status: null, output: "" };
+        }
+        return await new Promise((resolve) => {
+          resolveAvailability = resolve;
+        });
+      }
+      return await new Promise((resolve) => {
+        resolveInstall = resolve;
+      });
+    });
+    const store = await makeStore({ runBrewCommand });
+
+    await store.refreshToolStatus();
+    expect(store.getSnapshot().isHomebrewInstalled).toBe(false);
+
+    const firstInstall = store.installHomebrewItem(item);
+    const secondInstall = store.installHomebrewItem(item);
+
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(item.id);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["--version"],
+      ["--version"]
+    ]);
+
+    resolveAvailability({ success: true, status: 0, output: "" });
+    await vi.waitFor(() => {
+      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+        ["--version"],
+        ["--version"],
+        ["install", "ripgrep"]
+      ]);
+    });
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await Promise.all([firstInstall, secondInstall]);
+
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
+  });
+
   it("does not start other Homebrew commands during an active Discover install", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3063,7 +3063,7 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().isHomebrewInstalled).toBe(true);
   });
 
-  it("does not start other Homebrew commands during an active Discover install", async () => {
+  it("queues individual Homebrew updates during an active Discover install", async () => {
     const discoverItem = {
       id: "formula:fd",
       kind: "formula" as const,
@@ -3075,12 +3075,14 @@ describe("update store helpers", () => {
     let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
-    >(
-      async () =>
-        await new Promise((resolve) => {
+    >(async (command) => {
+      if (command[0] === "install") {
+        return await new Promise((resolve) => {
           resolveInstall = resolve;
-        })
-    );
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
     const store = await makeStore({
       persisted: {
         ...defaultPersistedSnapshot(),
@@ -3095,20 +3097,46 @@ describe("update store helpers", () => {
           })
         ]
       },
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:raycast",
+                token: "raycast",
+                name: "Raycast",
+                kind: "cask",
+                latestVersion: version("2.0.0"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
       runBrewCommand
     });
 
     const install = store.installHomebrewItem(discoverItem);
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
 
-    await store.performHomebrewUpdate("cask:raycast");
+    const queuedUpdate = store.performHomebrewUpdate("cask:raycast");
+    await Promise.resolve();
     await store.performHomebrewUpdateAll();
     await store.uninstallHomebrewItem("cask:raycast");
 
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("cask:raycast");
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
 
     resolveInstall({ success: true, status: 0, output: "" });
     await install;
+    await queuedUpdate;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["install", "fd"],
+      ["upgrade", "--cask", "raycast"]
+    ]);
   });
 
   it("does not install mas through Homebrew during an active Discover install", async () => {
@@ -3187,13 +3215,16 @@ describe("update store helpers", () => {
     await store.refresh(false);
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
 
-    await store.performHomebrewUpdate("formula:ripgrep");
+    const queuedUpdate = store.performHomebrewUpdate("formula:ripgrep");
+    await Promise.resolve();
     await store.performHomebrewUpdateAll();
 
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("formula:ripgrep");
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
 
     resolveInstall({ success: true, status: 0, output: "" });
     await install;
+    await queuedUpdate;
 
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
   });
@@ -3243,9 +3274,6 @@ describe("update store helpers", () => {
       expect(store.getSnapshot().homebrewDiscoverInstalledPendingRefreshItemIDs).toContain(
         discoverItem.id
       );
-
-      await store.performHomebrewUpdate("formula:ripgrep");
-      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
 
       await vi.advanceTimersByTimeAsync(100);
       await install;

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3556,6 +3556,94 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
   });
 
+  it("skips stale queued Homebrew app updates after refresh inventory marks them current", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Example.app",
+      displayName: "Example",
+      bundleIdentifier: "com.example.app",
+      localVersion: version("1.0.0")
+    });
+    const outdatedItem = homebrewItem({
+      id: "cask:example",
+      token: "example",
+      name: "Example",
+      kind: "cask",
+      appID: app.id,
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    });
+    const currentItem = {
+      ...outdatedItem,
+      installedVersion: version("2.0.0"),
+      isOutdated: false
+    };
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(
+      async () =>
+        await new Promise<{
+          items: HomebrewManagedItem[];
+          outdatedDetectionSucceeded: boolean;
+          outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+        }>((resolve) => {
+          resolveInventory = resolve;
+        })
+    );
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "homebrew",
+            supportLevel: "limited",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            homebrewToken: "example",
+            checkedAt: "2026-05-20T12:00:00.000Z"
+          }
+        ],
+        homebrewItems: [outdatedItem]
+      },
+      clients: {
+        scanner: { scanApplications: async () => [app] },
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const refresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+
+    const update = store.performAppUpdate(app.id);
+    await Promise.resolve();
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain(outdatedItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(outdatedItem.id);
+
+    resolveInventory({
+      items: [currentItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await refresh;
+    await update;
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().homebrewItems[0]?.isOutdated).toBe(false);
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(outdatedItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3145,11 +3145,16 @@ describe("update store helpers", () => {
 
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("formula:ripgrep");
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("cask:raycast");
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain("formula:ripgrep");
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain("cask:raycast");
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
 
     resolveInstall({ success: true, status: 0, output: "" });
     await install;
     await Promise.all([queuedFormulaUpdate, queuedUpdate]);
+
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain("formula:ripgrep");
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain("cask:raycast");
 
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["install", "fd"],
@@ -3239,6 +3244,7 @@ describe("update store helpers", () => {
     await store.performHomebrewUpdateAll();
 
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("formula:ripgrep");
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain("formula:ripgrep");
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
 
     resolveInstall({ success: true, status: 0, output: "" });
@@ -3246,6 +3252,7 @@ describe("update store helpers", () => {
     await queuedUpdate;
 
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain("formula:ripgrep");
   });
 
   it("keeps the Homebrew command lock visible during a successful Discover install hold", async () => {
@@ -3466,6 +3473,7 @@ describe("update store helpers", () => {
     const update = store.performHomebrewUpdate(item.id);
     await Promise.resolve();
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain(item.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(item.id);
     expect(runBrewCommand).not.toHaveBeenCalled();
 
     resolveInventory({
@@ -3478,6 +3486,7 @@ describe("update store helpers", () => {
 
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
     expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
   });
 
   it("does not start Discover installs during active Homebrew maintenance", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3678,6 +3678,89 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
   });
 
+  it("applies in-flight Homebrew inventory before draining queued updates after refresh failure", async () => {
+    const outdatedItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const currentItem = {
+      ...outdatedItem,
+      installedVersion: version("14.1.0"),
+      isOutdated: false
+    };
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(
+      async () =>
+        await new Promise<{
+          items: HomebrewManagedItem[];
+          outdatedDetectionSucceeded: boolean;
+          outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+        }>((resolve) => {
+          resolveInventory = resolve;
+        })
+    );
+    const fetchIndex = vi.fn(async () => {
+      if (fetchIndex.mock.calls.length > 1) {
+        throw new Error("index failed");
+      }
+      return emptyHomebrewCaskIndex;
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [outdatedItem]
+      },
+      clients: {
+        homebrew: {
+          fetchIndex,
+          lookupUpdate: () => undefined,
+          searchCasks: () => []
+        },
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const staleRefresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+
+    const update = store.performHomebrewUpdate(outdatedItem.id);
+    await Promise.resolve();
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(outdatedItem.id);
+
+    const failingRefresh = store.refresh(false);
+    await Promise.resolve();
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(outdatedItem.id);
+
+    resolveInventory({
+      items: [currentItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await Promise.all([staleRefresh, failingRefresh, update]);
+
+    expect(fetchIndex).toHaveBeenCalledTimes(2);
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().refreshErrorMessage).toBe("index failed");
+    expect(store.getSnapshot().homebrewItems[0]?.isOutdated).toBe(false);
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(outdatedItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
+  });
+
   it("skips stale queued Homebrew updates after refresh inventory marks them current", async () => {
     const outdatedItem = homebrewItem({
       id: "formula:ripgrep",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2901,6 +2901,54 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
   });
 
+  it("does not start other Homebrew commands during an active Discover install", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(
+      async () =>
+        await new Promise((resolve) => {
+          resolveInstall = resolve;
+        })
+    );
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:raycast",
+            token: "raycast",
+            name: "Raycast",
+            kind: "cask",
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    const install = store.installHomebrewItem(discoverItem);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
+
+    await store.performHomebrewUpdate("cask:raycast");
+    await store.performHomebrewUpdateAll();
+    await store.uninstallHomebrewItem("cask:raycast");
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3088,6 +3088,14 @@ describe("update store helpers", () => {
         ...defaultPersistedSnapshot(),
         homebrewItems: [
           homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
             id: "cask:raycast",
             token: "raycast",
             name: "Raycast",
@@ -3101,6 +3109,14 @@ describe("update store helpers", () => {
         homebrewInventory: {
           fetchInventory: async () => ({
             items: [
+              homebrewItem({
+                id: "formula:ripgrep",
+                token: "ripgrep",
+                name: "ripgrep",
+                kind: "formula",
+                latestVersion: version("14.1.0"),
+                isOutdated: true
+              }),
               homebrewItem({
                 id: "cask:raycast",
                 token: "raycast",
@@ -3121,20 +3137,23 @@ describe("update store helpers", () => {
     const install = store.installHomebrewItem(discoverItem);
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
 
+    const queuedFormulaUpdate = store.performHomebrewUpdate("formula:ripgrep");
     const queuedUpdate = store.performHomebrewUpdate("cask:raycast");
     await Promise.resolve();
     await store.performHomebrewUpdateAll();
     await store.uninstallHomebrewItem("cask:raycast");
 
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("formula:ripgrep");
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain("cask:raycast");
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
 
     resolveInstall({ success: true, status: 0, output: "" });
     await install;
-    await queuedUpdate;
+    await Promise.all([queuedFormulaUpdate, queuedUpdate]);
 
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["install", "fd"],
+      ["upgrade", "ripgrep"],
       ["upgrade", "--cask", "raycast"]
     ]);
   });

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3163,6 +3163,87 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("queues burst-clicked individual Homebrew updates behind the active update", async () => {
+    const formula = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const secondFormula = homebrewItem({
+      id: "formula:bat",
+      token: "bat",
+      name: "bat",
+      kind: "formula",
+      latestVersion: version("0.25.0"),
+      isOutdated: true
+    });
+    const cask = homebrewItem({
+      id: "cask:raycast",
+      token: "raycast",
+      name: "Raycast",
+      kind: "cask",
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    });
+    let resolveFirstUpdate!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "upgrade" && command.includes("ripgrep")) {
+        return await new Promise((resolve) => {
+          resolveFirstUpdate = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [formula, secondFormula, cask]
+      },
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [formula, secondFormula, cask],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
+      runBrewCommand
+    });
+
+    const firstUpdate = store.performHomebrewUpdate(formula.id);
+    await vi.waitFor(() => {
+      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+        ["upgrade", "ripgrep"]
+      ]);
+    });
+
+    const secondUpdate = store.performHomebrewUpdate(secondFormula.id);
+    const thirdUpdate = store.performHomebrewUpdate(cask.id);
+    await Promise.resolve();
+
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual(
+      expect.arrayContaining([secondFormula.id, cask.id])
+    );
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
+
+    resolveFirstUpdate({ success: true, status: 0, output: "" });
+    await Promise.all([firstUpdate, secondUpdate, thirdUpdate]);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "ripgrep"],
+      ["upgrade", "bat"],
+      ["upgrade", "--cask", "raycast"]
+    ]);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual([]);
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toEqual([]);
+  });
+
   it("keeps Discover install state visible during unrelated refreshes", async () => {
     const discoverItem = {
       id: "formula:fd",
@@ -3680,6 +3761,57 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewItems[0]?.isOutdated).toBe(false);
     expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(outdatedItem.id);
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
+  });
+
+  it("does not run stale app-backed Homebrew updates when the current cask is not outdated", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Example.app",
+      displayName: "Example",
+      bundleIdentifier: "com.example.app",
+      localVersion: version("1.0.0")
+    });
+    const currentItem = homebrewItem({
+      id: "cask:example",
+      token: "example",
+      name: "Example",
+      kind: "cask",
+      appID: app.id,
+      installedVersion: version("2.0.0"),
+      latestVersion: undefined,
+      isOutdated: false
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const openExternalURL = vi.fn(async () => true);
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "homebrew",
+            supportLevel: "limited",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            homebrewToken: "example",
+            checkedAt: "2026-05-20T12:00:00.000Z"
+          }
+        ],
+        homebrewItems: [currentItem]
+      },
+      runBrewCommand,
+      openExternalURL
+    });
+
+    await store.performAppUpdate(app.id);
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(openExternalURL).toHaveBeenCalledWith("https://formulae.brew.sh/cask/example");
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(currentItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(currentItem.id);
   });
 
   it("does not start Discover installs during active Homebrew maintenance", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3163,39 +3163,6 @@ describe("update store helpers", () => {
     ]);
   });
 
-  it("does not install mas through Homebrew during an active Discover install", async () => {
-    const discoverItem = {
-      id: "formula:fd",
-      kind: "formula" as const,
-      token: "fd",
-      displayName: "fd",
-      presentation: "formula" as const,
-      version: version("10.0.0")
-    };
-    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
-    const runBrewCommand = vi.fn<
-      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
-    >(
-      async () =>
-        await new Promise((resolve) => {
-          resolveInstall = resolve;
-        })
-    );
-    const runMasCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
-    const store = await makeStore({ runBrewCommand, runMasCommand });
-
-    const install = store.installHomebrewItem(discoverItem);
-    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
-
-    await store.installMasWithHomebrew();
-
-    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
-    expect(runMasCommand).not.toHaveBeenCalled();
-
-    resolveInstall({ success: true, status: 0, output: "" });
-    await install;
-  });
-
   it("keeps Discover install state visible during unrelated refreshes", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2867,6 +2867,95 @@ describe("update store helpers", () => {
       "Homebrew is not installed. Install Homebrew to install Discover items."
     );
   });
+
+  it("suppresses duplicate Homebrew Discover install dispatches", async () => {
+    const item = {
+      id: "formula:ripgrep",
+      kind: "formula" as const,
+      token: "ripgrep",
+      displayName: "ripgrep",
+      presentation: "formula" as const,
+      version: version("14.1.0")
+    };
+    let resolveCommand!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(
+      async () =>
+        await new Promise((resolve) => {
+          resolveCommand = resolve;
+        })
+    );
+    const store = await makeStore({ runBrewCommand });
+
+    const firstInstall = store.installHomebrewItem(item);
+    const secondInstall = store.installHomebrewItem(item);
+
+    expect(runBrewCommand).toHaveBeenCalledOnce();
+    expect(runBrewCommand).toHaveBeenCalledWith(["install", "ripgrep"], expect.any(Function));
+
+    resolveCommand({ success: true, status: 0, output: "" });
+    await Promise.all([firstInstall, secondInstall]);
+
+    expect(runBrewCommand).toHaveBeenCalledOnce();
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
+  });
+
+  it("does not start Discover installs during active Homebrew maintenance", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let releaseMaintenance!: () => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => {
+      if (runBrewCommand.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseMaintenance = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    const maintenance = store.performHomebrewUpdateAll();
+    expect(store.getSnapshot().isRunningHomebrewMaintenance).toBe(true);
+
+    await store.installHomebrewItem(discoverItem);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["update"]]);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
+
+    releaseMaintenance();
+    await maintenance;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+  });
 });
 
 async function makeStore({

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3008,7 +3008,7 @@ describe("update store helpers", () => {
     await install;
   });
 
-  it("keeps Homebrew commands locked when refresh clears active Discover install state", async () => {
+  it("keeps Discover install state visible during unrelated refreshes", async () => {
     const discoverItem = {
       id: "formula:fd",
       kind: "formula" as const,
@@ -3049,7 +3049,7 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
 
     await store.refresh(false);
-    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
 
     await store.performHomebrewUpdate("formula:ripgrep");
     await store.performHomebrewUpdateAll();
@@ -3058,6 +3058,8 @@ describe("update store helpers", () => {
 
     resolveInstall({ success: true, status: 0, output: "" });
     await install;
+
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
   });
 
   it("skips Homebrew inventory during unrelated refreshes while a Discover install is active", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3413,6 +3413,73 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
   });
 
+  it("starts queued Homebrew updates after refresh inventory completes", async () => {
+    const item = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(async () => {
+      if (fetchInventory.mock.calls.length > 1) {
+        return {
+          items: [item],
+          outdatedDetectionSucceeded: true,
+          outdatedDetectionSucceededByKind: { formula: true, cask: true }
+        };
+      }
+      return await new Promise<{
+        items: HomebrewManagedItem[];
+        outdatedDetectionSucceeded: boolean;
+        outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+      }>((resolve) => {
+        resolveInventory = resolve;
+      });
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [item]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const refresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+
+    const update = store.performHomebrewUpdate(item.id);
+    await Promise.resolve();
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain(item.id);
+    expect(runBrewCommand).not.toHaveBeenCalled();
+
+    resolveInventory({
+      items: [item],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await refresh;
+    await update;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3008,6 +3008,58 @@ describe("update store helpers", () => {
     await install;
   });
 
+  it("keeps Homebrew commands locked when refresh clears active Discover install state", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "install") {
+        return await new Promise((resolve) => {
+          resolveInstall = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    const install = store.installHomebrewItem(discoverItem);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
+
+    await store.refresh(false);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
+
+    await store.performHomebrewUpdate("formula:ripgrep");
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2960,6 +2960,91 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
   });
 
+  it("does not run tool-status Homebrew checks during an active Discover install", async () => {
+    const item = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "--version") {
+        return { success: true, status: 0, output: "" };
+      }
+      return await new Promise((resolve) => {
+        resolveInstall = resolve;
+      });
+    });
+    const runMasCommand = vi.fn(async () => ({ success: false, status: null, output: "" }));
+    const store = await makeStore({ runBrewCommand, runMasCommand });
+
+    await store.refreshToolStatus();
+    expect(store.getSnapshot().isHomebrewInstalled).toBe(true);
+
+    const install = store.installHomebrewItem(item);
+    await vi.waitFor(() => {
+      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+        ["--version"],
+        ["install", "fd"]
+      ]);
+    });
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(item.id);
+
+    await store.refreshToolStatus();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["--version"],
+      ["install", "fd"]
+    ]);
+    expect(runMasCommand).toHaveBeenCalledTimes(2);
+    expect(store.getSnapshot().isHomebrewInstalled).toBe(true);
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+  });
+
+  it("blocks Discover installs while a tool-status Homebrew check is active", async () => {
+    const item = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let resolveStatus!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(
+      async () =>
+        await new Promise((resolve) => {
+          resolveStatus = resolve;
+        })
+    );
+    const store = await makeStore({ runBrewCommand });
+
+    const status = store.refreshToolStatus();
+    await vi.waitFor(() => {
+      expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+    });
+
+    await store.installHomebrewItem(item);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["--version"]]);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
+
+    resolveStatus({ success: true, status: 0, output: "" });
+    await status;
+
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
+    expect(store.getSnapshot().isHomebrewInstalled).toBe(true);
+  });
+
   it("does not start other Homebrew commands during an active Discover install", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3008,6 +3008,39 @@ describe("update store helpers", () => {
     await install;
   });
 
+  it("does not install mas through Homebrew during an active Discover install", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(
+      async () =>
+        await new Promise((resolve) => {
+          resolveInstall = resolve;
+        })
+    );
+    const runMasCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({ runBrewCommand, runMasCommand });
+
+    const install = store.installHomebrewItem(discoverItem);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
+
+    await store.installMasWithHomebrew();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
+    expect(runMasCommand).not.toHaveBeenCalled();
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+  });
+
   it("keeps Discover install state visible during unrelated refreshes", async () => {
     const discoverItem = {
       id: "formula:fd",
@@ -3284,6 +3317,137 @@ describe("update store helpers", () => {
       ["autoremove"],
       ["cleanup"]
     ]);
+  });
+
+  it("keeps the Homebrew command lock through batch maintenance refresh", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    const outdatedItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const fetchInventory = vi.fn(async () => ({
+      items: [{ ...outdatedItem, installedVersion: version("14.1.0"), isOutdated: false }],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [outdatedItem]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand,
+      successRefreshDelayMS: 100
+    });
+
+    vi.useFakeTimers();
+    try {
+      const maintenance = store.performHomebrewUpdateAll();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().homebrewUpdatedPendingRefreshItemIDs).toContain(outdatedItem.id);
+      });
+      expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+
+      await store.installHomebrewItem(discoverItem);
+      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+        ["update"],
+        ["upgrade", "ripgrep"],
+        ["autoremove"],
+        ["cleanup"]
+      ]);
+
+      await vi.advanceTimersByTimeAsync(100);
+      await maintenance;
+
+      expect(fetchInventory).toHaveBeenCalledOnce();
+      expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the Homebrew command lock through cask uninstall refresh", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    const caskItem = homebrewItem({
+      id: "cask:raycast",
+      token: "raycast",
+      name: "Raycast",
+      kind: "cask"
+    });
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(
+      async () =>
+        await new Promise<{
+          items: HomebrewManagedItem[];
+          outdatedDetectionSucceeded: boolean;
+          outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+        }>((resolve) => {
+          resolveInventory = resolve;
+        })
+    );
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [caskItem]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const uninstall = store.uninstallHomebrewItem(caskItem.id);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+    expect(store.getSnapshot().homebrewUninstallingItemIDs).not.toContain(caskItem.id);
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+
+    await store.installHomebrewItem(discoverItem);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["uninstall", "--cask", "raycast"]
+    ]);
+
+    resolveInventory({
+      items: [],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await uninstall;
+
+    expect(store.getSnapshot().homebrewItems).toEqual([]);
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
   });
 });
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3592,20 +3592,90 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain(item.id);
     expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(item.id);
 
-    await store.refresh(false);
+    const winningRefresh = store.refresh(false);
+    await Promise.resolve();
     expect(runBrewCommand).not.toHaveBeenCalled();
     expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(item.id);
+    expect(fetchInventory).toHaveBeenCalledOnce();
 
     resolveInventory({
       items: [item],
       outdatedDetectionSucceeded: true,
       outdatedDetectionSucceededByKind: { formula: true, cask: true }
     });
-    await staleRefresh;
-    await update;
+    await Promise.all([staleRefresh, winningRefresh, update]);
 
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
+  });
+
+  it("applies superseded fresh refresh inventory before draining queued Homebrew updates", async () => {
+    const outdatedItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const currentItem = {
+      ...outdatedItem,
+      installedVersion: version("14.1.0"),
+      isOutdated: false
+    };
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(
+      async () =>
+        await new Promise<{
+          items: HomebrewManagedItem[];
+          outdatedDetectionSucceeded: boolean;
+          outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+        }>((resolve) => {
+          resolveInventory = resolve;
+        })
+    );
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [outdatedItem]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const staleRefresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+
+    const update = store.performHomebrewUpdate(outdatedItem.id);
+    await Promise.resolve();
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(outdatedItem.id);
+
+    const winningRefresh = store.refresh(false);
+    await Promise.resolve();
+    expect(fetchInventory).toHaveBeenCalledOnce();
+
+    resolveInventory({
+      items: [currentItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await Promise.all([staleRefresh, winningRefresh, update]);
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().homebrewItems[0]?.isOutdated).toBe(false);
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(outdatedItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
   });
 
   it("skips stale queued Homebrew updates after refresh inventory marks them current", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2625,7 +2625,31 @@ describe("update store helpers", () => {
         return { ...stats, signature: `sealed-${sealCount}` };
       })
     };
-    const store = await makeStore({ profileStatsIntegrity });
+    const app = appRecord({
+      bundlePath: "/Applications/Profiled App.app",
+      displayName: "Profiled App",
+      bundleIdentifier: "com.example.profiled",
+      localVersion: version("1.0.0")
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [
+          {
+            id: app.id,
+            appID: app.id,
+            source: "appStore",
+            supportLevel: "supported",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            appStoreItemID: 123,
+            checkedAt: "2026-06-01T12:00:00.000Z"
+          }
+        ]
+      },
+      profileStatsIntegrity
+    });
 
     const firstInstall = store.installHomebrewItem({
       id: "formula:bat",
@@ -2636,18 +2660,12 @@ describe("update store helpers", () => {
     });
     await firstSealStarted;
 
-    const secondInstall = store.installHomebrewItem({
-      id: "formula:fd",
-      kind: "formula",
-      token: "fd",
-      displayName: "fd",
-      version: version("1.0.0")
-    });
+    const appUpdate = store.performAppUpdate(app.id);
     await Promise.resolve();
     expect(profileStatsIntegrity.seal).toHaveBeenCalledTimes(1);
 
     resolveFirstSeal?.();
-    await Promise.all([firstInstall, secondInstall]);
+    await Promise.all([firstInstall, appUpdate]);
 
     expect(
       store.getSnapshot().profileStats.events.map((event) => ({
@@ -2656,7 +2674,7 @@ describe("update store helpers", () => {
         displayName: event.displayName
       }))
     ).toEqual([
-      { type: "homebrewInstall", targetID: "formula:fd", displayName: "fd" },
+      { type: "appUpdate", targetID: app.id, displayName: "Profiled App" },
       { type: "homebrewInstall", targetID: "formula:bat", displayName: "bat" }
     ]);
   });

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3489,6 +3489,73 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
   });
 
+  it("skips stale queued Homebrew updates after refresh inventory marks them current", async () => {
+    const outdatedItem = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const currentItem = {
+      ...outdatedItem,
+      installedVersion: version("14.1.0"),
+      isOutdated: false
+    };
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(
+      async () =>
+        await new Promise<{
+          items: HomebrewManagedItem[];
+          outdatedDetectionSucceeded: boolean;
+          outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+        }>((resolve) => {
+          resolveInventory = resolve;
+        })
+    );
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [outdatedItem]
+      },
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const refresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+
+    const update = store.performHomebrewUpdate(outdatedItem.id);
+    await Promise.resolve();
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).toContain(outdatedItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toContain(outdatedItem.id);
+
+    resolveInventory({
+      items: [currentItem],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await refresh;
+    await update;
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().homebrewItems[0]?.isOutdated).toBe(false);
+    expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(outdatedItem.id);
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(outdatedItem.id);
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3176,6 +3176,60 @@ describe("update store helpers", () => {
     expect(fetchInventory).toHaveBeenCalledOnce();
   });
 
+  it("does not start Discover installs while refresh inventory is active", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    let resolveInventory!: (result: {
+      items: HomebrewManagedItem[];
+      outdatedDetectionSucceeded: boolean;
+      outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+    }) => void;
+    const fetchInventory = vi.fn(
+      async () =>
+        await new Promise<{
+          items: HomebrewManagedItem[];
+          outdatedDetectionSucceeded: boolean;
+          outdatedDetectionSucceededByKind: { formula: boolean; cask: boolean };
+        }>((resolve) => {
+          resolveInventory = resolve;
+        })
+    );
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      clients: {
+        homebrewInventory: { fetchInventory }
+      },
+      runBrewCommand
+    });
+
+    const refresh = store.refresh(false);
+    await vi.waitFor(() => {
+      expect(fetchInventory).toHaveBeenCalledOnce();
+    });
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(true);
+
+    await store.installHomebrewItem(discoverItem);
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(discoverItem.id);
+
+    resolveInventory({
+      items: [],
+      outdatedDetectionSucceeded: true,
+      outdatedDetectionSucceededByKind: { formula: true, cask: true }
+    });
+    await refresh;
+
+    expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
+  });
+
   it("does not start Discover installs during active Homebrew maintenance", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1001,6 +1001,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         ]);
       const homebrewItems = homebrewInventory.items;
       if (sequence !== this.refreshSequence) {
+        void this.processHomebrewUpdateQueue();
         return;
       }
       this.latestHomebrewIndex = homebrewIndex;
@@ -1087,6 +1088,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       }
 
       if (sequence !== this.refreshSequence) {
+        void this.processHomebrewUpdateQueue();
         return;
       }
       const previousUpdates = new Map(this.state.updates.map((update) => [update.appID, update]));
@@ -1146,6 +1148,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       void this.processHomebrewUpdateQueue();
     } catch (error) {
       if (sequence !== this.refreshSequence) {
+        void this.processHomebrewUpdateQueue();
         return;
       }
       this.patch({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1181,6 +1181,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     } finally {
       this.activeHomebrewInventoryCount = Math.max(0, this.activeHomebrewInventoryCount - 1);
       this.updateHomebrewCommandLockState();
+      void this.processHomebrewUpdateQueue();
     }
   }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -243,22 +243,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
   }
 
-  async installMasWithHomebrew(): Promise<void> {
-    const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
-    if (!releaseHomebrewCommandLock) {
-      return;
-    }
-    try {
-      const result = await this.runBrewCommand(["install", "mas"]);
-      const installed = await this.runMasCommand(["version"]);
-      this.patch({
-        isMasInstalled: result.success && installed.success
-      });
-    } finally {
-      releaseHomebrewCommandLock();
-    }
-  }
-
   async setSearchText(searchText: string): Promise<void> {
     this.patch({ searchText });
     await this.refreshHomebrewDiscoverItems();
@@ -1437,23 +1421,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       await operation();
     } finally {
       this.patch({ appUpdatingIDs: removeFromArray(this.state.appUpdatingIDs, appID) });
-    }
-  }
-
-  private async withHomebrewUpdating(
-    itemID: string,
-    operation: () => Promise<void>
-  ): Promise<void> {
-    if (this.state.homebrewUpdatingItemIDs.includes(itemID)) {
-      return;
-    }
-    this.patch({ homebrewUpdatingItemIDs: addToArray(this.state.homebrewUpdatingItemIDs, itemID) });
-    try {
-      await operation();
-    } finally {
-      this.patch({
-        homebrewUpdatingItemIDs: removeFromArray(this.state.homebrewUpdatingItemIDs, itemID)
-      });
     }
   }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -97,6 +97,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
   private hasCheckedHomebrewAvailability = false;
   private profileStatsMutationQueue: Promise<void> = Promise.resolve();
+  private activeHomebrewCommandCount = 0;
 
   private state: BaselineSnapshot;
 
@@ -578,73 +579,74 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({ refreshErrorMessage: `Blocked unsafe Homebrew token for ${item.displayName}.` });
       return;
     }
-    const itemID = item.id;
-    if (this.isHomebrewCommandActive()) {
-      return;
-    }
-    this.clearHomebrewDiscoverFailureTimer(itemID);
-    this.patch({
-      homebrewDiscoverInstallingItemIDs: addToArray(
-        this.state.homebrewDiscoverInstallingItemIDs,
-        itemID
-      ),
-      homebrewDiscoverFailedItemIDs: removeFromArray(
-        this.state.homebrewDiscoverFailedItemIDs,
-        itemID
-      ),
-      homebrewDiscoverProgressByItemID: {
-        ...this.state.homebrewDiscoverProgressByItemID,
-        [itemID]: HomebrewMaintenanceProgressStage.queued
+    await this.withHomebrewCommandLock(async () => {
+      const itemID = item.id;
+      this.clearHomebrewDiscoverFailureTimer(itemID);
+      this.patch({
+        homebrewDiscoverInstallingItemIDs: addToArray(
+          this.state.homebrewDiscoverInstallingItemIDs,
+          itemID
+        ),
+        homebrewDiscoverFailedItemIDs: removeFromArray(
+          this.state.homebrewDiscoverFailedItemIDs,
+          itemID
+        ),
+        homebrewDiscoverProgressByItemID: {
+          ...this.state.homebrewDiscoverProgressByItemID,
+          [itemID]: HomebrewMaintenanceProgressStage.queued
+        }
+      });
+      if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
+        const brew = await this.runBrewCommand(["--version"]);
+        this.hasCheckedHomebrewAvailability = true;
+        if (!brew.success) {
+          this.patch({
+            homebrewDiscoverInstallingItemIDs: removeFromArray(
+              this.state.homebrewDiscoverInstallingItemIDs,
+              itemID
+            ),
+            homebrewDiscoverProgressByItemID: removeRecordKey(
+              this.state.homebrewDiscoverProgressByItemID,
+              itemID
+            ),
+            refreshErrorMessage:
+              "Homebrew is not installed. Install Homebrew to install Discover items."
+          });
+          return;
+        }
+        this.patch({ isHomebrewInstalled: true });
+      }
+      const command =
+        item.kind === "cask" ? ["install", "--cask", item.token] : ["install", item.token];
+      const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
+      const success = await this.runBrewWithEvents(command, (event) => {
+        this.applyDiscoverInstallEvent(event, parser, itemID, item.token.toLowerCase());
+      });
+      this.patch({
+        homebrewDiscoverInstallingItemIDs: removeFromArray(
+          this.state.homebrewDiscoverInstallingItemIDs,
+          itemID
+        ),
+        homebrewDiscoverInstalledPendingRefreshItemIDs: success
+          ? addToArray(this.state.homebrewDiscoverInstalledPendingRefreshItemIDs, itemID)
+          : this.state.homebrewDiscoverInstalledPendingRefreshItemIDs,
+        homebrewDiscoverFailedItemIDs: success
+          ? removeFromArray(this.state.homebrewDiscoverFailedItemIDs, itemID)
+          : addToArray(this.state.homebrewDiscoverFailedItemIDs, itemID),
+        refreshErrorMessage: success
+          ? undefined
+          : `Homebrew install failed for ${item.displayName}.`
+      });
+      if (success) {
+        this.hasCheckedHomebrewAvailability = true;
+        this.patch({ isHomebrewInstalled: true });
+        await this.recordProfileStatsEvents([homebrewInstallProfileStatsEvent(item)]);
+        await this.holdSuccessfulUpdate();
+        await this.refresh();
+      } else {
+        this.scheduleHomebrewDiscoverFailureClear(itemID);
       }
     });
-    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
-      const brew = await this.runBrewCommand(["--version"]);
-      this.hasCheckedHomebrewAvailability = true;
-      if (!brew.success) {
-        this.patch({
-          homebrewDiscoverInstallingItemIDs: removeFromArray(
-            this.state.homebrewDiscoverInstallingItemIDs,
-            itemID
-          ),
-          homebrewDiscoverProgressByItemID: removeRecordKey(
-            this.state.homebrewDiscoverProgressByItemID,
-            itemID
-          ),
-          refreshErrorMessage:
-            "Homebrew is not installed. Install Homebrew to install Discover items."
-        });
-        return;
-      }
-      this.patch({ isHomebrewInstalled: true });
-    }
-    const command =
-      item.kind === "cask" ? ["install", "--cask", item.token] : ["install", item.token];
-    const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
-    const success = await this.runBrewWithEvents(command, (event) => {
-      this.applyDiscoverInstallEvent(event, parser, itemID, item.token.toLowerCase());
-    });
-    this.patch({
-      homebrewDiscoverInstallingItemIDs: removeFromArray(
-        this.state.homebrewDiscoverInstallingItemIDs,
-        itemID
-      ),
-      homebrewDiscoverInstalledPendingRefreshItemIDs: success
-        ? addToArray(this.state.homebrewDiscoverInstalledPendingRefreshItemIDs, itemID)
-        : this.state.homebrewDiscoverInstalledPendingRefreshItemIDs,
-      homebrewDiscoverFailedItemIDs: success
-        ? removeFromArray(this.state.homebrewDiscoverFailedItemIDs, itemID)
-        : addToArray(this.state.homebrewDiscoverFailedItemIDs, itemID),
-      refreshErrorMessage: success ? undefined : `Homebrew install failed for ${item.displayName}.`
-    });
-    if (success) {
-      this.hasCheckedHomebrewAvailability = true;
-      this.patch({ isHomebrewInstalled: true });
-      await this.recordProfileStatsEvents([homebrewInstallProfileStatsEvent(item)]);
-      await this.holdSuccessfulUpdate();
-      await this.refresh();
-    } else {
-      this.scheduleHomebrewDiscoverFailureClear(itemID);
-    }
   }
 
   async uninstallHomebrewItem(itemID: string): Promise<void> {
@@ -680,6 +682,18 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({
         refreshErrorMessage: homebrewUninstallFailureMessage(item, output)
       });
+    }
+  }
+
+  private async withHomebrewCommandLock(operation: () => Promise<void>): Promise<void> {
+    if (this.isHomebrewCommandActive()) {
+      return;
+    }
+    this.activeHomebrewCommandCount += 1;
+    try {
+      await operation();
+    } finally {
+      this.activeHomebrewCommandCount = Math.max(0, this.activeHomebrewCommandCount - 1);
     }
   }
 
@@ -1027,6 +1041,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   private isHomebrewCommandActive(): boolean {
     return (
+      this.activeHomebrewCommandCount > 0 ||
       this.state.isRunningHomebrewMaintenance ||
       this.state.homebrewUpdatingItemIDs.length > 0 ||
       this.state.homebrewUninstallingItemIDs.length > 0 ||

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -231,23 +231,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
   }
 
-  async testMasSetup(): Promise<void> {
-    if (!this.state.isMasInstalled) {
-      this.patch({
-        masTestSucceeded: false,
-        masTestMessage: "mas is not installed yet. Install mas to start App Store updates."
-      });
-      return;
-    }
-    const result = await this.runMasCommand(["outdated"]);
-    this.patch({
-      masTestSucceeded: result.success,
-      masTestMessage: result.success
-        ? "mas is ready, and Baseline can start App Store updates."
-        : "mas is installed, but it is not connected to your App Store account yet."
-    });
-  }
-
   async installMasWithHomebrew(): Promise<void> {
     const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
     if (!releaseHomebrewCommandLock) {
@@ -257,12 +240,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       const result = await this.runBrewCommand(["install", "mas"]);
       const installed = await this.runMasCommand(["version"]);
       this.patch({
-        isMasInstalled: installed.success,
-        masTestSucceeded: result.success && installed.success,
-        masTestMessage:
-          result.success && installed.success
-            ? "mas was installed successfully."
-            : "We could not install mas automatically. Please use the install guide and try again."
+        isMasInstalled: result.success && installed.success
       });
     } finally {
       releaseHomebrewCommandLock();

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -150,6 +150,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       isRefreshing: false,
       searchText: "",
       isRunningHomebrewMaintenance: false,
+      isHomebrewCommandLocked: false,
       appUpdatingIDs: [],
       appUpdatedPendingRefreshIDs: [],
       homebrewUpdatingItemIDs: [],
@@ -694,10 +695,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return;
     }
     this.activeHomebrewCommandCount += 1;
+    this.patch({ isHomebrewCommandLocked: true });
     try {
       await operation();
     } finally {
       this.activeHomebrewCommandCount = Math.max(0, this.activeHomebrewCommandCount - 1);
+      this.patch({ isHomebrewCommandLocked: this.activeHomebrewCommandCount > 0 });
     }
   }
 
@@ -831,10 +834,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         reconciledHomebrewItems,
         now
       );
-      const preserveDiscoverInstallState =
-        this.activeHomebrewCommandCount > 0 &&
-        !options.allowHomebrewInventoryDuringActiveCommand &&
-        this.state.homebrewDiscoverInstallingItemIDs.length > 0;
+      const preserveHomebrewCommandState =
+        this.isHomebrewCommandActive() && !options.allowHomebrewInventoryDuringActiveCommand;
       this.patch({
         apps,
         updates,
@@ -845,14 +846,16 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         isRefreshing: false,
         lastRefreshNoticeMessage: homebrewInventory.warning,
         appUpdatedPendingRefreshIDs: [],
-        homebrewUpdatedPendingRefreshItemIDs: [],
-        homebrewDiscoverInstallingItemIDs: preserveDiscoverInstallState
+        homebrewUpdatedPendingRefreshItemIDs: preserveHomebrewCommandState
+          ? this.state.homebrewUpdatedPendingRefreshItemIDs
+          : [],
+        homebrewDiscoverInstallingItemIDs: preserveHomebrewCommandState
           ? this.state.homebrewDiscoverInstallingItemIDs
           : [],
-        homebrewDiscoverInstalledPendingRefreshItemIDs: preserveDiscoverInstallState
+        homebrewDiscoverInstalledPendingRefreshItemIDs: preserveHomebrewCommandState
           ? this.state.homebrewDiscoverInstalledPendingRefreshItemIDs
           : [],
-        homebrewDiscoverProgressByItemID: preserveDiscoverInstallState
+        homebrewDiscoverProgressByItemID: preserveHomebrewCommandState
           ? this.state.homebrewDiscoverProgressByItemID
           : {},
         selfUpdate,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -102,6 +102,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private hasCheckedHomebrewAvailability = false;
   private profileStatsMutationQueue: Promise<void> = Promise.resolve();
   private activeHomebrewCommandCount = 0;
+  private activeHomebrewInventoryCount = 0;
 
   private state: BaselineSnapshot;
 
@@ -695,12 +696,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       return;
     }
     this.activeHomebrewCommandCount += 1;
-    this.patch({ isHomebrewCommandLocked: true });
+    this.updateHomebrewCommandLockState();
     try {
       await operation();
     } finally {
       this.activeHomebrewCommandCount = Math.max(0, this.activeHomebrewCommandCount - 1);
-      this.patch({ isHomebrewCommandLocked: this.activeHomebrewCommandCount > 0 });
+      this.updateHomebrewCommandLockState();
     }
   }
 
@@ -922,15 +923,22 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         outdatedDetectionSucceededByKind: { formula: false, cask: false }
       };
     }
-    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
-      const brew = await this.runBrewCommand(["--version"]);
-      this.hasCheckedHomebrewAvailability = true;
-      if (!brew.success) {
-        return emptyHomebrewInventoryResult();
+    this.activeHomebrewInventoryCount += 1;
+    this.updateHomebrewCommandLockState();
+    try {
+      if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
+        const brew = await this.runBrewCommand(["--version"]);
+        this.hasCheckedHomebrewAvailability = true;
+        if (!brew.success) {
+          return emptyHomebrewInventoryResult();
+        }
+        this.patch({ isHomebrewInstalled: true });
       }
-      this.patch({ isHomebrewInstalled: true });
+      return await this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight });
+    } finally {
+      this.activeHomebrewInventoryCount = Math.max(0, this.activeHomebrewInventoryCount - 1);
+      this.updateHomebrewCommandLockState();
     }
-    return this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight });
   }
 
   private scanDirectories(): string[] {
@@ -1073,6 +1081,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private isHomebrewCommandActive(): boolean {
     return (
       this.activeHomebrewCommandCount > 0 ||
+      this.activeHomebrewInventoryCount > 0 ||
       this.state.isRunningHomebrewMaintenance ||
       this.state.homebrewUpdatingItemIDs.length > 0 ||
       this.state.homebrewUninstallingItemIDs.length > 0 ||
@@ -1307,6 +1316,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private patch(patch: Partial<BaselineSnapshot>): void {
     this.state = { ...this.state, ...patch };
     this.emit("snapshot", this.getSnapshot());
+  }
+
+  private updateHomebrewCommandLockState(): void {
+    this.patch({
+      isHomebrewCommandLocked:
+        this.activeHomebrewCommandCount > 0 || this.activeHomebrewInventoryCount > 0
+    });
   }
 }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -66,6 +66,10 @@ type StoreEvents = {
   homebrewCommand: [HomebrewMaintenanceRunEvent];
 };
 
+type RefreshOptions = {
+  allowHomebrewInventoryDuringActiveCommand?: boolean;
+};
+
 const TRANSIENT_HOMEBREW_FAILURE_MS = 4000;
 const successfulUpdateHoldMs = 2000;
 
@@ -190,12 +194,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
   }
 
-  async refresh(lightweight = false): Promise<void> {
+  async refresh(lightweight = false, options: RefreshOptions = {}): Promise<void> {
     if (this.refreshTask && lightweight) {
       return this.refreshTask;
     }
     const sequence = ++this.refreshSequence;
-    const task = this.computeRefresh(lightweight, sequence);
+    const task = this.computeRefresh(lightweight, sequence, options);
     this.refreshTask = task;
     return task.finally(() => {
       if (this.refreshTask === task) {
@@ -431,7 +435,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         });
         this.scheduleHomebrewBatchFailureClear([itemID]);
       }
-      await this.refresh();
+      await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
     });
   }
 
@@ -642,7 +646,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         this.patch({ isHomebrewInstalled: true });
         await this.recordProfileStatsEvents([homebrewInstallProfileStatsEvent(item)]);
         await this.holdSuccessfulUpdate();
-        await this.refresh();
+        await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
       } else {
         this.scheduleHomebrewDiscoverFailureClear(itemID);
       }
@@ -697,7 +701,11 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
   }
 
-  private async computeRefresh(lightweight: boolean, sequence: number): Promise<void> {
+  private async computeRefresh(
+    lightweight: boolean,
+    sequence: number,
+    options: RefreshOptions
+  ): Promise<void> {
     this.patch({
       isRefreshing: true,
       refreshErrorMessage: undefined,
@@ -710,7 +718,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           this.scanner.scanApplications(this.scanDirectories()),
           this.homebrew.fetchIndex(),
           this.homebrewFormula.fetchIndex(),
-          this.fetchHomebrewInventory(lightweight),
+          this.fetchHomebrewInventory(lightweight, options),
           this.lookupSelfUpdate(now)
         ]);
       const homebrewItems = homebrewInventory.items;
@@ -890,7 +898,17 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     return this.selfUpdate.lookup(this.currentAppVersion, now);
   }
 
-  private async fetchHomebrewInventory(lightweight: boolean): Promise<HomebrewInventoryResult> {
+  private async fetchHomebrewInventory(
+    lightweight: boolean,
+    options: RefreshOptions
+  ): Promise<HomebrewInventoryResult> {
+    if (this.isHomebrewCommandActive() && !options.allowHomebrewInventoryDuringActiveCommand) {
+      return {
+        items: this.state.homebrewItems,
+        outdatedDetectionSucceeded: false,
+        outdatedDetectionSucceededByKind: { formula: false, cask: false }
+      };
+    }
     if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
       const brew = await this.runBrewCommand(["--version"]);
       this.hasCheckedHomebrewAvailability = true;

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -73,6 +73,7 @@ type RefreshOptions = {
 type HomebrewUpdateQueueEntry = {
   item: HomebrewManagedItem;
   profileStatsEvent?: ProfileStatsEvent;
+  requireOutdated: boolean;
   resolve: () => void;
   reject: (error: unknown) => void;
 };
@@ -409,12 +410,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (!item?.isOutdated || !isValidHomebrewToken(item.token)) {
       return;
     }
-    await this.performHomebrewItemUpdate(item);
+    await this.performHomebrewItemUpdate(item, { requireOutdated: true });
   }
 
   private async performHomebrewItemUpdate(
     item: HomebrewManagedItem,
-    options: { profileStatsEvent?: ProfileStatsEvent } = {}
+    options: { profileStatsEvent?: ProfileStatsEvent; requireOutdated?: boolean } = {}
   ): Promise<void> {
     if (!isValidHomebrewToken(item.token)) {
       return;
@@ -439,6 +440,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.homebrewUpdateQueue.push({
         item,
         profileStatsEvent: options.profileStatsEvent,
+        requireOutdated: options.requireOutdated ?? false,
         resolve,
         reject
       });
@@ -495,12 +497,20 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   private async runHomebrewQueuedUpdates(entries: HomebrewUpdateQueueEntry[]): Promise<void> {
     const itemsWithEvents = entries
-      .map((entry) => ({
-        entry,
-        item:
-          this.state.homebrewItems.find((candidate) => candidate.id === entry.item.id) ?? entry.item
-      }))
-      .filter(({ item }) => isValidHomebrewToken(item.token));
+      .map((entry) => {
+        const item = this.state.homebrewItems.find((candidate) => candidate.id === entry.item.id);
+        return item ? { entry, item } : undefined;
+      })
+      .filter(
+        (
+          itemWithEvent
+        ): itemWithEvent is { entry: HomebrewUpdateQueueEntry; item: HomebrewManagedItem } =>
+          Boolean(
+            itemWithEvent &&
+            (!itemWithEvent.entry.requireOutdated || itemWithEvent.item.isOutdated) &&
+            isValidHomebrewToken(itemWithEvent.item.token)
+          )
+      );
     if (itemsWithEvents.length === 0) {
       return;
     }
@@ -1126,6 +1136,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       });
       await this.refreshHomebrewDiscoverItems();
       await this.persist();
+      void this.processHomebrewUpdateQueue();
     } catch (error) {
       if (sequence !== this.refreshSequence) {
         return;
@@ -1134,6 +1145,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         isRefreshing: false,
         refreshErrorMessage: error instanceof Error ? error.message : "Refresh failed."
       });
+      void this.processHomebrewUpdateQueue();
     }
   }
 
@@ -1195,7 +1207,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     } finally {
       this.activeHomebrewInventoryCount = Math.max(0, this.activeHomebrewInventoryCount - 1);
       this.updateHomebrewCommandLockState();
-      void this.processHomebrewUpdateQueue();
     }
   }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -982,6 +982,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       lastRefreshNoticeMessage: undefined
     });
     const now = new Date().toISOString();
+    let completedHomebrewInventory: HomebrewInventoryResult | undefined;
     try {
       const [apps, homebrewIndex, homebrewFormulaIndex, homebrewInventory, selfUpdate] =
         await Promise.all([
@@ -991,6 +992,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           this.fetchHomebrewInventory(lightweight, options),
           this.lookupSelfUpdate(now)
         ]);
+      completedHomebrewInventory = homebrewInventory;
       const homebrewItems = homebrewInventory.items;
       if (sequence !== this.refreshSequence) {
         return;
@@ -1140,10 +1142,25 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       if (sequence !== this.refreshSequence) {
         return;
       }
-      this.patch({
+      const recoveredHomebrewInventory =
+        completedHomebrewInventory ??
+        (await this.activeHomebrewInventoryTask?.task.catch(() => undefined));
+      if (sequence !== this.refreshSequence) {
+        return;
+      }
+      const patch: Partial<BaselineSnapshot> = {
         isRefreshing: false,
         refreshErrorMessage: error instanceof Error ? error.message : "Refresh failed."
-      });
+      };
+      if (recoveredHomebrewInventory) {
+        patch.homebrewItems = preservePreviousHomebrewOutdatedState(
+          recoveredHomebrewInventory.items,
+          this.state.homebrewItems,
+          recoveredHomebrewInventory.outdatedDetectionSucceededByKind
+        );
+        patch.lastRefreshNoticeMessage = recoveredHomebrewInventory.warning;
+      }
+      this.patch(patch);
       void this.processHomebrewUpdateQueue();
     }
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -212,14 +212,21 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   async refreshToolStatus(): Promise<void> {
     this.patch({ isChecking: true });
-    const [mas, brew] = await Promise.all([
-      this.runMasCommand(["version"]),
-      this.runBrewCommand(["--version"])
-    ]);
-    this.hasCheckedHomebrewAvailability = true;
+    const masStatus = this.runMasCommand(["version"]);
+    const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
+    let brew: CommandResult | undefined;
+    try {
+      brew = releaseHomebrewCommandLock ? await this.runBrewCommand(["--version"]) : undefined;
+    } finally {
+      releaseHomebrewCommandLock?.();
+    }
+    if (brew) {
+      this.hasCheckedHomebrewAvailability = true;
+    }
+    const mas = await masStatus;
     this.patch({
       isMasInstalled: mas.success,
-      isHomebrewInstalled: brew.success,
+      ...(brew ? { isHomebrewInstalled: brew.success } : {}),
       isChecking: false
     });
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -491,6 +491,116 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
   }
 
+  private async runHomebrewQueuedUpdates(entries: HomebrewUpdateQueueEntry[]): Promise<void> {
+    const itemsWithEvents = entries
+      .map((entry) => ({
+        entry,
+        item:
+          this.state.homebrewItems.find((candidate) => candidate.id === entry.item.id) ?? entry.item
+      }))
+      .filter(({ item }) => isValidHomebrewToken(item.token));
+    if (itemsWithEvents.length === 0) {
+      return;
+    }
+    const firstItemWithEvent = itemsWithEvents[0];
+    if (itemsWithEvents.length === 1 && firstItemWithEvent) {
+      await this.runHomebrewItemUpdate(
+        firstItemWithEvent.item,
+        firstItemWithEvent.entry.profileStatsEvent
+      );
+      return;
+    }
+
+    const affected = itemsWithEvents.map(({ item }) => item);
+    const formulaTokens = affected
+      .filter((item) => item.kind === "formula")
+      .map((item) => item.token);
+    const caskTokens = affected.filter((item) => item.kind === "cask").map((item) => item.token);
+    const affectedIDs = affected.map((item) => item.id);
+    const affectedByToken = new Map<string, string[]>();
+    for (const item of affected) {
+      affectedByToken.set(item.token.toLowerCase(), [
+        ...(affectedByToken.get(item.token.toLowerCase()) ?? []),
+        item.id
+      ]);
+    }
+    const affectedKindByID = new Map(affected.map((item) => [item.id, item.kind]));
+    const parser = new HomebrewMaintenanceOutputParser(
+      affected.map((item) => item.token.toLowerCase())
+    );
+    const sequence = [
+      ...(formulaTokens.length > 0 ? [["upgrade", ...formulaTokens]] : []),
+      ...(caskTokens.length > 0 ? [["upgrade", "--cask", ...caskTokens]] : [])
+    ];
+    const completedItemIDs = new Set<string>();
+    let success = true;
+    for (const command of sequence) {
+      const result = await this.runBrewWithEvents(command, (event) => {
+        this.applyHomebrewProgressEvent(
+          event,
+          parser,
+          affectedByToken,
+          affectedKindByID,
+          completedItemIDs
+        );
+      });
+      if (result) {
+        const upgradedKind = homebrewUpgradeKindForCommand(command);
+        if (upgradedKind) {
+          for (const item of affected.filter((candidate) => candidate.kind === upgradedKind)) {
+            completedItemIDs.add(item.id);
+          }
+        }
+      }
+      if (!result) {
+        success = false;
+        break;
+      }
+    }
+
+    const completedIDs = success
+      ? affectedIDs
+      : affectedIDs.filter((id) => completedItemIDs.has(id));
+    const failedIDs = affectedIDs.filter((id) => !completedItemIDs.has(id));
+    this.patch({
+      refreshErrorMessage: success ? undefined : "Homebrew update failed.",
+      homebrewBatchFailedItemIDs: success
+        ? this.state.homebrewBatchFailedItemIDs.filter((id) => !affectedIDs.includes(id))
+        : [
+            ...new Set([
+              ...this.state.homebrewBatchFailedItemIDs,
+              ...failedIDs.filter(
+                (id) => !this.state.homebrewUpdatedPendingRefreshItemIDs.includes(id)
+              )
+            ])
+          ],
+      homebrewUpdatedPendingRefreshItemIDs:
+        completedIDs.length > 0
+          ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...completedIDs])]
+          : this.state.homebrewUpdatedPendingRefreshItemIDs,
+      homebrewBatchProgressByItemID: {
+        ...this.state.homebrewBatchProgressByItemID,
+        ...Object.fromEntries(affectedIDs.map((id) => [id, 1]))
+      }
+    });
+    if (!success) {
+      this.scheduleHomebrewBatchFailureClear(failedIDs);
+    }
+    if (completedIDs.length > 0) {
+      const occurredAt = new Date().toISOString();
+      await this.recordProfileStatsEvents(
+        itemsWithEvents
+          .filter(({ item }) => completedIDs.includes(item.id))
+          .map(
+            ({ entry, item }) =>
+              entry.profileStatsEvent ?? homebrewUpdateProfileStatsEvent({ item, occurredAt })
+          )
+      );
+      await this.holdSuccessfulUpdate();
+    }
+    await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+  }
+
   async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
     if (this.state.homebrewUpdatingItemIDs.length > 0 || this.homebrewUpdateQueue.length > 0) {
       return;
@@ -773,28 +883,28 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         if (!releaseHomebrewCommandLock) {
           return;
         }
-        const entry = this.homebrewUpdateQueue.shift();
-        if (!entry) {
+        const entries = this.homebrewUpdateQueue.splice(0);
+        if (entries.length === 0) {
           releaseHomebrewCommandLock();
           continue;
         }
         try {
-          const item =
-            this.state.homebrewItems.find((candidate) => candidate.id === entry.item.id) ??
-            entry.item;
-          if (isValidHomebrewToken(item.token)) {
-            await this.runHomebrewItemUpdate(item, entry.profileStatsEvent);
+          await this.runHomebrewQueuedUpdates(entries);
+          for (const entry of entries) {
+            entry.resolve();
           }
-          entry.resolve();
         } catch (error) {
-          entry.reject(error);
+          for (const entry of entries) {
+            entry.reject(error);
+          }
         } finally {
-          if (this.state.homebrewUpdatingItemIDs.includes(entry.item.id)) {
+          const entryIDs = entries.map((entry) => entry.item.id);
+          const updatingItemIDs = this.state.homebrewUpdatingItemIDs.filter(
+            (itemID) => !entryIDs.includes(itemID)
+          );
+          if (updatingItemIDs.length !== this.state.homebrewUpdatingItemIDs.length) {
             this.patch({
-              homebrewUpdatingItemIDs: removeFromArray(
-                this.state.homebrewUpdatingItemIDs,
-                entry.item.id
-              )
+              homebrewUpdatingItemIDs: updatingItemIDs
             });
           }
           releaseHomebrewCommandLock();

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -74,6 +74,7 @@ type HomebrewUpdateQueueEntry = {
   item: HomebrewManagedItem;
   profileStatsEvent?: ProfileStatsEvent;
   appUpdateAppID?: string;
+  requiredRemoteVersion?: VersionValue;
   requireOutdated: boolean;
   resolve: () => void;
   reject: (error: unknown) => void;
@@ -366,14 +367,15 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         return;
       }
       const item = this.matchingHomebrewItemForApp(appRecord);
-      if (item) {
+      if (item && homebrewItemCanRunAppUpdate(item, update)) {
         await this.performHomebrewItemUpdate(item, {
           profileStatsEvent: appUpdateProfileStatsEvent({
             appRecord,
             update,
             occurredAt: new Date().toISOString()
           }),
-          appUpdateAppID: appID
+          appUpdateAppID: appID,
+          requiredRemoteVersion: update.remoteVersion
         });
         return;
       }
@@ -404,6 +406,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     options: {
       profileStatsEvent?: ProfileStatsEvent;
       appUpdateAppID?: string;
+      requiredRemoteVersion?: VersionValue;
       requireOutdated?: boolean;
     } = {}
   ): Promise<void> {
@@ -431,6 +434,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         item,
         profileStatsEvent: options.profileStatsEvent,
         appUpdateAppID: options.appUpdateAppID,
+        requiredRemoteVersion: options.requiredRemoteVersion,
         requireOutdated: options.requireOutdated ?? false,
         resolve,
         reject
@@ -1304,6 +1308,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (entry.requireOutdated && !item.isOutdated) {
       return false;
     }
+    if (
+      entry.requiredRemoteVersion &&
+      !isVersionGreater(entry.requiredRemoteVersion, item.installedVersion)
+    ) {
+      return false;
+    }
     if (!entry.appUpdateAppID) {
       return true;
     }
@@ -1582,10 +1592,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   private updateHomebrewCommandLockState(): void {
-    this.patch({
-      isHomebrewCommandLocked:
-        this.activeHomebrewCommandCount > 0 || this.activeHomebrewInventoryCount > 0
-    });
+    const isHomebrewCommandLocked =
+      this.activeHomebrewCommandCount > 0 || this.activeHomebrewInventoryCount > 0;
+    if (this.state.isHomebrewCommandLocked === isHomebrewCommandLocked) {
+      return;
+    }
+    this.patch({ isHomebrewCommandLocked });
   }
 }
 
@@ -1776,6 +1788,10 @@ function canUseHomebrewAppUpdate(
       item.token.toLowerCase() === token &&
       homebrewCaskItemProvesAppOwnership(item, appRecord, caskIndex.byToken[token])
   );
+}
+
+function homebrewItemCanRunAppUpdate(item: HomebrewManagedItem, update: UpdateRecord): boolean {
+  return item.isOutdated || isVersionGreater(update.remoteVersion, item.installedVersion);
 }
 
 function requiresHomebrewOwnershipProof(appRecord: AppRecord): boolean {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -224,6 +224,44 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
   }
 
+  async testMasSetup(): Promise<void> {
+    if (!this.state.isMasInstalled) {
+      this.patch({
+        masTestSucceeded: false,
+        masTestMessage: "mas is not installed yet. Install mas to start App Store updates."
+      });
+      return;
+    }
+    const result = await this.runMasCommand(["outdated"]);
+    this.patch({
+      masTestSucceeded: result.success,
+      masTestMessage: result.success
+        ? "mas is ready, and Baseline can start App Store updates."
+        : "mas is installed, but it is not connected to your App Store account yet."
+    });
+  }
+
+  async installMasWithHomebrew(): Promise<void> {
+    const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
+    if (!releaseHomebrewCommandLock) {
+      return;
+    }
+    try {
+      const result = await this.runBrewCommand(["install", "mas"]);
+      const installed = await this.runMasCommand(["version"]);
+      this.patch({
+        isMasInstalled: installed.success,
+        masTestSucceeded: result.success && installed.success,
+        masTestMessage:
+          result.success && installed.success
+            ? "mas was installed successfully."
+            : "We could not install mas automatically. Please use the install guide and try again."
+      });
+    } finally {
+      releaseHomebrewCommandLock();
+    }
+  }
+
   async setSearchText(searchText: string): Promise<void> {
     this.patch({ searchText });
     await this.refreshHomebrewDiscoverItems();
@@ -442,142 +480,147 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
-    if (this.isHomebrewCommandActive()) {
+    const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
+    if (!releaseHomebrewCommandLock) {
       return;
     }
 
-    const requestedItemIDs = itemIDs ? new Set(itemIDs) : undefined;
-    const updatesByAppID = new Map(this.state.updates.map((update) => [update.appID, update]));
-    const appsRepresentedOutsideHomebrew = this.state.apps.filter(
-      (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
-    );
-    const ignoredApps = this.state.apps.filter((app) => this.state.ignoredIDs.includes(app.id));
-    const affected = this.state.homebrewItems.filter(
-      (item) =>
-        (!requestedItemIDs || requestedItemIDs.has(item.id)) &&
-        item.isOutdated &&
-        !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
-        isValidHomebrewToken(item.token) &&
-        !homebrewItemHasAppRepresentation(
-          item,
-          requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew,
-          updatesByAppID
-        )
-    );
-    if (affected.length === 0) {
-      return;
-    }
+    try {
+      const requestedItemIDs = itemIDs ? new Set(itemIDs) : undefined;
+      const updatesByAppID = new Map(this.state.updates.map((update) => [update.appID, update]));
+      const appsRepresentedOutsideHomebrew = this.state.apps.filter(
+        (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
+      );
+      const ignoredApps = this.state.apps.filter((app) => this.state.ignoredIDs.includes(app.id));
+      const affected = this.state.homebrewItems.filter(
+        (item) =>
+          (!requestedItemIDs || requestedItemIDs.has(item.id)) &&
+          item.isOutdated &&
+          !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
+          isValidHomebrewToken(item.token) &&
+          !homebrewItemHasAppRepresentation(
+            item,
+            requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew,
+            updatesByAppID
+          )
+      );
+      if (affected.length === 0) {
+        return;
+      }
 
-    const formulaTokens = affected
-      .filter((item) => item.kind === "formula")
-      .map((item) => item.token);
-    const caskTokens = affected.filter((item) => item.kind === "cask").map((item) => item.token);
-    const affectedIDs = affected.map((item) => item.id);
-    const affectedByToken = new Map<string, string[]>();
-    for (const item of affected) {
-      affectedByToken.set(item.token.toLowerCase(), [
-        ...(affectedByToken.get(item.token.toLowerCase()) ?? []),
-        item.id
-      ]);
-    }
-    const affectedKindByID = new Map(affected.map((item) => [item.id, item.kind]));
+      const formulaTokens = affected
+        .filter((item) => item.kind === "formula")
+        .map((item) => item.token);
+      const caskTokens = affected.filter((item) => item.kind === "cask").map((item) => item.token);
+      const affectedIDs = affected.map((item) => item.id);
+      const affectedByToken = new Map<string, string[]>();
+      for (const item of affected) {
+        affectedByToken.set(item.token.toLowerCase(), [
+          ...(affectedByToken.get(item.token.toLowerCase()) ?? []),
+          item.id
+        ]);
+      }
+      const affectedKindByID = new Map(affected.map((item) => [item.id, item.kind]));
 
-    this.patch({
-      isRunningHomebrewMaintenance: true,
-      homebrewUpdatingItemIDs: [
-        ...new Set([...this.state.homebrewUpdatingItemIDs, ...affectedIDs])
-      ],
-      homebrewBatchProgressByItemID: {
-        ...this.state.homebrewBatchProgressByItemID,
-        ...Object.fromEntries(
-          affectedIDs.map((id) => [id, HomebrewMaintenanceProgressStage.queued])
-        )
-      },
-      homebrewBatchFailedItemIDs: this.state.homebrewBatchFailedItemIDs.filter(
-        (id) => !affectedIDs.includes(id)
-      ),
-      refreshErrorMessage: undefined
-    });
-    for (const id of affectedIDs) {
-      this.clearHomebrewBatchFailureTimer(id);
-    }
-
-    const parser = new HomebrewMaintenanceOutputParser(
-      affected.map((item) => item.token.toLowerCase())
-    );
-    const sequence = [
-      ["update"],
-      ...(formulaTokens.length > 0 ? [["upgrade", ...formulaTokens]] : []),
-      ...(caskTokens.length > 0 ? [["upgrade", "--cask", "--greedy", ...caskTokens]] : []),
-      ["autoremove"],
-      ["cleanup"]
-    ];
-    const completedItemIDs = new Set<string>();
-    let success = true;
-    for (const command of sequence) {
-      const result = await this.runBrewWithEvents(command, (event) => {
-        this.applyHomebrewProgressEvent(
-          event,
-          parser,
-          affectedByToken,
-          affectedKindByID,
-          completedItemIDs
-        );
+      this.patch({
+        isRunningHomebrewMaintenance: true,
+        homebrewUpdatingItemIDs: [
+          ...new Set([...this.state.homebrewUpdatingItemIDs, ...affectedIDs])
+        ],
+        homebrewBatchProgressByItemID: {
+          ...this.state.homebrewBatchProgressByItemID,
+          ...Object.fromEntries(
+            affectedIDs.map((id) => [id, HomebrewMaintenanceProgressStage.queued])
+          )
+        },
+        homebrewBatchFailedItemIDs: this.state.homebrewBatchFailedItemIDs.filter(
+          (id) => !affectedIDs.includes(id)
+        ),
+        refreshErrorMessage: undefined
       });
-      if (result) {
-        const upgradedKind = homebrewUpgradeKindForCommand(command);
-        if (upgradedKind) {
-          for (const item of affected.filter((candidate) => candidate.kind === upgradedKind)) {
-            completedItemIDs.add(item.id);
+      for (const id of affectedIDs) {
+        this.clearHomebrewBatchFailureTimer(id);
+      }
+
+      const parser = new HomebrewMaintenanceOutputParser(
+        affected.map((item) => item.token.toLowerCase())
+      );
+      const sequence = [
+        ["update"],
+        ...(formulaTokens.length > 0 ? [["upgrade", ...formulaTokens]] : []),
+        ...(caskTokens.length > 0 ? [["upgrade", "--cask", "--greedy", ...caskTokens]] : []),
+        ["autoremove"],
+        ["cleanup"]
+      ];
+      const completedItemIDs = new Set<string>();
+      let success = true;
+      for (const command of sequence) {
+        const result = await this.runBrewWithEvents(command, (event) => {
+          this.applyHomebrewProgressEvent(
+            event,
+            parser,
+            affectedByToken,
+            affectedKindByID,
+            completedItemIDs
+          );
+        });
+        if (result) {
+          const upgradedKind = homebrewUpgradeKindForCommand(command);
+          if (upgradedKind) {
+            for (const item of affected.filter((candidate) => candidate.kind === upgradedKind)) {
+              completedItemIDs.add(item.id);
+            }
           }
         }
+        if (!result) {
+          success = false;
+          break;
+        }
       }
-      if (!result) {
-        success = false;
-        break;
-      }
-    }
-    const completedIDs = success
-      ? affectedIDs
-      : affectedIDs.filter((id) => completedItemIDs.has(id));
-    const failedIDs = affectedIDs.filter((id) => !completedItemIDs.has(id));
+      const completedIDs = success
+        ? affectedIDs
+        : affectedIDs.filter((id) => completedItemIDs.has(id));
+      const failedIDs = affectedIDs.filter((id) => !completedItemIDs.has(id));
 
-    this.patch({
-      isRunningHomebrewMaintenance: false,
-      homebrewUpdatingItemIDs: this.state.homebrewUpdatingItemIDs.filter(
-        (id) => !affectedIDs.includes(id)
-      ),
-      homebrewBatchFailedItemIDs: success
-        ? this.state.homebrewBatchFailedItemIDs.filter((id) => !affectedIDs.includes(id))
-        : [
-            ...new Set([
-              ...this.state.homebrewBatchFailedItemIDs,
-              ...failedIDs.filter(
-                (id) => !this.state.homebrewUpdatedPendingRefreshItemIDs.includes(id)
-              )
-            ])
-          ],
-      homebrewUpdatedPendingRefreshItemIDs:
-        completedIDs.length > 0
-          ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...completedIDs])]
-          : this.state.homebrewUpdatedPendingRefreshItemIDs,
-      refreshErrorMessage: success ? undefined : "Homebrew maintenance cycle failed."
-    });
-    if (!success) {
-      this.scheduleHomebrewBatchFailureClear(failedIDs);
+      this.patch({
+        isRunningHomebrewMaintenance: false,
+        homebrewUpdatingItemIDs: this.state.homebrewUpdatingItemIDs.filter(
+          (id) => !affectedIDs.includes(id)
+        ),
+        homebrewBatchFailedItemIDs: success
+          ? this.state.homebrewBatchFailedItemIDs.filter((id) => !affectedIDs.includes(id))
+          : [
+              ...new Set([
+                ...this.state.homebrewBatchFailedItemIDs,
+                ...failedIDs.filter(
+                  (id) => !this.state.homebrewUpdatedPendingRefreshItemIDs.includes(id)
+                )
+              ])
+            ],
+        homebrewUpdatedPendingRefreshItemIDs:
+          completedIDs.length > 0
+            ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...completedIDs])]
+            : this.state.homebrewUpdatedPendingRefreshItemIDs,
+        refreshErrorMessage: success ? undefined : "Homebrew maintenance cycle failed."
+      });
+      if (!success) {
+        this.scheduleHomebrewBatchFailureClear(failedIDs);
+      }
+      if (completedIDs.length > 0) {
+        const occurredAt = new Date().toISOString();
+        await this.recordProfileStatsEvents(
+          affected
+            .filter((item) => completedIDs.includes(item.id))
+            .map((item) => homebrewUpdateProfileStatsEvent({ item, occurredAt }))
+        );
+      }
+      if (success) {
+        await this.holdSuccessfulUpdate();
+      }
+      await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+    } finally {
+      releaseHomebrewCommandLock();
     }
-    if (completedIDs.length > 0) {
-      const occurredAt = new Date().toISOString();
-      await this.recordProfileStatsEvents(
-        affected
-          .filter((item) => completedIDs.includes(item.id))
-          .map((item) => homebrewUpdateProfileStatsEvent({ item, occurredAt }))
-      );
-    }
-    if (success) {
-      await this.holdSuccessfulUpdate();
-    }
-    await this.refresh();
   }
 
   async installHomebrewItem(item: HomebrewCaskDiscoveryItem): Promise<void> {
@@ -664,45 +707,73 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({ refreshErrorMessage: `Blocked unsafe Homebrew token for ${item.name}.` });
       return;
     }
-    if (this.isHomebrewCommandActive()) {
+    const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
+    if (!releaseHomebrewCommandLock) {
       return;
     }
     this.patch({
       homebrewUninstallingItemIDs: addToArray(this.state.homebrewUninstallingItemIDs, itemID)
     });
-    const outputLines: string[] = [];
-    const result = await this.runBrewWithResultEvents(
-      ["uninstall", "--cask", item.token],
-      (event) => {
-        if (event.type === "outputLine") {
-          outputLines.push(event.line);
+    try {
+      const outputLines: string[] = [];
+      const result = await this.runBrewWithResultEvents(
+        ["uninstall", "--cask", item.token],
+        (event) => {
+          if (event.type === "outputLine") {
+            outputLines.push(event.line);
+          }
         }
-      }
-    );
-    this.patch({
-      homebrewUninstallingItemIDs: removeFromArray(this.state.homebrewUninstallingItemIDs, itemID)
-    });
-    await this.refresh();
-    if (!result.success) {
-      const output = (outputLines.join("\n") || result.output).trim();
+      );
       this.patch({
-        refreshErrorMessage: homebrewUninstallFailureMessage(item, output)
+        homebrewUninstallingItemIDs: removeFromArray(this.state.homebrewUninstallingItemIDs, itemID)
       });
+      await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+      if (!result.success) {
+        const output = (outputLines.join("\n") || result.output).trim();
+        this.patch({
+          refreshErrorMessage: homebrewUninstallFailureMessage(item, output)
+        });
+      }
+    } finally {
+      if (this.state.homebrewUninstallingItemIDs.includes(itemID)) {
+        this.patch({
+          homebrewUninstallingItemIDs: removeFromArray(
+            this.state.homebrewUninstallingItemIDs,
+            itemID
+          )
+        });
+      }
+      releaseHomebrewCommandLock();
     }
   }
 
   private async withHomebrewCommandLock(operation: () => Promise<void>): Promise<void> {
-    if (this.isHomebrewCommandActive()) {
+    const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
+    if (!releaseHomebrewCommandLock) {
       return;
     }
-    this.activeHomebrewCommandCount += 1;
-    this.updateHomebrewCommandLockState();
     try {
       await operation();
     } finally {
+      releaseHomebrewCommandLock();
+    }
+  }
+
+  private reserveHomebrewCommandLock(): (() => void) | undefined {
+    if (this.isHomebrewCommandActive()) {
+      return undefined;
+    }
+    let released = false;
+    this.activeHomebrewCommandCount += 1;
+    this.updateHomebrewCommandLockState();
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
       this.activeHomebrewCommandCount = Math.max(0, this.activeHomebrewCommandCount - 1);
       this.updateHomebrewCommandLockState();
-    }
+    };
   }
 
   private async computeRefresh(

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -831,6 +831,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         reconciledHomebrewItems,
         now
       );
+      const preserveDiscoverInstallState =
+        this.activeHomebrewCommandCount > 0 &&
+        !options.allowHomebrewInventoryDuringActiveCommand &&
+        this.state.homebrewDiscoverInstallingItemIDs.length > 0;
       this.patch({
         apps,
         updates,
@@ -842,9 +846,15 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         lastRefreshNoticeMessage: homebrewInventory.warning,
         appUpdatedPendingRefreshIDs: [],
         homebrewUpdatedPendingRefreshItemIDs: [],
-        homebrewDiscoverInstallingItemIDs: [],
-        homebrewDiscoverInstalledPendingRefreshItemIDs: [],
-        homebrewDiscoverProgressByItemID: {},
+        homebrewDiscoverInstallingItemIDs: preserveDiscoverInstallState
+          ? this.state.homebrewDiscoverInstallingItemIDs
+          : [],
+        homebrewDiscoverInstalledPendingRefreshItemIDs: preserveDiscoverInstallState
+          ? this.state.homebrewDiscoverInstalledPendingRefreshItemIDs
+          : [],
+        homebrewDiscoverProgressByItemID: preserveDiscoverInstallState
+          ? this.state.homebrewDiscoverProgressByItemID
+          : {},
         selfUpdate,
         laggingHomebrewCaskTokens: detectLaggingHomebrewCaskTokens(
           homebrewItems,

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -164,6 +164,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       appUpdatingIDs: [],
       appUpdatedPendingRefreshIDs: [],
       homebrewUpdatingItemIDs: [],
+      homebrewQueuedItemIDs: [],
       homebrewUninstallingItemIDs: [],
       homebrewUpdatedPendingRefreshItemIDs: [],
       homebrewBatchProgressByItemID: {},
@@ -427,6 +428,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     this.clearHomebrewBatchFailureTimer(item.id);
     this.patch({
       homebrewUpdatingItemIDs: addToArray(this.state.homebrewUpdatingItemIDs, item.id),
+      homebrewQueuedItemIDs: addToArray(this.state.homebrewQueuedItemIDs, item.id),
       homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, item.id),
       homebrewBatchProgressByItemID: {
         ...this.state.homebrewBatchProgressByItemID,
@@ -888,6 +890,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           releaseHomebrewCommandLock();
           continue;
         }
+        const entryIDs = entries.map((entry) => entry.item.id);
+        this.patch({
+          homebrewQueuedItemIDs: this.state.homebrewQueuedItemIDs.filter(
+            (itemID) => !entryIDs.includes(itemID)
+          )
+        });
         try {
           await this.runHomebrewQueuedUpdates(entries);
           for (const entry of entries) {
@@ -898,13 +906,19 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             entry.reject(error);
           }
         } finally {
-          const entryIDs = entries.map((entry) => entry.item.id);
           const updatingItemIDs = this.state.homebrewUpdatingItemIDs.filter(
             (itemID) => !entryIDs.includes(itemID)
           );
-          if (updatingItemIDs.length !== this.state.homebrewUpdatingItemIDs.length) {
+          const queuedItemIDs = this.state.homebrewQueuedItemIDs.filter(
+            (itemID) => !entryIDs.includes(itemID)
+          );
+          if (
+            updatingItemIDs.length !== this.state.homebrewUpdatingItemIDs.length ||
+            queuedItemIDs.length !== this.state.homebrewQueuedItemIDs.length
+          ) {
             this.patch({
-              homebrewUpdatingItemIDs: updatingItemIDs
+              homebrewUpdatingItemIDs: updatingItemIDs,
+              homebrewQueuedItemIDs: queuedItemIDs
             });
           }
           releaseHomebrewCommandLock();

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -379,6 +379,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (!isValidHomebrewToken(item.token)) {
       return;
     }
+    if (this.isHomebrewCommandActive()) {
+      return;
+    }
     const itemID = item.id;
     const command =
       item.kind === "cask" ? ["upgrade", "--cask", item.token] : ["upgrade", item.token];
@@ -432,7 +435,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
-    if (this.state.isRunningHomebrewMaintenance) {
+    if (this.isHomebrewCommandActive()) {
       return;
     }
 
@@ -575,6 +578,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({ refreshErrorMessage: `Blocked unsafe Homebrew token for ${item.displayName}.` });
       return;
     }
+    const itemID = item.id;
+    if (this.isHomebrewCommandActive()) {
+      return;
+    }
     if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
       const brew = await this.runBrewCommand(["--version"]);
       this.hasCheckedHomebrewAvailability = true;
@@ -586,13 +593,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         return;
       }
       this.patch({ isHomebrewInstalled: true });
-    }
-    const itemID = item.id;
-    if (
-      this.state.homebrewDiscoverInstallingItemIDs.includes(itemID) ||
-      this.isHomebrewCommandActive()
-    ) {
-      return;
     }
     this.clearHomebrewDiscoverFailureTimer(itemID);
     const command =
@@ -648,11 +648,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({ refreshErrorMessage: `Blocked unsafe Homebrew token for ${item.name}.` });
       return;
     }
-    if (
-      this.state.isRunningHomebrewMaintenance ||
-      this.state.homebrewUninstallingItemIDs.includes(itemID) ||
-      this.state.homebrewUpdatingItemIDs.includes(itemID)
-    ) {
+    if (this.isHomebrewCommandActive()) {
       return;
     }
     this.patch({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -73,6 +73,7 @@ type RefreshOptions = {
 type HomebrewUpdateQueueEntry = {
   item: HomebrewManagedItem;
   profileStatsEvent?: ProfileStatsEvent;
+  appUpdateAppID?: string;
   requireOutdated: boolean;
   resolve: () => void;
   reject: (error: unknown) => void;
@@ -387,7 +388,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             appRecord,
             update,
             occurredAt: new Date().toISOString()
-          })
+          }),
+          appUpdateAppID: appID
         });
         return;
       }
@@ -415,7 +417,11 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   private async performHomebrewItemUpdate(
     item: HomebrewManagedItem,
-    options: { profileStatsEvent?: ProfileStatsEvent; requireOutdated?: boolean } = {}
+    options: {
+      profileStatsEvent?: ProfileStatsEvent;
+      appUpdateAppID?: string;
+      requireOutdated?: boolean;
+    } = {}
   ): Promise<void> {
     if (!isValidHomebrewToken(item.token)) {
       return;
@@ -440,6 +446,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.homebrewUpdateQueue.push({
         item,
         profileStatsEvent: options.profileStatsEvent,
+        appUpdateAppID: options.appUpdateAppID,
         requireOutdated: options.requireOutdated ?? false,
         resolve,
         reject
@@ -507,7 +514,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         ): itemWithEvent is { entry: HomebrewUpdateQueueEntry; item: HomebrewManagedItem } =>
           Boolean(
             itemWithEvent &&
-            (!itemWithEvent.entry.requireOutdated || itemWithEvent.item.isOutdated) &&
+            this.queuedHomebrewUpdateIsStillCurrent(itemWithEvent.entry, itemWithEvent.item) &&
             isValidHomebrewToken(itemWithEvent.item.token)
           )
       );
@@ -1301,6 +1308,24 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         }
       }
     }
+  }
+
+  private queuedHomebrewUpdateIsStillCurrent(
+    entry: HomebrewUpdateQueueEntry,
+    item: HomebrewManagedItem
+  ): boolean {
+    if (entry.requireOutdated && !item.isOutdated) {
+      return false;
+    }
+    if (!entry.appUpdateAppID) {
+      return true;
+    }
+    return this.state.updates.some(
+      (update) =>
+        update.appID === entry.appUpdateAppID &&
+        update.source === "homebrew" &&
+        update.homebrewToken?.toLowerCase() === item.token.toLowerCase()
+    );
   }
 
   private applyDiscoverInstallEvent(

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -588,6 +588,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({ isHomebrewInstalled: true });
     }
     const itemID = item.id;
+    if (
+      this.state.homebrewDiscoverInstallingItemIDs.includes(itemID) ||
+      this.isHomebrewCommandActive()
+    ) {
+      return;
+    }
     this.clearHomebrewDiscoverFailureTimer(itemID);
     const command =
       item.kind === "cask" ? ["install", "--cask", item.token] : ["install", item.token];
@@ -1012,6 +1018,15 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             appRecord,
             this.latestHomebrewIndex.byToken[token]
           ))
+    );
+  }
+
+  private isHomebrewCommandActive(): boolean {
+    return (
+      this.state.isRunningHomebrewMaintenance ||
+      this.state.homebrewUpdatingItemIDs.length > 0 ||
+      this.state.homebrewUninstallingItemIDs.length > 0 ||
+      this.state.homebrewDiscoverInstallingItemIDs.length > 0
     );
   }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -70,6 +70,13 @@ type RefreshOptions = {
   allowHomebrewInventoryDuringActiveCommand?: boolean;
 };
 
+type HomebrewUpdateQueueEntry = {
+  item: HomebrewManagedItem;
+  profileStatsEvent?: ProfileStatsEvent;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
 const TRANSIENT_HOMEBREW_FAILURE_MS = 4000;
 const successfulUpdateHoldMs = 2000;
 
@@ -103,6 +110,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private profileStatsMutationQueue: Promise<void> = Promise.resolve();
   private activeHomebrewCommandCount = 0;
   private activeHomebrewInventoryCount = 0;
+  private readonly homebrewUpdateQueue: HomebrewUpdateQueueEntry[] = [];
+  private isProcessingHomebrewUpdateQueue = false;
 
   private state: BaselineSnapshot;
 
@@ -409,62 +418,83 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (!isValidHomebrewToken(item.token)) {
       return;
     }
-    if (this.isHomebrewCommandActive()) {
+    if (
+      this.state.homebrewUpdatingItemIDs.includes(item.id) ||
+      this.homebrewUpdateQueue.some((entry) => entry.item.id === item.id)
+    ) {
       return;
     }
-    const itemID = item.id;
-    const command =
-      item.kind === "cask" ? ["upgrade", "--cask", item.token] : ["upgrade", item.token];
-    await this.withHomebrewUpdating(itemID, async () => {
-      this.clearHomebrewBatchFailureTimer(itemID);
-      this.patch({
-        homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID)
-      });
-      const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
-      const result = await this.runBrewWithEvents(command, (event) => {
-        this.applyHomebrewProgressEvent(
-          event,
-          parser,
-          new Map([[item.token.toLowerCase(), [itemID]]])
-        );
-      });
-      if (result) {
-        this.patch({
-          refreshErrorMessage: undefined,
-          homebrewBatchFailedItemIDs: removeFromArray(
-            this.state.homebrewBatchFailedItemIDs,
-            itemID
-          ),
-          homebrewUpdatedPendingRefreshItemIDs: addToArray(
-            this.state.homebrewUpdatedPendingRefreshItemIDs,
-            itemID
-          ),
-          homebrewBatchProgressByItemID: {
-            ...this.state.homebrewBatchProgressByItemID,
-            [itemID]: 1
-          }
-        });
-        await this.recordProfileStatsEvents([
-          options.profileStatsEvent ??
-            homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
-        ]);
-        await this.holdSuccessfulUpdate();
-      } else {
-        this.patch({
-          refreshErrorMessage: `Homebrew update failed for ${item.name}.`,
-          homebrewBatchFailedItemIDs: addToArray(this.state.homebrewBatchFailedItemIDs, itemID),
-          homebrewBatchProgressByItemID: {
-            ...this.state.homebrewBatchProgressByItemID,
-            [itemID]: 1
-          }
-        });
-        this.scheduleHomebrewBatchFailureClear([itemID]);
+    this.clearHomebrewBatchFailureTimer(item.id);
+    this.patch({
+      homebrewUpdatingItemIDs: addToArray(this.state.homebrewUpdatingItemIDs, item.id),
+      homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, item.id),
+      homebrewBatchProgressByItemID: {
+        ...this.state.homebrewBatchProgressByItemID,
+        [item.id]: HomebrewMaintenanceProgressStage.queued
       }
-      await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+    });
+    await new Promise<void>((resolve, reject) => {
+      this.homebrewUpdateQueue.push({
+        item,
+        profileStatsEvent: options.profileStatsEvent,
+        resolve,
+        reject
+      });
+      void this.processHomebrewUpdateQueue();
     });
   }
 
+  private async runHomebrewItemUpdate(
+    item: HomebrewManagedItem,
+    profileStatsEvent?: ProfileStatsEvent
+  ): Promise<void> {
+    const itemID = item.id;
+    const command =
+      item.kind === "cask" ? ["upgrade", "--cask", item.token] : ["upgrade", item.token];
+    const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
+    const result = await this.runBrewWithEvents(command, (event) => {
+      this.applyHomebrewProgressEvent(
+        event,
+        parser,
+        new Map([[item.token.toLowerCase(), [itemID]]])
+      );
+    });
+    if (result) {
+      this.patch({
+        refreshErrorMessage: undefined,
+        homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID),
+        homebrewUpdatedPendingRefreshItemIDs: addToArray(
+          this.state.homebrewUpdatedPendingRefreshItemIDs,
+          itemID
+        ),
+        homebrewBatchProgressByItemID: {
+          ...this.state.homebrewBatchProgressByItemID,
+          [itemID]: 1
+        }
+      });
+      await this.recordProfileStatsEvents([
+        profileStatsEvent ??
+          homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
+      ]);
+      await this.holdSuccessfulUpdate();
+    } else {
+      this.patch({
+        refreshErrorMessage: `Homebrew update failed for ${item.name}.`,
+        homebrewBatchFailedItemIDs: addToArray(this.state.homebrewBatchFailedItemIDs, itemID),
+        homebrewBatchProgressByItemID: {
+          ...this.state.homebrewBatchProgressByItemID,
+          [itemID]: 1
+        }
+      });
+      this.scheduleHomebrewBatchFailureClear([itemID]);
+    }
+    await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+  }
+
   async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
+    if (this.state.homebrewUpdatingItemIDs.length > 0 || this.homebrewUpdateQueue.length > 0) {
+      return;
+    }
     const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
     if (!releaseHomebrewCommandLock) {
       return;
@@ -732,6 +762,52 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
   }
 
+  private async processHomebrewUpdateQueue(): Promise<void> {
+    if (this.isProcessingHomebrewUpdateQueue) {
+      return;
+    }
+    this.isProcessingHomebrewUpdateQueue = true;
+    try {
+      while (this.homebrewUpdateQueue.length > 0) {
+        const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
+        if (!releaseHomebrewCommandLock) {
+          return;
+        }
+        const entry = this.homebrewUpdateQueue.shift();
+        if (!entry) {
+          releaseHomebrewCommandLock();
+          continue;
+        }
+        try {
+          const item =
+            this.state.homebrewItems.find((candidate) => candidate.id === entry.item.id) ??
+            entry.item;
+          if (isValidHomebrewToken(item.token)) {
+            await this.runHomebrewItemUpdate(item, entry.profileStatsEvent);
+          }
+          entry.resolve();
+        } catch (error) {
+          entry.reject(error);
+        } finally {
+          if (this.state.homebrewUpdatingItemIDs.includes(entry.item.id)) {
+            this.patch({
+              homebrewUpdatingItemIDs: removeFromArray(
+                this.state.homebrewUpdatingItemIDs,
+                entry.item.id
+              )
+            });
+          }
+          releaseHomebrewCommandLock();
+        }
+      }
+    } finally {
+      this.isProcessingHomebrewUpdateQueue = false;
+      if (this.homebrewUpdateQueue.length > 0 && !this.isHomebrewCommandActive()) {
+        void this.processHomebrewUpdateQueue();
+      }
+    }
+  }
+
   private async withHomebrewCommandLock(operation: () => Promise<void>): Promise<void> {
     const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
     if (!releaseHomebrewCommandLock) {
@@ -758,6 +834,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       released = true;
       this.activeHomebrewCommandCount = Math.max(0, this.activeHomebrewCommandCount - 1);
       this.updateHomebrewCommandLockState();
+      void this.processHomebrewUpdateQueue();
     };
   }
 
@@ -1139,7 +1216,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.activeHomebrewCommandCount > 0 ||
       this.activeHomebrewInventoryCount > 0 ||
       this.state.isRunningHomebrewMaintenance ||
-      this.state.homebrewUpdatingItemIDs.length > 0 ||
       this.state.homebrewUninstallingItemIDs.length > 0 ||
       this.state.homebrewDiscoverInstallingItemIDs.length > 0
     );

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -113,6 +113,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private profileStatsMutationQueue: Promise<void> = Promise.resolve();
   private activeHomebrewCommandCount = 0;
   private activeHomebrewInventoryCount = 0;
+  private activeHomebrewInventoryTask?: {
+    updateMetadata: boolean;
+    task: Promise<HomebrewInventoryResult>;
+  };
   private readonly homebrewUpdateQueue: HomebrewUpdateQueueEntry[] = [];
   private isProcessingHomebrewUpdateQueue = false;
 
@@ -989,7 +993,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         ]);
       const homebrewItems = homebrewInventory.items;
       if (sequence !== this.refreshSequence) {
-        void this.processHomebrewUpdateQueue();
         return;
       }
       this.latestHomebrewIndex = homebrewIndex;
@@ -1076,7 +1079,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       }
 
       if (sequence !== this.refreshSequence) {
-        void this.processHomebrewUpdateQueue();
         return;
       }
       const previousUpdates = new Map(this.state.updates.map((update) => [update.appID, update]));
@@ -1136,7 +1138,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       void this.processHomebrewUpdateQueue();
     } catch (error) {
       if (sequence !== this.refreshSequence) {
-        void this.processHomebrewUpdateQueue();
         return;
       }
       this.patch({
@@ -1183,6 +1184,14 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     lightweight: boolean,
     options: RefreshOptions
   ): Promise<HomebrewInventoryResult> {
+    const updateMetadata = !lightweight;
+    const activeHomebrewInventoryTask = this.activeHomebrewInventoryTask;
+    if (activeHomebrewInventoryTask) {
+      const result = await activeHomebrewInventoryTask.task;
+      if (!updateMetadata || activeHomebrewInventoryTask.updateMetadata) {
+        return result;
+      }
+    }
     if (this.isHomebrewCommandActive() && !options.allowHomebrewInventoryDuringActiveCommand) {
       return {
         items: this.state.homebrewItems,
@@ -1192,20 +1201,31 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
     this.activeHomebrewInventoryCount += 1;
     this.updateHomebrewCommandLockState();
+    const task = this.fetchFreshHomebrewInventory(updateMetadata);
+    this.activeHomebrewInventoryTask = { updateMetadata, task };
     try {
-      if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
-        const brew = await this.runBrewCommand(["--version"]);
-        this.hasCheckedHomebrewAvailability = true;
-        if (!brew.success) {
-          return emptyHomebrewInventoryResult();
-        }
-        this.patch({ isHomebrewInstalled: true });
-      }
-      return await this.homebrewInventory.fetchInventory({ updateMetadata: !lightweight });
+      return await task;
     } finally {
+      if (this.activeHomebrewInventoryTask?.task === task) {
+        this.activeHomebrewInventoryTask = undefined;
+      }
       this.activeHomebrewInventoryCount = Math.max(0, this.activeHomebrewInventoryCount - 1);
       this.updateHomebrewCommandLockState();
     }
+  }
+
+  private async fetchFreshHomebrewInventory(
+    updateMetadata: boolean
+  ): Promise<HomebrewInventoryResult> {
+    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
+      const brew = await this.runBrewCommand(["--version"]);
+      this.hasCheckedHomebrewAvailability = true;
+      if (!brew.success) {
+        return emptyHomebrewInventoryResult();
+      }
+      this.patch({ isHomebrewInstalled: true });
+    }
+    return this.homebrewInventory.fetchInventory({ updateMetadata });
   }
 
   private scanDirectories(): string[] {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -582,21 +582,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (this.isHomebrewCommandActive()) {
       return;
     }
-    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
-      const brew = await this.runBrewCommand(["--version"]);
-      this.hasCheckedHomebrewAvailability = true;
-      if (!brew.success) {
-        this.patch({
-          refreshErrorMessage:
-            "Homebrew is not installed. Install Homebrew to install Discover items."
-        });
-        return;
-      }
-      this.patch({ isHomebrewInstalled: true });
-    }
     this.clearHomebrewDiscoverFailureTimer(itemID);
-    const command =
-      item.kind === "cask" ? ["install", "--cask", item.token] : ["install", item.token];
     this.patch({
       homebrewDiscoverInstallingItemIDs: addToArray(
         this.state.homebrewDiscoverInstallingItemIDs,
@@ -611,6 +597,28 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         [itemID]: HomebrewMaintenanceProgressStage.queued
       }
     });
+    if (this.hasCheckedHomebrewAvailability && !this.state.isHomebrewInstalled) {
+      const brew = await this.runBrewCommand(["--version"]);
+      this.hasCheckedHomebrewAvailability = true;
+      if (!brew.success) {
+        this.patch({
+          homebrewDiscoverInstallingItemIDs: removeFromArray(
+            this.state.homebrewDiscoverInstallingItemIDs,
+            itemID
+          ),
+          homebrewDiscoverProgressByItemID: removeRecordKey(
+            this.state.homebrewDiscoverProgressByItemID,
+            itemID
+          ),
+          refreshErrorMessage:
+            "Homebrew is not installed. Install Homebrew to install Discover items."
+        });
+        return;
+      }
+      this.patch({ isHomebrewInstalled: true });
+    }
+    const command =
+      item.kind === "cask" ? ["install", "--cask", item.token] : ["install", item.token];
     const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
     const success = await this.runBrewWithEvents(command, (event) => {
       this.applyDiscoverInstallEvent(event, parser, itemID, item.token.toLowerCase());

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -980,7 +980,6 @@ type AppControlState = {
   isUninstalling: boolean;
   actionState: ActionState;
   isUpdating: boolean;
-  homebrewUpdateBlocked: boolean;
   homebrewUninstallBlocked: boolean;
 };
 
@@ -993,7 +992,6 @@ function appControlState(app: AppRecord, snapshot: BaselineSnapshot): AppControl
     : false;
   const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
   const homebrewCommandActive = isHomebrewCommandActive(snapshot);
-  const homebrewUpdateBlocked = false;
   const homebrewUninstallBlocked = Boolean(
     uninstallableItem && homebrewCommandActive && !isUninstalling
   );
@@ -1004,7 +1002,6 @@ function appControlState(app: AppRecord, snapshot: BaselineSnapshot): AppControl
     isUninstalling,
     actionState,
     isUpdating,
-    homebrewUpdateBlocked,
     homebrewUninstallBlocked
   };
 }
@@ -1039,7 +1036,6 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
     isUninstalling,
     actionState,
     isUpdating,
-    homebrewUpdateBlocked,
     homebrewUninstallBlocked
   } = appControlState(app, snapshot);
   const label = appSourceLabel(app, snapshot);
@@ -1052,7 +1048,7 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
           {update && (
             <UpdateActionButton
               state={actionState}
-              disabled={isUninstalling || homebrewUpdateBlocked}
+              disabled={isUninstalling}
               onAction={() => void window.baseline.performAppUpdate(app.id)}
             />
           )}
@@ -1239,7 +1235,6 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
     isUninstalling,
     actionState,
     isUpdating,
-    homebrewUpdateBlocked,
     homebrewUninstallBlocked
   } = appControlState(app, snapshot);
   const recentlyUpdatedRecord = snapshot.recentlyUpdated.find((record) => record.appID === app.id);
@@ -1253,7 +1248,7 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
           {update && (
             <UpdateActionButton
               state={actionState}
-              disabled={isUninstalling || homebrewUpdateBlocked}
+              disabled={isUninstalling}
               onAction={() => void window.baseline.performAppUpdate(app.id)}
             />
           )}
@@ -1296,7 +1291,6 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
     isUninstalling,
     actionState,
     isUpdating,
-    homebrewUpdateBlocked,
     homebrewUninstallBlocked
   } = appControlState(app, snapshot);
   const label = appSourceLabel(app, snapshot);
@@ -1313,7 +1307,7 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
               update
                 ? {
                     state: actionState,
-                    disabled: isUninstalling || homebrewUpdateBlocked,
+                    disabled: isUninstalling,
                     onAction: () => void window.baseline.performAppUpdate(app.id)
                   }
                 : undefined
@@ -1367,7 +1361,6 @@ export function AppRow({
     isUninstalling,
     actionState,
     isUpdating,
-    homebrewUpdateBlocked,
     homebrewUninstallBlocked
   } = appControlState(app, snapshot);
   const recentlyUpdatedRecord = recentlyUpdated
@@ -1401,7 +1394,7 @@ export function AppRow({
         {update && (
           <UpdateActionButton
             state={actionState}
-            disabled={isUninstalling || homebrewUpdateBlocked}
+            disabled={isUninstalling}
             onAction={() => void window.baseline.performAppUpdate(app.id)}
           />
         )}
@@ -1699,7 +1692,6 @@ type HomebrewControlState = {
   isUninstalling: boolean;
   isIgnored: boolean;
   updateState: ActionState;
-  homebrewUpdateBlocked: boolean;
   homebrewUninstallBlocked: boolean;
 };
 
@@ -1714,7 +1706,6 @@ function homebrewControlState(
   const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
   const done = snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id);
   const progress = snapshot.homebrewBatchProgressByItemID[item.id];
-  const homebrewUpdateBlocked = false;
   const homebrewUninstallBlocked = isHomebrewCommandActive(snapshot) && !isUninstalling;
   return {
     isUpdating,
@@ -1727,7 +1718,6 @@ function homebrewControlState(
       progress,
       done
     }),
-    homebrewUpdateBlocked,
     homebrewUninstallBlocked
   };
 }
@@ -1740,14 +1730,8 @@ function HomebrewUpdateCard({
   snapshot: BaselineSnapshot;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const {
-    isUpdating,
-    isUninstalling,
-    isIgnored,
-    updateState,
-    homebrewUpdateBlocked,
-    homebrewUninstallBlocked
-  } = homebrewControlState(item, snapshot);
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewUninstallBlocked } =
+    homebrewControlState(item, snapshot);
 
   return (
     <article className={isIgnored ? "item-card update-card ignored-row" : "item-card update-card"}>
@@ -1757,7 +1741,7 @@ function HomebrewUpdateCard({
           {item.isOutdated && (
             <UpdateActionButton
               state={updateState}
-              disabled={isUninstalling || homebrewUpdateBlocked}
+              disabled={isUninstalling}
               onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
             />
           )}
@@ -1880,14 +1864,8 @@ function RecentHomebrewCard({
   appCaskLabel?: string;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const {
-    isUpdating,
-    isUninstalling,
-    isIgnored,
-    updateState,
-    homebrewUpdateBlocked,
-    homebrewUninstallBlocked
-  } = homebrewControlState(item, snapshot);
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewUninstallBlocked } =
+    homebrewControlState(item, snapshot);
   const recentlyUpdatedRecord = snapshot.homebrewRecentlyUpdated.find(
     (record) => record.itemID === item.id
   );
@@ -1900,7 +1878,7 @@ function RecentHomebrewCard({
           {item.isOutdated && (
             <UpdateActionButton
               state={updateState}
-              disabled={isUninstalling || homebrewUpdateBlocked}
+              disabled={isUninstalling}
               onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
             />
           )}
@@ -1939,14 +1917,8 @@ function IgnoredHomebrewCard({
   snapshot: BaselineSnapshot;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const {
-    isUpdating,
-    isUninstalling,
-    isIgnored,
-    updateState,
-    homebrewUpdateBlocked,
-    homebrewUninstallBlocked
-  } = homebrewControlState(item, snapshot);
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewUninstallBlocked } =
+    homebrewControlState(item, snapshot);
 
   return (
     <article className="item-card ignored-card ignored-row">
@@ -1960,7 +1932,7 @@ function IgnoredHomebrewCard({
               item.isOutdated
                 ? {
                     state: updateState,
-                    disabled: isUninstalling || homebrewUpdateBlocked,
+                    disabled: isUninstalling,
                     onAction: () => void window.baseline.performHomebrewUpdate(item.id)
                   }
                 : undefined
@@ -2004,14 +1976,8 @@ export function HomebrewRow({
   recentlyUpdated?: boolean;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const {
-    isUpdating,
-    isUninstalling,
-    isIgnored,
-    updateState,
-    homebrewUpdateBlocked,
-    homebrewUninstallBlocked
-  } = homebrewControlState(item, snapshot);
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewUninstallBlocked } =
+    homebrewControlState(item, snapshot);
   const recentlyUpdatedAt = recentlyUpdated
     ? snapshot.homebrewRecentlyUpdated.find((record) => record.itemID === item.id)?.updatedAt
     : undefined;
@@ -2041,7 +2007,7 @@ export function HomebrewRow({
         {item.isOutdated && (
           <UpdateActionButton
             state={updateState}
-            disabled={isUninstalling || homebrewUpdateBlocked}
+            disabled={isUninstalling}
             onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
           />
         )}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -102,6 +102,7 @@ const initialSnapshot: BaselineSnapshot = {
   isRefreshing: false,
   searchText: "",
   isRunningHomebrewMaintenance: false,
+  isHomebrewCommandLocked: false,
   appUpdatingIDs: [],
   appUpdatedPendingRefreshIDs: [],
   homebrewUpdatingItemIDs: [],
@@ -2374,6 +2375,7 @@ function actionStateFromFlags({
 
 function isHomebrewCommandActive(snapshot: BaselineSnapshot): boolean {
   return (
+    snapshot.isHomebrewCommandLocked ||
     snapshot.isRunningHomebrewMaintenance ||
     snapshot.homebrewUpdatingItemIDs.length > 0 ||
     snapshot.homebrewUninstallingItemIDs.length > 0 ||

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -990,7 +990,7 @@ function appControlState(app: AppRecord, snapshot: BaselineSnapshot): AppControl
     : false;
   const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
   const homebrewCommandActive = isHomebrewCommandActive(snapshot);
-  const homebrewUpdateBlocked = isHomebrewAppUpdateBlocked(update, snapshot, isUpdating);
+  const homebrewUpdateBlocked = false;
   const homebrewUninstallBlocked = Boolean(
     uninstallableItem && homebrewCommandActive && !isUninstalling
   );
@@ -1696,7 +1696,8 @@ type HomebrewControlState = {
   isUninstalling: boolean;
   isIgnored: boolean;
   updateState: ActionState;
-  homebrewActionBlocked: boolean;
+  homebrewUpdateBlocked: boolean;
+  homebrewUninstallBlocked: boolean;
 };
 
 function homebrewControlState(
@@ -1709,7 +1710,8 @@ function homebrewControlState(
   const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
   const done = snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id);
   const progress = snapshot.homebrewBatchProgressByItemID[item.id];
-  const homebrewActionBlocked = isHomebrewCommandActive(snapshot) && !isUpdating && !isUninstalling;
+  const homebrewUpdateBlocked = false;
+  const homebrewUninstallBlocked = isHomebrewCommandActive(snapshot) && !isUninstalling;
   return {
     isUpdating,
     isUninstalling,
@@ -1720,7 +1722,8 @@ function homebrewControlState(
       progress,
       done
     }),
-    homebrewActionBlocked
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
   };
 }
 
@@ -1732,8 +1735,14 @@ function HomebrewUpdateCard({
   snapshot: BaselineSnapshot;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
-    homebrewControlState(item, snapshot);
+  const {
+    isUpdating,
+    isUninstalling,
+    isIgnored,
+    updateState,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = homebrewControlState(item, snapshot);
 
   return (
     <article className={isIgnored ? "item-card update-card ignored-row" : "item-card update-card"}>
@@ -1743,7 +1752,7 @@ function HomebrewUpdateCard({
           {item.isOutdated && (
             <UpdateActionButton
               state={updateState}
-              disabled={isUninstalling || homebrewActionBlocked}
+              disabled={isUninstalling || homebrewUpdateBlocked}
               onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
             />
           )}
@@ -1754,7 +1763,7 @@ function HomebrewUpdateCard({
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
             onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
           />
         </div>
@@ -1866,8 +1875,14 @@ function RecentHomebrewCard({
   appCaskLabel?: string;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
-    homebrewControlState(item, snapshot);
+  const {
+    isUpdating,
+    isUninstalling,
+    isIgnored,
+    updateState,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = homebrewControlState(item, snapshot);
   const recentlyUpdatedRecord = snapshot.homebrewRecentlyUpdated.find(
     (record) => record.itemID === item.id
   );
@@ -1880,7 +1895,7 @@ function RecentHomebrewCard({
           {item.isOutdated && (
             <UpdateActionButton
               state={updateState}
-              disabled={isUninstalling || homebrewActionBlocked}
+              disabled={isUninstalling || homebrewUpdateBlocked}
               onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
             />
           )}
@@ -1891,7 +1906,7 @@ function RecentHomebrewCard({
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
             onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
           />
         </div>
@@ -1919,8 +1934,14 @@ function IgnoredHomebrewCard({
   snapshot: BaselineSnapshot;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
-    homebrewControlState(item, snapshot);
+  const {
+    isUpdating,
+    isUninstalling,
+    isIgnored,
+    updateState,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = homebrewControlState(item, snapshot);
 
   return (
     <article className="item-card ignored-card ignored-row">
@@ -1934,7 +1955,7 @@ function IgnoredHomebrewCard({
               item.isOutdated
                 ? {
                     state: updateState,
-                    disabled: isUninstalling || homebrewActionBlocked,
+                    disabled: isUninstalling || homebrewUpdateBlocked,
                     onAction: () => void window.baseline.performHomebrewUpdate(item.id)
                   }
                 : undefined
@@ -1943,7 +1964,7 @@ function IgnoredHomebrewCard({
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
             onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
           />
         </div>
@@ -1978,8 +1999,14 @@ export function HomebrewRow({
   recentlyUpdated?: boolean;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
-    homebrewControlState(item, snapshot);
+  const {
+    isUpdating,
+    isUninstalling,
+    isIgnored,
+    updateState,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = homebrewControlState(item, snapshot);
   const recentlyUpdatedAt = recentlyUpdated
     ? snapshot.homebrewRecentlyUpdated.find((record) => record.itemID === item.id)?.updatedAt
     : undefined;
@@ -2009,7 +2036,7 @@ export function HomebrewRow({
         {item.isOutdated && (
           <UpdateActionButton
             state={updateState}
-            disabled={isUninstalling || homebrewActionBlocked}
+            disabled={isUninstalling || homebrewUpdateBlocked}
             onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
           />
         )}
@@ -2020,7 +2047,7 @@ export function HomebrewRow({
           uninstallLabel="Uninstall"
           canUninstall={item.kind === "cask"}
           uninstalling={isUninstalling}
-          uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
+          uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
           onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
         />
       </div>
@@ -2379,14 +2406,6 @@ function isHomebrewCommandActive(snapshot: BaselineSnapshot): boolean {
     snapshot.homebrewUninstallingItemIDs.length > 0 ||
     snapshot.homebrewDiscoverInstallingItemIDs.length > 0
   );
-}
-
-function isHomebrewAppUpdateBlocked(
-  update: UpdateRecord | undefined,
-  snapshot: BaselineSnapshot,
-  isUpdating: boolean
-): boolean {
-  return Boolean(update?.source === "homebrew" && isHomebrewCommandActive(snapshot) && !isUpdating);
 }
 
 function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -774,6 +774,7 @@ function AllUpdatesSection({
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
 }) {
+  const homebrewCommandActive = isHomebrewCommandActive(snapshot);
   const items: RecentGridItem[] = [
     ...derived.availableApps.map((app) => ({
       type: "app" as const,
@@ -797,7 +798,7 @@ function AllUpdatesSection({
           derived.allHomebrewOutdated.length > 1 ? (
             <UpdateActionButton
               state={
-                snapshot.isRunningHomebrewMaintenance
+                homebrewCommandActive
                   ? { type: "updating" }
                   : derived.allHomebrewOutdated.every((item) =>
                         snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id)
@@ -807,6 +808,7 @@ function AllUpdatesSection({
               }
               readyLabel="Update Brews"
               readyVariant="outline"
+              disabled={homebrewCommandActive}
               onAction={() => performHomebrewUpdateAllForItems(derived.allHomebrewOutdated)}
             />
           ) : undefined
@@ -974,6 +976,8 @@ type AppControlState = {
   isUninstalling: boolean;
   actionState: ActionState;
   isUpdating: boolean;
+  homebrewUpdateBlocked: boolean;
+  homebrewUninstallBlocked: boolean;
 };
 
 function appControlState(app: AppRecord, snapshot: BaselineSnapshot): AppControlState {
@@ -984,7 +988,23 @@ function appControlState(app: AppRecord, snapshot: BaselineSnapshot): AppControl
     ? snapshot.homebrewUninstallingItemIDs.includes(uninstallableItem.id)
     : false;
   const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
-  return { update, isIgnored, uninstallableItem, isUninstalling, actionState, isUpdating };
+  const homebrewCommandActive = isHomebrewCommandActive(snapshot);
+  const homebrewUpdateBlocked = Boolean(
+    update?.source === "homebrew" && uninstallableItem && homebrewCommandActive && !isUpdating
+  );
+  const homebrewUninstallBlocked = Boolean(
+    uninstallableItem && homebrewCommandActive && !isUninstalling
+  );
+  return {
+    update,
+    isIgnored,
+    uninstallableItem,
+    isUninstalling,
+    actionState,
+    isUpdating,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  };
 }
 
 function AppIconButton({ app }: { app: AppRecord }) {
@@ -1010,8 +1030,16 @@ function AppIconButton({ app }: { app: AppRecord }) {
 
 function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { update, isIgnored, uninstallableItem, isUninstalling, actionState, isUpdating } =
-    appControlState(app, snapshot);
+  const {
+    update,
+    isIgnored,
+    uninstallableItem,
+    isUninstalling,
+    actionState,
+    isUpdating,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = appControlState(app, snapshot);
   const label = appSourceLabel(app, snapshot);
 
   return (
@@ -1022,7 +1050,7 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
           {update && (
             <UpdateActionButton
               state={actionState}
-              disabled={isUninstalling}
+              disabled={isUninstalling || homebrewUpdateBlocked}
               onAction={() => void window.baseline.performAppUpdate(app.id)}
             />
           )}
@@ -1033,7 +1061,7 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
             uninstallLabel="Uninstall"
             canUninstall={Boolean(uninstallableItem)}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
             onUninstall={() =>
               uninstallableItem &&
               requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
@@ -1202,8 +1230,16 @@ function CardGrid({
 
 function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { update, isIgnored, uninstallableItem, isUninstalling, actionState, isUpdating } =
-    appControlState(app, snapshot);
+  const {
+    update,
+    isIgnored,
+    uninstallableItem,
+    isUninstalling,
+    actionState,
+    isUpdating,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = appControlState(app, snapshot);
   const recentlyUpdatedRecord = snapshot.recentlyUpdated.find((record) => record.appID === app.id);
   const label = appSourceLabel(app, snapshot, recentlyUpdatedRecord);
 
@@ -1215,7 +1251,7 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
           {update && (
             <UpdateActionButton
               state={actionState}
-              disabled={isUninstalling}
+              disabled={isUninstalling || homebrewUpdateBlocked}
               onAction={() => void window.baseline.performAppUpdate(app.id)}
             />
           )}
@@ -1226,7 +1262,7 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
             uninstallLabel="Uninstall"
             canUninstall={Boolean(uninstallableItem)}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
             onUninstall={() =>
               uninstallableItem &&
               requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
@@ -1251,8 +1287,16 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
 
 function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSnapshot }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { update, isIgnored, uninstallableItem, isUninstalling, actionState, isUpdating } =
-    appControlState(app, snapshot);
+  const {
+    update,
+    isIgnored,
+    uninstallableItem,
+    isUninstalling,
+    actionState,
+    isUpdating,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = appControlState(app, snapshot);
   const label = appSourceLabel(app, snapshot);
 
   return (
@@ -1267,7 +1311,7 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
               update
                 ? {
                     state: actionState,
-                    disabled: isUninstalling,
+                    disabled: isUninstalling || homebrewUpdateBlocked,
                     onAction: () => void window.baseline.performAppUpdate(app.id)
                   }
                 : undefined
@@ -1276,7 +1320,7 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
             uninstallLabel="Uninstall"
             canUninstall={Boolean(uninstallableItem)}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
             onUninstall={() =>
               uninstallableItem &&
               requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
@@ -1314,8 +1358,16 @@ export function AppRow({
   recentlyUpdated: boolean;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { update, isIgnored, uninstallableItem, isUninstalling, actionState, isUpdating } =
-    appControlState(app, snapshot);
+  const {
+    update,
+    isIgnored,
+    uninstallableItem,
+    isUninstalling,
+    actionState,
+    isUpdating,
+    homebrewUpdateBlocked,
+    homebrewUninstallBlocked
+  } = appControlState(app, snapshot);
   const recentlyUpdatedRecord = recentlyUpdated
     ? snapshot.recentlyUpdated.find((record) => record.appID === app.id)
     : undefined;
@@ -1347,7 +1399,7 @@ export function AppRow({
         {update && (
           <UpdateActionButton
             state={actionState}
-            disabled={isUninstalling}
+            disabled={isUninstalling || homebrewUpdateBlocked}
             onAction={() => void window.baseline.performAppUpdate(app.id)}
           />
         )}
@@ -1358,7 +1410,7 @@ export function AppRow({
           uninstallLabel="Uninstall"
           canUninstall={Boolean(uninstallableItem)}
           uninstalling={isUninstalling}
-          uninstallDisabled={isUpdating || isUninstalling}
+          uninstallDisabled={isUpdating || isUninstalling || homebrewUninstallBlocked}
           onUninstall={() =>
             uninstallableItem &&
             requestActionConfirmation({ type: "uninstall", item: uninstallableItem })
@@ -1587,6 +1639,7 @@ export function HomebrewSection({
   cardLayout?: boolean;
 }) {
   const collapsed = collapsible && snapshot.collapsedHomebrewSectionIDs.includes(sectionID);
+  const homebrewCommandActive = isHomebrewCommandActive(snapshot);
   return (
     <section className="panel">
       <PanelTitle
@@ -1598,7 +1651,7 @@ export function HomebrewSection({
           showUpdateAll && items.length > 1 ? (
             <UpdateActionButton
               state={
-                snapshot.isRunningHomebrewMaintenance
+                homebrewCommandActive
                   ? { type: "updating" }
                   : items.every((item) =>
                         snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id)
@@ -1608,6 +1661,7 @@ export function HomebrewSection({
               }
               readyLabel="Update Brews"
               readyVariant="outline"
+              disabled={homebrewCommandActive}
               onAction={() => performHomebrewUpdateAllForItems(items)}
             />
           ) : undefined
@@ -1643,6 +1697,7 @@ type HomebrewControlState = {
   isUninstalling: boolean;
   isIgnored: boolean;
   updateState: ActionState;
+  homebrewActionBlocked: boolean;
 };
 
 function homebrewControlState(
@@ -1655,6 +1710,7 @@ function homebrewControlState(
   const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
   const done = snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id);
   const progress = snapshot.homebrewBatchProgressByItemID[item.id];
+  const homebrewActionBlocked = isHomebrewCommandActive(snapshot) && !isUpdating && !isUninstalling;
   return {
     isUpdating,
     isUninstalling,
@@ -1664,7 +1720,8 @@ function homebrewControlState(
       updating: isUpdating,
       progress,
       done
-    })
+    }),
+    homebrewActionBlocked
   };
 }
 
@@ -1676,10 +1733,8 @@ function HomebrewUpdateCard({
   snapshot: BaselineSnapshot;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState } = homebrewControlState(
-    item,
-    snapshot
-  );
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
+    homebrewControlState(item, snapshot);
 
   return (
     <article className={isIgnored ? "item-card update-card ignored-row" : "item-card update-card"}>
@@ -1689,7 +1744,7 @@ function HomebrewUpdateCard({
           {item.isOutdated && (
             <UpdateActionButton
               state={updateState}
-              disabled={isUninstalling}
+              disabled={isUninstalling || homebrewActionBlocked}
               onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
             />
           )}
@@ -1700,7 +1755,7 @@ function HomebrewUpdateCard({
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
             onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
           />
         </div>
@@ -1812,10 +1867,8 @@ function RecentHomebrewCard({
   appCaskLabel?: string;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState } = homebrewControlState(
-    item,
-    snapshot
-  );
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
+    homebrewControlState(item, snapshot);
   const recentlyUpdatedRecord = snapshot.homebrewRecentlyUpdated.find(
     (record) => record.itemID === item.id
   );
@@ -1828,7 +1881,7 @@ function RecentHomebrewCard({
           {item.isOutdated && (
             <UpdateActionButton
               state={updateState}
-              disabled={isUninstalling}
+              disabled={isUninstalling || homebrewActionBlocked}
               onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
             />
           )}
@@ -1839,7 +1892,7 @@ function RecentHomebrewCard({
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
             onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
           />
         </div>
@@ -1867,10 +1920,8 @@ function IgnoredHomebrewCard({
   snapshot: BaselineSnapshot;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState } = homebrewControlState(
-    item,
-    snapshot
-  );
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
+    homebrewControlState(item, snapshot);
 
   return (
     <article className="item-card ignored-card ignored-row">
@@ -1884,7 +1935,7 @@ function IgnoredHomebrewCard({
               item.isOutdated
                 ? {
                     state: updateState,
-                    disabled: isUninstalling,
+                    disabled: isUninstalling || homebrewActionBlocked,
                     onAction: () => void window.baseline.performHomebrewUpdate(item.id)
                   }
                 : undefined
@@ -1893,7 +1944,7 @@ function IgnoredHomebrewCard({
             uninstallLabel="Uninstall"
             canUninstall={item.kind === "cask"}
             uninstalling={isUninstalling}
-            uninstallDisabled={isUpdating || isUninstalling}
+            uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
             onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
           />
         </div>
@@ -1928,10 +1979,8 @@ export function HomebrewRow({
   recentlyUpdated?: boolean;
 }) {
   const requestActionConfirmation = React.useContext(ActionConfirmationContext);
-  const { isUpdating, isUninstalling, isIgnored, updateState } = homebrewControlState(
-    item,
-    snapshot
-  );
+  const { isUpdating, isUninstalling, isIgnored, updateState, homebrewActionBlocked } =
+    homebrewControlState(item, snapshot);
   const recentlyUpdatedAt = recentlyUpdated
     ? snapshot.homebrewRecentlyUpdated.find((record) => record.itemID === item.id)?.updatedAt
     : undefined;
@@ -1961,7 +2010,7 @@ export function HomebrewRow({
         {item.isOutdated && (
           <UpdateActionButton
             state={updateState}
-            disabled={isUninstalling}
+            disabled={isUninstalling || homebrewActionBlocked}
             onAction={() => void window.baseline.performHomebrewUpdate(item.id)}
           />
         )}
@@ -1972,7 +2021,7 @@ export function HomebrewRow({
           uninstallLabel="Uninstall"
           canUninstall={item.kind === "cask"}
           uninstalling={isUninstalling}
-          uninstallDisabled={isUpdating || isUninstalling}
+          uninstallDisabled={isUpdating || isUninstalling || homebrewActionBlocked}
           onUninstall={() => requestActionConfirmation({ type: "uninstall", item })}
         />
       </div>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1523,6 +1523,7 @@ export function DiscoverRow({
   const done = snapshot.homebrewDiscoverInstalledPendingRefreshItemIDs.includes(item.id);
   const progress = snapshot.homebrewDiscoverProgressByItemID[item.id];
   const canInstall = snapshot.isHomebrewInstalled;
+  const busy = canInstall && !installing && !failed && !done && isHomebrewCommandActive(snapshot);
 
   return (
     <article className="row">
@@ -1541,10 +1542,10 @@ export function DiscoverRow({
       <div className="row-actions">
         <UpdateActionButton
           state={actionStateFromFlags({ failed, updating: installing, progress, done })}
-          readyLabel={canInstall ? "Install" : "Needs Homebrew"}
-          disabled={!canInstall}
+          readyLabel={canInstall ? (busy ? "Busy" : "Install") : "Needs Homebrew"}
+          disabled={!canInstall || busy}
           onAction={() => {
-            if (canInstall) {
+            if (canInstall && !busy) {
               requestActionConfirmation({ type: "install", item });
             }
           }}
@@ -2320,6 +2321,15 @@ function actionStateFromFlags({
     return progress === undefined ? { type: "updating" } : { type: "updating", progress };
   }
   return { type: "ready" };
+}
+
+function isHomebrewCommandActive(snapshot: BaselineSnapshot): boolean {
+  return (
+    snapshot.isRunningHomebrewMaintenance ||
+    snapshot.homebrewUpdatingItemIDs.length > 0 ||
+    snapshot.homebrewUninstallingItemIDs.length > 0 ||
+    snapshot.homebrewDiscoverInstallingItemIDs.length > 0
+  );
 }
 
 function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -990,9 +990,7 @@ function appControlState(app: AppRecord, snapshot: BaselineSnapshot): AppControl
     : false;
   const { state: actionState, isUpdating } = appUpdateActionState(app, snapshot);
   const homebrewCommandActive = isHomebrewCommandActive(snapshot);
-  const homebrewUpdateBlocked = Boolean(
-    update?.source === "homebrew" && uninstallableItem && homebrewCommandActive && !isUpdating
-  );
+  const homebrewUpdateBlocked = isHomebrewAppUpdateBlocked(update, snapshot, isUpdating);
   const homebrewUninstallBlocked = Boolean(
     uninstallableItem && homebrewCommandActive && !isUninstalling
   );
@@ -2381,6 +2379,14 @@ function isHomebrewCommandActive(snapshot: BaselineSnapshot): boolean {
     snapshot.homebrewUninstallingItemIDs.length > 0 ||
     snapshot.homebrewDiscoverInstallingItemIDs.length > 0
   );
+}
+
+function isHomebrewAppUpdateBlocked(
+  update: UpdateRecord | undefined,
+  snapshot: BaselineSnapshot,
+  isUpdating: boolean
+): boolean {
+  return Boolean(update?.source === "homebrew" && isHomebrewCommandActive(snapshot) && !isUpdating);
 }
 
 function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -12,6 +12,7 @@ import {
   CheckCircle2,
   CircleUserRound,
   ChevronRight,
+  ClockArrowDown,
   Download,
   Eye,
   EyeOff,
@@ -63,6 +64,7 @@ import "./styles.css";
 type Route = "main" | "menubar" | "settings";
 type ActionState =
   | { type: "ready" }
+  | { type: "queued" }
   | { type: "updating"; progress?: number }
   | { type: "done" }
   | { type: "failed" };
@@ -106,6 +108,7 @@ const initialSnapshot: BaselineSnapshot = {
   appUpdatingIDs: [],
   appUpdatedPendingRefreshIDs: [],
   homebrewUpdatingItemIDs: [],
+  homebrewQueuedItemIDs: [],
   homebrewUninstallingItemIDs: [],
   homebrewUpdatedPendingRefreshItemIDs: [],
   homebrewBatchProgressByItemID: {},
@@ -1705,6 +1708,7 @@ function homebrewControlState(
   snapshot: BaselineSnapshot
 ): HomebrewControlState {
   const isUpdating = snapshot.homebrewUpdatingItemIDs.includes(item.id);
+  const queued = snapshot.homebrewQueuedItemIDs.includes(item.id);
   const isUninstalling = snapshot.homebrewUninstallingItemIDs.includes(item.id);
   const isIgnored = snapshot.ignoredHomebrewItemIDs.includes(item.id);
   const failed = snapshot.homebrewBatchFailedItemIDs.includes(item.id);
@@ -1718,6 +1722,7 @@ function homebrewControlState(
     isIgnored,
     updateState: actionStateFromFlags({
       failed,
+      queued,
       updating: isUpdating,
       progress,
       done
@@ -2148,7 +2153,9 @@ export function UpdateActionButton({
       tabIndex={-1}
       type="button"
     >
-      {state.type === "updating" ? (
+      {state.type === "queued" ? (
+        <ClockArrowDown size={14} />
+      ) : state.type === "updating" ? (
         state.progress === undefined ? (
           <RefreshCcw className="spin" size={14} />
         ) : (
@@ -2254,6 +2261,8 @@ function RowMoreActionButton({
             >
               {updateAction.state.type === "ready" ? (
                 <Download size={14} />
+              ) : updateAction.state.type === "queued" ? (
+                <ClockArrowDown size={14} />
               ) : updateAction.state.type === "updating" ? (
                 updateAction.state.progress === undefined ? (
                   <RefreshCcw className="spin" size={14} />
@@ -2377,11 +2386,13 @@ function ActionConfirmationOverlay({
 
 function actionStateFromFlags({
   failed,
+  queued = false,
   updating,
   progress,
   done
 }: {
   failed: boolean;
+  queued?: boolean;
   updating: boolean;
   progress?: number;
   done: boolean;
@@ -2391,6 +2402,9 @@ function actionStateFromFlags({
   }
   if (done) {
     return { type: "done" };
+  }
+  if (queued) {
+    return { type: "queued" };
   }
   if (updating) {
     return progress === undefined ? { type: "updating" } : { type: "updating", progress };
@@ -2412,6 +2426,9 @@ function actionStateLabel(state: Exclude<ActionState, { type: "ready" }>): strin
   if (state.type === "updating") {
     return "Updating";
   }
+  if (state.type === "queued") {
+    return "Queued";
+  }
   if (state.type === "done") {
     return "Updated";
   }
@@ -2430,6 +2447,9 @@ function appUpdateActionState(
     Boolean(
       matchedHomebrewItem && snapshot.homebrewUpdatingItemIDs.includes(matchedHomebrewItem.id)
     );
+  const queued = Boolean(
+    matchedHomebrewItem && snapshot.homebrewQueuedItemIDs.includes(matchedHomebrewItem.id)
+  );
   const progress =
     snapshot.homebrewFallbackProgressByAppID[app.id] ??
     (matchedHomebrewItem
@@ -2451,6 +2471,7 @@ function appUpdateActionState(
     isUpdating,
     state: actionStateFromFlags({
       failed,
+      queued,
       updating: isUpdating,
       progress,
       done

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -227,6 +227,7 @@ export type BaselineSnapshot = PersistedSnapshot &
     appUpdatingIDs: string[];
     appUpdatedPendingRefreshIDs: string[];
     homebrewUpdatingItemIDs: string[];
+    homebrewQueuedItemIDs: string[];
     homebrewUninstallingItemIDs: string[];
     homebrewUpdatedPendingRefreshItemIDs: string[];
     homebrewBatchProgressByItemID: Record<string, number>;

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -223,6 +223,7 @@ export type BaselineSnapshot = PersistedSnapshot &
   RefreshState & {
     searchText: string;
     isRunningHomebrewMaintenance: boolean;
+    isHomebrewCommandLocked: boolean;
     appUpdatingIDs: string[];
     appUpdatedPendingRefreshIDs: string[];
     homebrewUpdatingItemIDs: string[];


### PR DESCRIPTION
## Summary

- serialize Homebrew command and inventory work through a shared command lock so Discover installs, updates, uninstalls, tool checks, and refresh-driven inventory do not run overlapping `brew` commands
- keep individual Homebrew-backed app and Homebrew item update clicks responsive during active Homebrew work by queueing requested items, draining the queue when the command/inventory lock clears, and batching queued formula/cask upgrades where possible
- re-check queued Homebrew work against current state before execution so stale queued rows do not run after inventory marks them current or removes the active app update
- keep the renderer aligned with the Homebrew lifecycle: Discover installs show a disabled Busy action while Homebrew is active, queued updates show the ClockArrowDown Queued state, running updates keep progress/success/failure states, and unsafe uninstall/Update Brews actions stay blocked during active Homebrew work
- preserve Discover install and Homebrew update state across refreshes, including waking queued updates after inventory refreshes complete or get superseded

Fixes #108
Fixes #103

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --audit-level=high`
