### PR TITLE
Respect Sparkle app ownership before Homebrew fallback

### DIFF
--- a/ElectronTests/homebrewAppLinking.test.ts
+++ b/ElectronTests/homebrewAppLinking.test.ts
@@ -53,6 +53,34 @@ describe("Homebrew app linking", () => {
     expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map())).toBe(false);
   });
 
+  it("does not use token-only Homebrew updates as app-backed proof for Sparkle-origin apps", () => {
+    const sparkleApp = {
+      ...app,
+      sourceHint: "sparkle" as const
+    };
+    const update: UpdateRecord = {
+      id: sparkleApp.id,
+      appID: sparkleApp.id,
+      source: "homebrew",
+      supportLevel: "limited",
+      localVersion: version("1.0.0"),
+      remoteVersion: version("2.0.0"),
+      homebrewToken: "visual-studio-code",
+      checkedAt: "2026-04-30T12:00:00.000Z"
+    };
+
+    expect(
+      homebrewItemHasAppRepresentation(codeCask, [sparkleApp], new Map([[sparkleApp.id, update]]))
+    ).toBe(false);
+    expect(
+      homebrewItemHasAppRepresentation(
+        { ...codeCask, appID: sparkleApp.id },
+        [sparkleApp],
+        new Map([[sparkleApp.id, update]])
+      )
+    ).toBe(true);
+  });
+
   it("does not treat formulae as app-backed items", () => {
     const formula: HomebrewManagedItem = {
       id: "formula:visual-studio-code",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -537,6 +537,41 @@ describe("renderer button parity", () => {
     expect(within(homebrewButton as HTMLElement).queryByText("0")).not.toBeInTheDocument();
   });
 
+  it("keeps unowned Sparkle Homebrew fallback casks visible as Homebrew updates", () => {
+    const sparkleApp: AppRecord = {
+      ...app,
+      sourceHint: "sparkle",
+      sparkleFeedURL: "https://updates.example.com/appcast.xml"
+    };
+    const fallbackUpdate: UpdateRecord = {
+      ...update,
+      supportLevel: "limited",
+      appID: sparkleApp.id,
+      id: sparkleApp.id
+    };
+    const fallbackCask: HomebrewManagedItem = {
+      ...cask,
+      name: "example-cask",
+      presentation: "app"
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          apps: [sparkleApp],
+          updates: [fallbackUpdate],
+          homebrewItems: [fallbackCask]
+        })}
+      />
+    );
+
+    expect(screen.getByText("Example")).toBeInTheDocument();
+    expect(screen.getByText("example-cask")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Open app" })).toHaveLength(1);
+  });
+
   it("shows settings sections as sidebar tabs without search-filtered badges", () => {
     const installedApp: AppRecord = {
       ...app,

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -693,6 +693,87 @@ describe("update store helpers", () => {
     });
   });
 
+  it("does not create Homebrew fallback updates for Sparkle-origin apps without installed cask ownership", async () => {
+    const sparkleApp = appRecord({
+      bundlePath: "/Applications/Sparkle App.app",
+      displayName: "Sparkle App",
+      bundleIdentifier: "com.example.sparkle-app",
+      sparkleFeedURL: "https://updates.example.com/appcast.xml",
+      sourceHint: "sparkle",
+      localVersion: version("1.0.0")
+    });
+    const homebrewCaskEntry = {
+      token: "sparkle-app",
+      version: version("2.0.0"),
+      homepageURL: "https://formulae.brew.sh/cask/sparkle-app",
+      presentation: "app" as const,
+      bundleIdentifiers: ["com.example.sparkle-app"],
+      appBundleNames: ["sparkle app.app"]
+    };
+    const homebrewIndex = {
+      byToken: { "sparkle-app": homebrewCaskEntry },
+      byBundleIdentifier: { "com.example.sparkle-app": homebrewCaskEntry },
+      byAppBundleName: { "sparkle app.app": [homebrewCaskEntry] }
+    };
+    const lookupUpdate = vi.fn(() => ({
+      remoteVersion: version("2.0.0"),
+      token: "sparkle-app",
+      homepageURL: "https://formulae.brew.sh/cask/sparkle-app"
+    }));
+    const clients = {
+      scanner: { scanApplications: async () => [sparkleApp] },
+      appStore: { lookupOutcome: async () => ({ type: "completed" as const }) },
+      sparkle: { lookupOutcome: async () => ({ type: "completed" as const }) },
+      homebrew: {
+        fetchIndex: async () => homebrewIndex,
+        lookupUpdate,
+        searchCasks: () => []
+      }
+    };
+    const unmanagedStore = await makeStore({ clients });
+
+    await unmanagedStore.refresh(false);
+
+    expect(lookupUpdate).toHaveBeenCalled();
+    expect(unmanagedStore.getSnapshot().updates).toEqual([]);
+
+    const managedStore = await makeStore({
+      clients: {
+        ...clients,
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [
+              homebrewItem({
+                id: "cask:sparkle-app",
+                token: "sparkle-app",
+                name: "Sparkle App",
+                kind: "cask",
+                installedVersion: version("1.0.0"),
+                latestVersion: version("2.0.0"),
+                isOutdated: true
+              })
+            ],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      }
+    });
+
+    await managedStore.refresh(false);
+
+    expect(managedStore.getSnapshot().updates[0]).toMatchObject({
+      source: "homebrew",
+      remoteVersion: version("2.0.0"),
+      homebrewToken: "sparkle-app"
+    });
+    expect(managedStore.getSnapshot().homebrewItems[0]).toMatchObject({
+      id: "cask:sparkle-app",
+      appID: sparkleApp.id,
+      presentation: "app"
+    });
+  });
+
   it("only enables iOS App Store lookup for installed iOS-on-Mac apps", async () => {
     const iOSAppOnMac = appRecord({
       bundlePath: "/Applications/App Store iPad App.app",
@@ -1884,6 +1965,75 @@ describe("update store helpers", () => {
     expect(runBrewCommand).not.toHaveBeenCalled();
     expect(openExternalURL).toHaveBeenCalledWith(fallbackURL);
     expect(openAppBundle).not.toHaveBeenCalled();
+  });
+
+  it("does not route stale token-only Homebrew updates through Homebrew for Sparkle-origin apps", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Sparkle Managed.app",
+      displayName: "Sparkle Managed",
+      bundleIdentifier: "com.example.sparkle-managed",
+      sparkleFeedURL: "https://updates.example.com/appcast.xml",
+      sourceHint: "sparkle",
+      localVersion: version("1.0.0")
+    });
+    const caskItem = homebrewItem({
+      id: "cask:sparkle-managed",
+      token: "sparkle-managed",
+      name: "Sparkle Managed",
+      kind: "cask",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    });
+    const persisted = {
+      ...defaultPersistedSnapshot(),
+      apps: [app],
+      updates: [
+        {
+          id: app.id,
+          appID: app.id,
+          source: "homebrew" as const,
+          supportLevel: "limited" as const,
+          localVersion: version("1.0.0"),
+          remoteVersion: version("2.0.0"),
+          homebrewToken: "sparkle-managed",
+          updateURL: "https://formulae.brew.sh/cask/sparkle-managed",
+          checkedAt: "2026-05-20T12:00:00.000Z"
+        }
+      ],
+      homebrewItems: [caskItem]
+    };
+    const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const openExternalURL = vi.fn(async () => true);
+    const openAppBundle = vi.fn(async () => undefined);
+    const staleFallbackStore = await makeStore({
+      persisted,
+      runBrewCommand,
+      openExternalURL,
+      openAppBundle
+    });
+
+    await staleFallbackStore.performAppUpdate(app.id);
+
+    expect(runBrewCommand).not.toHaveBeenCalled();
+    expect(openExternalURL).not.toHaveBeenCalled();
+    expect(openAppBundle).toHaveBeenCalledWith(app.bundlePath);
+
+    const linkedBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const linkedStore = await makeStore({
+      persisted: {
+        ...persisted,
+        homebrewItems: [{ ...caskItem, appID: app.id }]
+      },
+      runBrewCommand: linkedBrewCommand
+    });
+
+    await linkedStore.performAppUpdate(app.id);
+
+    expect(linkedBrewCommand).toHaveBeenCalledWith(
+      ["upgrade", "--cask", "sparkle-managed"],
+      expect.any(Function)
+    );
   });
 
   it("derives external fallback URLs for persisted Homebrew-backed app updates without URLs", async () => {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -336,6 +336,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         await this.performHomebrewItemUpdate(item);
         return;
       }
+      if (requiresHomebrewOwnershipProof(appRecord)) {
+        await this.routeExternalUpdate(appRecord, { ...update, updateURL: undefined });
+        return;
+      }
       await this.routeExternalUpdate(appRecord, {
         ...update,
         updateURL: update.updateURL ?? homebrewCaskPageURL(update.homebrewToken)
@@ -701,18 +705,22 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           homebrewIndex
         );
         if (homebrewUpdate && isValidHomebrewToken(homebrewUpdate.token)) {
-          updates.push({
-            id: appRecord.id,
-            appID: appRecord.id,
-            source: "homebrew",
-            supportLevel: "limited",
-            localVersion: appRecord.localVersion,
-            remoteVersion: homebrewUpdate.remoteVersion,
-            homebrewToken: homebrewUpdate.token,
-            updateURL: homebrewUpdate.homepageURL,
-            releaseNotesSummary: `Token: ${homebrewUpdate.token}`,
-            checkedAt: now
-          });
+          if (
+            canUseHomebrewAppUpdate(appRecord, homebrewUpdate.token, homebrewItems, homebrewIndex)
+          ) {
+            updates.push({
+              id: appRecord.id,
+              appID: appRecord.id,
+              source: "homebrew",
+              supportLevel: "limited",
+              localVersion: appRecord.localVersion,
+              remoteVersion: homebrewUpdate.remoteVersion,
+              homebrewToken: homebrewUpdate.token,
+              updateURL: homebrewUpdate.homepageURL,
+              releaseNotesSummary: `Token: ${homebrewUpdate.token}`,
+              checkedAt: now
+            });
+          }
         }
       }
 
@@ -933,11 +941,20 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private matchingHomebrewItemForApp(appRecord: AppRecord): HomebrewManagedItem | undefined {
     const update = this.state.updates.find((candidate) => candidate.appID === appRecord.id);
     const token = update?.homebrewToken?.toLowerCase();
-    return token
-      ? this.state.homebrewItems.find(
-          (item) => item.kind === "cask" && item.token.toLowerCase() === token
-        )
-      : undefined;
+    if (!token) {
+      return undefined;
+    }
+    return this.state.homebrewItems.find(
+      (item) =>
+        item.kind === "cask" &&
+        item.token.toLowerCase() === token &&
+        (!requiresHomebrewOwnershipProof(appRecord) ||
+          homebrewCaskItemProvesAppOwnership(
+            item,
+            appRecord,
+            this.latestHomebrewIndex.byToken[token]
+          ))
+    );
   }
 
   private mergeRecentlyUpdated(
@@ -1192,6 +1209,42 @@ export function preservePreviousHomebrewOutdatedState(
       iconDataURL: previous.iconDataURL ?? item.iconDataURL
     };
   });
+}
+
+function canUseHomebrewAppUpdate(
+  appRecord: AppRecord,
+  homebrewToken: string,
+  homebrewItems: HomebrewManagedItem[],
+  caskIndex: HomebrewCaskIndex
+): boolean {
+  if (!requiresHomebrewOwnershipProof(appRecord)) {
+    return true;
+  }
+  const token = homebrewToken.toLowerCase();
+  return homebrewItems.some(
+    (item) =>
+      item.kind === "cask" &&
+      item.token.toLowerCase() === token &&
+      homebrewCaskItemProvesAppOwnership(item, appRecord, caskIndex.byToken[token])
+  );
+}
+
+function requiresHomebrewOwnershipProof(appRecord: AppRecord): boolean {
+  return appRecord.sourceHint === "sparkle";
+}
+
+function homebrewCaskItemProvesAppOwnership(
+  item: HomebrewManagedItem,
+  appRecord: AppRecord,
+  caskEntry: HomebrewCaskEntry | undefined
+): boolean {
+  if (item.appID === appRecord.id) {
+    return true;
+  }
+  if (item.kind !== "cask" || !caskEntry) {
+    return false;
+  }
+  return appMatchesCaskEntry(appRecord, caskEntry);
 }
 
 function reconcileHomebrewInventory(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2926,6 +2926,13 @@ function appSourceLabel(
 ): string | undefined {
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
   if (update) {
+    if (
+      update.source === "homebrew" &&
+      app.sourceHint === "sparkle" &&
+      !uninstallableHomebrewItemForApp(app, snapshot)
+    ) {
+      return sourceDisplayName(app.sourceHint);
+    }
     return sourceLabel(update);
   }
 
@@ -3138,6 +3145,9 @@ function uninstallableHomebrewItemForApp(
   );
   if (matchedByExplicitLink) {
     return matchedByExplicitLink;
+  }
+  if (app.sourceHint === "sparkle") {
+    return undefined;
   }
 
   const update = snapshot.updates.find((candidate) => candidate.appID === app.id);

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3129,6 +3129,9 @@ function matchingAppForHomebrewItem(
   const appFromUpdate = matchingUpdate
     ? snapshot.apps.find((app) => app.id === matchingUpdate.appID)
     : undefined;
+  if (appFromUpdate?.sourceHint === "sparkle") {
+    return undefined;
+  }
   if (appFromUpdate?.iconDataURL) {
     return appFromUpdate;
   }

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -26,6 +26,9 @@ export function homebrewItemHasAppRepresentation(
   const identifiers = homebrewItemIdentifiers(item);
   return apps.some((app) => {
     const update = updatesByAppID.get(app.id);
+    if (app.sourceHint === "sparkle") {
+      return false;
+    }
     if (update?.homebrewToken && identifiers.has(normalizedHomebrewAppName(update.homebrewToken))) {
       return true;
     }


### PR DESCRIPTION
## Summary
- Require installed Homebrew cask ownership evidence before creating Homebrew fallback updates for Sparkle-origin apps.
- Prevent stale token-only Homebrew update records for Sparkle-origin apps from running `brew upgrade` or opening Homebrew cask fallback pages.
- Keep renderer Homebrew linkage heuristics aligned with the store policy and add regression coverage for unmanaged and explicitly linked cask cases.

Fixes #130.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:electron`
- `npm audit --omit=dev --audit-level=high`
