### PR TITLE
Commit refresh interval edits after typing

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -2050,7 +2050,9 @@ describe("renderer button parity", () => {
   });
 
   it("lets refresh interval edits build multi-digit values before committing", () => {
-    const { rerender } = render(<SettingsView snapshot={snapshot({ refreshIntervalMinutes: 60 })} />);
+    const { rerender } = render(
+      <SettingsView snapshot={snapshot({ refreshIntervalMinutes: 60 })} />
+    );
 
     const interval = screen.getByRole("textbox", { name: "Interval minutes" });
     fireEvent.change(interval, { target: { value: "" } });

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -2039,10 +2039,39 @@ describe("renderer button parity", () => {
 
     const enabledInterval = screen.getByRole("textbox", { name: "Interval minutes" });
     fireEvent.change(enabledInterval, { target: { value: "30" } });
+    expect(window.baseline.updatePreferences).not.toHaveBeenCalledWith({
+      refreshIntervalMinutes: 30
+    });
+    fireEvent.blur(enabledInterval);
 
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
       refreshIntervalMinutes: 30
     });
+  });
+
+  it("lets refresh interval edits build multi-digit values before committing", () => {
+    render(<SettingsView snapshot={snapshot({ refreshIntervalMinutes: 60 })} />);
+
+    const interval = screen.getByRole("textbox", { name: "Interval minutes" });
+    fireEvent.change(interval, { target: { value: "" } });
+    fireEvent.change(interval, { target: { value: "1" } });
+    fireEvent.change(interval, { target: { value: "15" } });
+
+    expect(interval).toHaveValue("15");
+    expect(window.baseline.updatePreferences).not.toHaveBeenCalledWith({
+      refreshIntervalMinutes: 5
+    });
+    expect(window.baseline.updatePreferences).not.toHaveBeenCalledWith({
+      refreshIntervalMinutes: 15
+    });
+
+    fireEvent.keyDown(interval, { key: "Enter" });
+
+    expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
+      refreshIntervalMinutes: 15
+    });
+    fireEvent.blur(interval);
+    expect(window.baseline.updatePreferences).toHaveBeenCalledTimes(1);
   });
 
   it("shows default scan directories when custom directories are present", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -2050,7 +2050,7 @@ describe("renderer button parity", () => {
   });
 
   it("lets refresh interval edits build multi-digit values before committing", () => {
-    render(<SettingsView snapshot={snapshot({ refreshIntervalMinutes: 60 })} />);
+    const { rerender } = render(<SettingsView snapshot={snapshot({ refreshIntervalMinutes: 60 })} />);
 
     const interval = screen.getByRole("textbox", { name: "Interval minutes" });
     fireEvent.change(interval, { target: { value: "" } });
@@ -2070,6 +2070,7 @@ describe("renderer button parity", () => {
     expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
       refreshIntervalMinutes: 15
     });
+    rerender(<SettingsView snapshot={snapshot({ refreshIntervalMinutes: 15 })} />);
     fireEvent.blur(interval);
     expect(window.baseline.updatePreferences).toHaveBeenCalledTimes(1);
   });

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2706,10 +2706,27 @@ function defaultScanDirectoryLabel(directory: string): string {
 
 function RefreshIntervalInput({ value, disabled }: { value: number; disabled: boolean }) {
   const [draft, setDraft] = useState(String(value));
+  const lastCommittedDraftRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     setDraft(String(value));
+    lastCommittedDraftRef.current = undefined;
   }, [value]);
+
+  const commitDraft = () => {
+    if (!draft) {
+      setDraft(String(value));
+      return;
+    }
+    const refreshIntervalMinutes = clampRefreshIntervalMinutes(Number.parseInt(draft, 10));
+    const normalizedDraft = String(refreshIntervalMinutes);
+    setDraft(normalizedDraft);
+    if (lastCommittedDraftRef.current === normalizedDraft) {
+      return;
+    }
+    lastCommittedDraftRef.current = normalizedDraft;
+    void window.baseline.updatePreferences({ refreshIntervalMinutes });
+  };
 
   return (
     <label
@@ -2736,16 +2753,22 @@ function RefreshIntervalInput({ value, disabled }: { value: number; disabled: bo
           if (!/^\d*$/u.test(nextValue)) {
             return;
           }
+          lastCommittedDraftRef.current = undefined;
           setDraft(nextValue);
-          if (nextValue) {
-            void window.baseline.updatePreferences({
-              refreshIntervalMinutes: Number.parseInt(nextValue, 10)
-            });
+        }}
+        onBlur={commitDraft}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            commitDraft();
           }
         }}
       />
     </label>
   );
+}
+
+function clampRefreshIntervalMinutes(value: number): number {
+  return Math.min(Math.max(Math.trunc(value), 5), 1440);
 }
 
 function Toggle({

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2709,8 +2709,11 @@ function RefreshIntervalInput({ value, disabled }: { value: number; disabled: bo
   const lastCommittedDraftRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    setDraft(String(value));
-    lastCommittedDraftRef.current = undefined;
+    const nextDraft = String(value);
+    setDraft(nextDraft);
+    if (lastCommittedDraftRef.current !== nextDraft) {
+      lastCommittedDraftRef.current = undefined;
+    }
   }, [value]);
 
   const commitDraft = () => {


### PR DESCRIPTION
## Summary

- keep refresh interval edits in a local numeric draft while the user types
- clamp and commit the preference only on blur or Enter
- avoid duplicate commits when Enter and blur submit the same draft before the snapshot rerenders

Fixes #101

## Validation
- `npm test -- --run ElectronTests/rendererButtons.test.tsx`
- `npm run typecheck`
- `npm run lint`
