### PR TITLE
Disable mas preference while unavailable

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -2093,6 +2093,46 @@ describe("renderer button parity", () => {
     expect(window.baseline.refresh).not.toHaveBeenCalled();
   });
 
+  it("keeps the mas preference checked but disabled until mas is detected", () => {
+    const { rerender } = render(
+      <SettingsView
+        snapshot={snapshot({
+          isMasInstalled: false,
+          useMasForAppStoreUpdates: true
+        })}
+      />
+    );
+
+    const unavailableMasSwitch = screen.getByRole("switch", {
+      name: "Use mas for App Store updates"
+    });
+    expect(unavailableMasSwitch).toBeChecked();
+    expect(unavailableMasSwitch).toBeDisabled();
+
+    fireEvent.click(unavailableMasSwitch);
+    expect(window.baseline.updatePreferences).not.toHaveBeenCalled();
+
+    rerender(
+      <SettingsView
+        snapshot={snapshot({
+          isMasInstalled: true,
+          useMasForAppStoreUpdates: true
+        })}
+      />
+    );
+
+    const availableMasSwitch = screen.getByRole("switch", {
+      name: "Use mas for App Store updates"
+    });
+    expect(availableMasSwitch).toBeChecked();
+    expect(availableMasSwitch).toBeEnabled();
+
+    fireEvent.click(availableMasSwitch);
+    expect(window.baseline.updatePreferences).toHaveBeenCalledWith({
+      useMasForAppStoreUpdates: false
+    });
+  });
+
   it("edits refresh interval only when auto refresh is enabled", () => {
     const { rerender } = render(
       <SettingsView snapshot={snapshot({ autoRefreshEnabled: false })} />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2534,6 +2534,7 @@ function SettingsPane({
                 description="When enabled, Baseline can install App Store updates directly. When disabled, it opens App Store links instead."
                 value={snapshot.useMasForAppStoreUpdates}
                 patch="useMasForAppStoreUpdates"
+                disabled={!snapshot.isMasInstalled}
               />
             </div>
           </section>
@@ -2762,15 +2763,23 @@ function Toggle({
   label,
   description,
   value,
-  patch
+  patch,
+  disabled = false
 }: {
   label: string;
   description: string;
   value: boolean;
   patch: TogglePatch;
+  disabled?: boolean;
 }) {
   return (
-    <label className="settings-row settings-row-control">
+    <label
+      className={
+        disabled
+          ? "settings-row settings-row-control settings-row-disabled"
+          : "settings-row settings-row-control"
+      }
+    >
       <SettingsRowText label={label} description={description} />
       <input
         aria-label={label}
@@ -2778,9 +2787,13 @@ function Toggle({
         type="checkbox"
         role="switch"
         checked={value}
-        onChange={(event) =>
-          void window.baseline.updatePreferences({ [patch]: event.currentTarget.checked })
-        }
+        disabled={disabled}
+        onChange={(event) => {
+          if (disabled) {
+            return;
+          }
+          void window.baseline.updatePreferences({ [patch]: event.currentTarget.checked });
+        }}
       />
     </label>
   );


### PR DESCRIPTION
## Summary
- Keep the App Store `mas` preference value checked when the helper is unavailable, but render its Settings switch disabled until `mas` is detected.
- Add a reusable disabled state to Settings toggles with a defensive no-op guard for programmatic events.
- Cover the unavailable-to-available transition with a renderer regression test.

Closes #129

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:electron`
