### PR TITLE
Scan symlinked app bundles

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -73,6 +73,30 @@ describe("bundle scanner", () => {
       "com.example.direct",
       "com.example.nested"
     ]);
+  });
+
+  it("scans symlinked app bundles once when their target is also scanned", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+    const scanRoot = path.join(root, "Scan");
+    const targetRoot = path.join(root, "Targets");
+    const targetApp = path.join(targetRoot, "Target.app");
+    const linkedApp = path.join(scanRoot, "Linked.app");
+    await mkdir(scanRoot, { recursive: true });
+    await writeAppPlist(targetApp, {
+      displayName: "Target",
+      bundleIdentifier: "com.example.target",
+      version: "1.0.0"
+    });
+    await symlink(targetApp, linkedApp);
+
+    const records = await new BundleScannerClient().scanApplications([scanRoot, targetRoot]);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      displayName: "Target",
+      bundleIdentifier: "com.example.target"
+    });
   });
 
   it("ignores Safari web app bundles", async () => {

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -3,7 +3,7 @@
 
 import { execFile } from "node:child_process";
 import { app as electronApp, nativeImage, type NativeImage } from "electron";
-import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, realpath, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -51,10 +51,11 @@ export class BundleScannerClient {
     for (const directory of directories) {
       const apps = await this.findApps(directory);
       for (const appPath of apps) {
-        if (seen.has(appPath)) {
+        const canonicalPath = await canonicalAppPath(appPath);
+        if (seen.has(canonicalPath)) {
           continue;
         }
-        seen.add(appPath);
+        seen.add(canonicalPath);
         const record = await this.makeRecord(appPath);
         if (record) {
           records.push(record);
@@ -72,12 +73,14 @@ export class BundleScannerClient {
       const entries = await readdir(directory, { withFileTypes: true });
       const apps: string[] = [];
       for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
         const entryPath = path.join(directory, entry.name);
         if (entry.name.endsWith(".app")) {
-          apps.push(entryPath);
+          if (entry.isDirectory() || (entry.isSymbolicLink() && (await isDirectory(entryPath)))) {
+            apps.push(entryPath);
+          }
+          continue;
+        }
+        if (!entry.isDirectory()) {
           continue;
         }
         apps.push(...(await this.findApps(entryPath)));
@@ -247,6 +250,22 @@ export class BundleScannerClient {
     }
 
     return {};
+  }
+}
+
+async function canonicalAppPath(appPath: string): Promise<string> {
+  try {
+    return await realpath(appPath);
+  } catch {
+    return appPath;
+  }
+}
+
+async function isDirectory(candidatePath: string): Promise<boolean> {
+  try {
+    return (await stat(candidatePath)).isDirectory();
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

- treat `.app` symlink entries as app bundle candidates when they resolve to directories
- deduplicate scanned app bundles by canonical real path so a symlink and its target produce one record
- add scanner coverage for a symlinked app whose target is also scanned

Fixes #106

## Validation
- `npm test -- --run ElectronTests/bundleScanner.test.ts`
- `npm run typecheck`
- `npm run lint`
