### PR TITLE
Add private local profile stats tab

### DIFF
--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -213,6 +213,36 @@ describe("snapshot persistence", () => {
     });
   });
 
+  it("preserves profile stats reset notice acknowledgement across save and load", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    const persistence = new SnapshotPersistence(userData);
+
+    await persistence.save({
+      ...defaultPersistedSnapshot(),
+      profileStatsResetAcknowledgedID: "tamper:2026-06-05T12:00:00.000Z",
+      profileStats: {
+        ...defaultPersistedSnapshot().profileStats,
+        resetNotice: {
+          id: "tamper:2026-06-05T12:00:00.000Z",
+          occurredAt: "2026-06-05T12:00:00.000Z",
+          reason: "tamper"
+        }
+      }
+    });
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      profileStatsResetAcknowledgedID: "tamper:2026-06-05T12:00:00.000Z",
+      profileStats: {
+        resetNotice: {
+          id: "tamper:2026-06-05T12:00:00.000Z",
+          occurredAt: "2026-06-05T12:00:00.000Z",
+          reason: "tamper"
+        }
+      }
+    });
+  });
+
   it("drops malformed profile stats events without resetting the snapshot", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);

--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -135,6 +135,38 @@ describe("snapshot persistence", () => {
     expect(loaded.profileStats.integrityStatus).toBe("pending");
   });
 
+  it("defaults the started using date on older snapshots", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    await mkdir(userData, { recursive: true });
+    await writeFile(path.join(userData, "baseline-snapshot.json"), "{}\n", "utf8");
+
+    const persistence = new SnapshotPersistence(userData);
+
+    const loaded = await persistence.load();
+    expect(Number.isFinite(new Date(loaded.profileStats.startedUsingAt).getTime())).toBe(true);
+  });
+
+  it("preserves the started using date across save and load", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    const persistence = new SnapshotPersistence(userData);
+
+    await persistence.save({
+      ...defaultPersistedSnapshot(),
+      profileStats: {
+        ...defaultPersistedSnapshot().profileStats,
+        startedUsingAt: "2026-06-01T12:00:00.000Z"
+      }
+    });
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      profileStats: {
+        startedUsingAt: "2026-06-01T12:00:00.000Z"
+      }
+    });
+  });
+
   it("preserves profile stats events across save and load", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);
@@ -144,6 +176,7 @@ describe("snapshot persistence", () => {
       ...defaultPersistedSnapshot(),
       profileStats: {
         createdAt: "2026-06-01T12:00:00.000Z",
+        startedUsingAt: "2026-05-15T12:00:00.000Z",
         signature: "signed",
         integrityStatus: "verified",
         events: [
@@ -162,6 +195,7 @@ describe("snapshot persistence", () => {
     await expect(persistence.load()).resolves.toMatchObject({
       profileStats: {
         createdAt: "2026-06-01T12:00:00.000Z",
+        startedUsingAt: "2026-05-15T12:00:00.000Z",
         signature: "signed",
         integrityStatus: "pending",
         events: [

--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -122,6 +122,62 @@ describe("snapshot persistence", () => {
     });
   });
 
+  it("defaults profile stats on older snapshots", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    await mkdir(userData, { recursive: true });
+    await writeFile(path.join(userData, "baseline-snapshot.json"), "{}\n", "utf8");
+
+    const persistence = new SnapshotPersistence(userData);
+
+    const loaded = await persistence.load();
+    expect(loaded.profileStats.events).toEqual([]);
+    expect(loaded.profileStats.integrityStatus).toBe("pending");
+  });
+
+  it("preserves profile stats events across save and load", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    const persistence = new SnapshotPersistence(userData);
+
+    await persistence.save({
+      ...defaultPersistedSnapshot(),
+      profileStats: {
+        createdAt: "2026-06-01T12:00:00.000Z",
+        signature: "signed",
+        integrityStatus: "verified",
+        events: [
+          {
+            id: "appUpdate:app:example:1:2::",
+            type: "appUpdate",
+            targetID: "app:example",
+            displayName: "Example",
+            channel: "sparkle",
+            occurredAt: "2026-06-02T12:00:00.000Z"
+          }
+        ]
+      }
+    });
+
+    await expect(persistence.load()).resolves.toMatchObject({
+      profileStats: {
+        createdAt: "2026-06-01T12:00:00.000Z",
+        signature: "signed",
+        integrityStatus: "pending",
+        events: [
+          {
+            id: "appUpdate:app:example:1:2::",
+            type: "appUpdate",
+            targetID: "app:example",
+            displayName: "Example",
+            channel: "sparkle",
+            occurredAt: "2026-06-02T12:00:00.000Z"
+          }
+        ]
+      }
+    });
+  });
+
   it("preserves recently updated and ignored state across save and load", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);

--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { SnapshotPersistence } from "../src/main/persistence";
-import { defaultPersistedSnapshot } from "../src/shared/domain";
+import { defaultPersistedSnapshot, profileStatsSignatureVersion } from "../src/shared/domain";
 import { version } from "../src/shared/version";
 
 let tempDirs: string[] = [];
@@ -177,6 +177,7 @@ describe("snapshot persistence", () => {
       profileStats: {
         createdAt: "2026-06-01T12:00:00.000Z",
         startedUsingAt: "2026-05-15T12:00:00.000Z",
+        signatureVersion: profileStatsSignatureVersion,
         signature: "signed",
         integrityStatus: "verified",
         events: [

--- a/ElectronTests/persistence.test.ts
+++ b/ElectronTests/persistence.test.ts
@@ -213,6 +213,48 @@ describe("snapshot persistence", () => {
     });
   });
 
+  it("drops malformed profile stats events without resetting the snapshot", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
+    tempDirs.push(userData);
+    await mkdir(userData, { recursive: true });
+    await writeFile(
+      path.join(userData, "baseline-snapshot.json"),
+      `${JSON.stringify({
+        ...defaultPersistedSnapshot(),
+        showMenuBarIcon: false,
+        profileStats: {
+          ...defaultPersistedSnapshot().profileStats,
+          events: [
+            null,
+            {
+              id: "appUpdate:app:example:1:2::",
+              type: "appUpdate",
+              targetID: "app:example",
+              displayName: "Example",
+              channel: "sparkle",
+              occurredAt: "2026-06-02T12:00:00.000Z"
+            }
+          ]
+        }
+      })}\n`,
+      "utf8"
+    );
+
+    const loaded = await new SnapshotPersistence(userData).load();
+
+    expect(loaded.showMenuBarIcon).toBe(false);
+    expect(loaded.profileStats.events).toEqual([
+      {
+        id: "appUpdate:app:example:1:2::",
+        type: "appUpdate",
+        targetID: "app:example",
+        displayName: "Example",
+        channel: "sparkle",
+        occurredAt: "2026-06-02T12:00:00.000Z"
+      }
+    ]);
+  });
+
   it("preserves recently updated and ignored state across save and load", async () => {
     const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-persistence-"));
     tempDirs.push(userData);

--- a/ElectronTests/profileStatsIntegrity.test.ts
+++ b/ElectronTests/profileStatsIntegrity.test.ts
@@ -46,6 +46,29 @@ describe("profile stats integrity", () => {
     expect(verified.integrityStatus).toBe("verified");
     expect(tampered.integrityStatus).toBe("resetAfterTamper");
     expect(tampered.events).toEqual([]);
+    expect(tampered.resetNotice).toMatchObject({
+      reason: "tamper"
+    });
+  });
+
+  it("keeps a signed reset notice visible after relaunch verification", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+    const sealed = await integrity.seal({
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      integrityStatus: "verified"
+    });
+    const tampered = await integrity.verifyOrInitialize({
+      ...sealed,
+      startedUsingAt: "2020-01-01T12:00:00.000Z"
+    });
+
+    const reverified = await integrity.verifyOrInitialize({
+      ...tampered,
+      integrityStatus: "pending"
+    });
+
+    expect(reverified.integrityStatus).toBe("resetAfterTamper");
+    expect(reverified.resetNotice).toEqual(tampered.resetNotice);
   });
 
   it("migrates valid unversioned seals to the current signature version", async () => {

--- a/ElectronTests/profileStatsIntegrity.test.ts
+++ b/ElectronTests/profileStatsIntegrity.test.ts
@@ -132,7 +132,7 @@ describe("profile stats integrity", () => {
     expect(migrated.signature).not.toBe(legacySignature);
   });
 
-  it("does not bless populated unsigned stats history", async () => {
+  it("resets populated unsigned stats history", async () => {
     const integrity = new KeychainProfileStatsIntegrity();
 
     const verified = await integrity.verifyOrInitialize({
@@ -149,8 +149,12 @@ describe("profile stats integrity", () => {
       ]
     });
 
-    expect(verified.integrityStatus).toBe("unavailable");
-    expect(verified.signature).toBeUndefined();
+    expect(verified.integrityStatus).toBe("resetAfterTamper");
+    expect(verified.events).toEqual([]);
+    expect(verified.resetNotice).toMatchObject({
+      reason: "tamper"
+    });
+    expect(verified.signature).toBeDefined();
   });
 
   it("preserves the existing signature when sealing is unavailable", async () => {

--- a/ElectronTests/profileStatsIntegrity.test.ts
+++ b/ElectronTests/profileStatsIntegrity.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { KeychainProfileStatsIntegrity } from "../src/main/profileStatsIntegrity";
+import { defaultProfileStats } from "../src/shared/domain";
+import { runCommand } from "../src/main/commandRunner";
+
+vi.mock("../src/main/commandRunner", () => ({
+  runCommand: vi.fn()
+}));
+
+const runCommandMock = vi.mocked(runCommand);
+
+beforeEach(() => {
+  runCommandMock.mockReset();
+  runCommandMock.mockResolvedValue({
+    success: true,
+    status: 0,
+    output: "profile-stats-secret\n",
+    stdout: "profile-stats-secret\n",
+    stderr: ""
+  });
+});
+
+describe("profile stats integrity", () => {
+  it("detects local edits to the started using date", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+    const sealed = await integrity.seal({
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      integrityStatus: "verified"
+    });
+
+    const verified = await integrity.verifyOrInitialize(sealed);
+    const tampered = await integrity.verifyOrInitialize({
+      ...sealed,
+      startedUsingAt: "2020-01-01T12:00:00.000Z"
+    });
+
+    expect(verified.integrityStatus).toBe("verified");
+    expect(tampered.integrityStatus).toBe("resetAfterTamper");
+    expect(tampered.events).toEqual([]);
+  });
+});

--- a/ElectronTests/profileStatsIntegrity.test.ts
+++ b/ElectronTests/profileStatsIntegrity.test.ts
@@ -187,6 +187,63 @@ describe("profile stats integrity", () => {
 
     expect(unavailable.integrityStatus).toBe("unavailable");
     expect(unavailable.signature).toBe(signed.signature);
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+    expect(runCommandMock.mock.calls[1]?.[1][0]).toBe("find-generic-password");
+  });
+
+  it("creates a Keychain secret only when the item is missing", async () => {
+    runCommandMock
+      .mockResolvedValueOnce({
+        success: false,
+        status: 44,
+        output:
+          "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.\n",
+        stdout: "",
+        stderr:
+          "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.\n"
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 0,
+        output: "",
+        stdout: "",
+        stderr: ""
+      });
+
+    const integrity = new KeychainProfileStatsIntegrity();
+    const sealed = await integrity.seal({
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      integrityStatus: "verified"
+    });
+
+    expect(sealed.integrityStatus).toBe("verified");
+    expect(sealed.signature).toBeDefined();
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+    expect(runCommandMock.mock.calls[1]?.[1]).toContain("add-generic-password");
+    expect(runCommandMock.mock.calls[1]?.[1]).not.toContain("-U");
+  });
+
+  it("does not replace the Keychain secret when reading it is denied", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+    const signed = await integrity.seal({
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      integrityStatus: "verified"
+    });
+    runCommandMock.mockClear();
+    runCommandMock.mockResolvedValue({
+      success: false,
+      status: 51,
+      output: "security: SecKeychainSearchCopyNext: User interaction is not allowed.\n",
+      stdout: "",
+      stderr: "security: SecKeychainSearchCopyNext: User interaction is not allowed.\n"
+    });
+
+    const verified = await integrity.verifyOrInitialize(signed);
+
+    expect(verified.integrityStatus).toBe("unavailable");
+    expect(verified.signature).toBe(signed.signature);
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock.mock.calls[0]?.[1][0]).toBe("find-generic-password");
   });
 });
 

--- a/ElectronTests/profileStatsIntegrity.test.ts
+++ b/ElectronTests/profileStatsIntegrity.test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { createHmac } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { KeychainProfileStatsIntegrity } from "../src/main/profileStatsIntegrity";
-import { defaultProfileStats } from "../src/shared/domain";
+import { defaultProfileStats, type ProfileStats } from "../src/shared/domain";
 import { runCommand } from "../src/main/commandRunner";
 
 vi.mock("../src/main/commandRunner", () => ({
@@ -41,4 +42,53 @@ describe("profile stats integrity", () => {
     expect(tampered.integrityStatus).toBe("resetAfterTamper");
     expect(tampered.events).toEqual([]);
   });
+
+  it("migrates valid legacy seals without trusting the unsigned started using date", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+    const legacyStats: ProfileStats = {
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      startedUsingAt: "2020-01-01T12:00:00.000Z",
+      integrityStatus: "pending",
+      events: [
+        {
+          id: "appUpdate:example",
+          type: "appUpdate",
+          targetID: "app:example",
+          displayName: "Example",
+          channel: "appStore",
+          occurredAt: "2026-06-02T12:00:00.000Z"
+        }
+      ]
+    };
+    const legacySignature = legacySignatureFor(legacyStats, "profile-stats-secret");
+
+    const migrated = await integrity.verifyOrInitialize({
+      ...legacyStats,
+      signature: legacySignature
+    });
+
+    expect(migrated.integrityStatus).toBe("verified");
+    expect(migrated.events).toEqual(legacyStats.events);
+    expect(migrated.startedUsingAt).toBe("2026-06-01T12:00:00.000Z");
+    expect(migrated.signature).toBeDefined();
+    expect(migrated.signature).not.toBe(legacySignature);
+  });
 });
+
+function legacySignatureFor(stats: ProfileStats, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(
+      JSON.stringify({
+        createdAt: stats.createdAt,
+        events: stats.events.map((event) => ({
+          id: event.id,
+          type: event.type,
+          targetID: event.targetID,
+          displayName: event.displayName,
+          channel: event.channel,
+          occurredAt: event.occurredAt
+        }))
+      })
+    )
+    .digest("base64url");
+}

--- a/ElectronTests/profileStatsIntegrity.test.ts
+++ b/ElectronTests/profileStatsIntegrity.test.ts
@@ -4,7 +4,11 @@
 import { createHmac } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { KeychainProfileStatsIntegrity } from "../src/main/profileStatsIntegrity";
-import { defaultProfileStats, type ProfileStats } from "../src/shared/domain";
+import {
+  defaultProfileStats,
+  profileStatsSignatureVersion,
+  type ProfileStats
+} from "../src/shared/domain";
 import { runCommand } from "../src/main/commandRunner";
 
 vi.mock("../src/main/commandRunner", () => ({
@@ -38,9 +42,39 @@ describe("profile stats integrity", () => {
       startedUsingAt: "2020-01-01T12:00:00.000Z"
     });
 
+    expect(sealed.signatureVersion).toBe(profileStatsSignatureVersion);
     expect(verified.integrityStatus).toBe("verified");
     expect(tampered.integrityStatus).toBe("resetAfterTamper");
     expect(tampered.events).toEqual([]);
+  });
+
+  it("migrates valid unversioned seals to the current signature version", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+    const unversionedStats = {
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      events: [
+        {
+          id: "appUpdate:example",
+          type: "appUpdate" as const,
+          targetID: "app:example",
+          displayName: "Example",
+          channel: "appStore" as const,
+          occurredAt: "2026-06-02T12:00:00.000Z"
+        }
+      ]
+    };
+    const unversionedSignature = unversionedSignatureFor(unversionedStats, "profile-stats-secret");
+
+    const migrated = await integrity.verifyOrInitialize({
+      ...unversionedStats,
+      signature: unversionedSignature
+    });
+
+    expect(migrated.integrityStatus).toBe("verified");
+    expect(migrated.events).toEqual(unversionedStats.events);
+    expect(migrated.signatureVersion).toBe(profileStatsSignatureVersion);
+    expect(migrated.signature).toBeDefined();
+    expect(migrated.signature).not.toBe(unversionedSignature);
   });
 
   it("migrates valid legacy seals without trusting the unsigned started using date", async () => {
@@ -70,10 +104,83 @@ describe("profile stats integrity", () => {
     expect(migrated.integrityStatus).toBe("verified");
     expect(migrated.events).toEqual(legacyStats.events);
     expect(migrated.startedUsingAt).toBe("2026-06-01T12:00:00.000Z");
+    expect(migrated.signatureVersion).toBe(profileStatsSignatureVersion);
     expect(migrated.signature).toBeDefined();
     expect(migrated.signature).not.toBe(legacySignature);
   });
+
+  it("does not bless populated unsigned stats history", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+
+    const verified = await integrity.verifyOrInitialize({
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      events: [
+        {
+          id: "appUpdate:unsigned",
+          type: "appUpdate",
+          targetID: "app:unsigned",
+          displayName: "Unsigned",
+          channel: "appStore",
+          occurredAt: "2026-06-02T12:00:00.000Z"
+        }
+      ]
+    });
+
+    expect(verified.integrityStatus).toBe("unavailable");
+    expect(verified.signature).toBeUndefined();
+  });
+
+  it("preserves the existing signature when sealing is unavailable", async () => {
+    const integrity = new KeychainProfileStatsIntegrity();
+    const signed = await integrity.seal({
+      ...defaultProfileStats("2026-06-01T12:00:00.000Z"),
+      integrityStatus: "verified"
+    });
+    runCommandMock.mockResolvedValue({
+      success: false,
+      status: 1,
+      output: "",
+      stdout: "",
+      stderr: "Keychain unavailable"
+    });
+
+    const unavailable = await integrity.seal({
+      ...signed,
+      events: [
+        {
+          id: "appUpdate:later",
+          type: "appUpdate",
+          targetID: "app:later",
+          displayName: "Later",
+          channel: "appStore",
+          occurredAt: "2026-06-02T12:00:00.000Z"
+        }
+      ]
+    });
+
+    expect(unavailable.integrityStatus).toBe("unavailable");
+    expect(unavailable.signature).toBe(signed.signature);
+  });
 });
+
+function unversionedSignatureFor(stats: ProfileStats, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(
+      JSON.stringify({
+        createdAt: stats.createdAt,
+        startedUsingAt: stats.startedUsingAt,
+        events: stats.events.map((event) => ({
+          id: event.id,
+          type: event.type,
+          targetID: event.targetID,
+          displayName: event.displayName,
+          channel: event.channel,
+          occurredAt: event.occurredAt
+        }))
+      })
+    )
+    .digest("base64url");
+}
 
 function legacySignatureFor(stats: ProfileStats, secret: string): string {
   return createHmac("sha256", secret)

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -760,6 +760,14 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Started using Baseline")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
     expect(screen.getByText("Current apps up to date")).toBeInTheDocument();
+    expect(
+      [...document.querySelectorAll(".profile-metric span")].map((metric) => metric.textContent)
+    ).toEqual([
+      "Apps updated",
+      "Total updates",
+      "Current apps up to date",
+      "Started using Baseline"
+    ]);
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Most updated apps" })).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -686,7 +686,8 @@ describe("renderer button parity", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Profile" }));
 
-    expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(2);
+    expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(1);
+    expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
     expect(screen.getByText("Apps updated")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -759,20 +759,21 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Total updates")).toBeInTheDocument();
     expect(screen.getByText("Started using Baseline")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
-    expect(screen.getByText("Current apps up to date")).toBeInTheDocument();
+    expect(screen.getByText("Apps up to date")).toBeInTheDocument();
     expect(
       [...document.querySelectorAll(".profile-metric span")].map((metric) => metric.textContent)
-    ).toEqual([
-      "Apps updated",
-      "Total updates",
-      "Current apps up to date",
-      "Started using Baseline"
-    ]);
-    expect(screen.getByText("Favorite channel")).toBeInTheDocument();
+    ).toEqual(["Apps updated", "Total updates", "Apps up to date", "Started using Baseline"]);
+    expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
+    expect(screen.getByText("Favorite source")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Most updated apps" })).toBeInTheDocument();
-    expect(screen.queryByText("No update source history yet.")).not.toBeInTheDocument();
-    expect(screen.queryByText("No updated apps yet.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Update or install something with Baseline to build a source history.")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Apps you update with Baseline will appear here.")
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("Sparkle 63%")).toHaveLength(1);
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();
@@ -791,7 +792,7 @@ describe("renderer button parity", () => {
     ]);
     expect(screen.getByText("Stable App")).toBeInTheDocument();
     expect(screen.getByText("Third App")).toBeInTheDocument();
-    expect(screen.queryByText("Fourth App")).not.toBeInTheDocument();
+    expect([...topAppTiles].some((tile) => tile.textContent?.includes("Fourth App"))).toBe(false);
     expect(screen.getByText("Stats are private and stored only on this Mac.")).toBeInTheDocument();
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();
     expect(screen.queryByText("Verified")).not.toBeInTheDocument();
@@ -816,8 +817,10 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Profile" }));
 
     expect(screen.getByText("No history yet")).toBeInTheDocument();
-    expect(screen.getByText("No update source history yet.")).toBeInTheDocument();
-    expect(screen.getByText("No updated apps yet.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Update or install something with Baseline to build a source history.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Apps you update with Baseline will appear here.")).toBeInTheDocument();
     expect(document.querySelectorAll(".profile-source-chip")).toHaveLength(0);
     expect(document.querySelectorAll(".profile-top-app-list li")).toHaveLength(0);
   });

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -796,7 +796,8 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Profile" }));
 
     expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(1);
-    expect(screen.getByRole("heading", { name: "Time with Baseline" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Time with Baseline" })).not.toBeInTheDocument();
+    expect(screen.getByText("with Baseline")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -688,12 +688,38 @@ describe("renderer button parity", () => {
 
     expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(1);
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Apps updated")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
     expect(screen.getByText("Most updated apps")).toBeInTheDocument();
     expect(screen.getByText("Sparkle")).toBeInTheDocument();
-    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText("Stats are private and stored only on this Mac.")).toBeInTheDocument();
+    expect(screen.queryByText("Private stats")).not.toBeInTheDocument();
+    expect(screen.queryByText("Verified")).not.toBeInTheDocument();
+    expect(screen.queryByText("Stats were reset")).not.toBeInTheDocument();
+  });
+
+  it("shows a profile stats warning only when local history was reset after tampering", () => {
+    render(
+      <SettingsView
+        snapshot={snapshot({
+          profileStats: {
+            ...snapshot().profileStats,
+            integrityStatus: "resetAfterTamper"
+          }
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Profile" }));
+
+    expect(screen.getByText("Stats were reset")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Baseline could not verify the local stats history, so it started a fresh one on this Mac."
+      )
+    ).toBeInTheDocument();
   });
 
   it("returns from settings through the main window bridge", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -629,12 +629,28 @@ describe("renderer button parity", () => {
       <SettingsView
         snapshot={snapshot({
           apps: [
-            app,
+            {
+              ...app,
+              iconDataURL: "data:image/png;base64,example-icon"
+            },
             {
               ...app,
               id: "app:stable",
               displayName: "Stable App",
-              bundleIdentifier: "com.example.stable"
+              bundleIdentifier: "com.example.stable",
+              iconDataURL: "data:image/png;base64,stable-icon"
+            },
+            {
+              ...app,
+              id: "app:third",
+              displayName: "Third App",
+              bundleIdentifier: "com.example.third"
+            },
+            {
+              ...app,
+              id: "app:fourth",
+              displayName: "Fourth App",
+              bundleIdentifier: "com.example.fourth"
             }
           ],
           updates: [],
@@ -660,6 +676,54 @@ describe("renderer button parity", () => {
                 displayName: "Example",
                 channel: "sparkle",
                 occurredAt: "2026-06-02T12:00:00.000Z"
+              },
+              {
+                id: "appUpdate:example:2:3::",
+                type: "appUpdate",
+                targetID: app.id,
+                displayName: "Example",
+                channel: "sparkle",
+                occurredAt: "2026-06-03T12:00:00.000Z"
+              },
+              {
+                id: "appUpdate:stable:1:2::",
+                type: "appUpdate",
+                targetID: "app:stable",
+                displayName: "Stable App",
+                channel: "appStore",
+                occurredAt: "2026-06-04T12:00:00.000Z"
+              },
+              {
+                id: "appUpdate:stable:2:3::",
+                type: "appUpdate",
+                targetID: "app:stable",
+                displayName: "Stable App",
+                channel: "appStore",
+                occurredAt: "2026-06-05T12:00:00.000Z"
+              },
+              {
+                id: "appUpdate:third:1:2::",
+                type: "appUpdate",
+                targetID: "app:third",
+                displayName: "Third App",
+                channel: "sparkle",
+                occurredAt: "2026-06-06T12:00:00.000Z"
+              },
+              {
+                id: "appUpdate:third:2:3::",
+                type: "appUpdate",
+                targetID: "app:third",
+                displayName: "Third App",
+                channel: "sparkle",
+                occurredAt: "2026-06-06T13:00:00.000Z"
+              },
+              {
+                id: "appUpdate:fourth:1:2::",
+                type: "appUpdate",
+                targetID: "app:fourth",
+                displayName: "Fourth App",
+                channel: "sparkle",
+                occurredAt: "2026-06-07T12:00:00.000Z"
               },
               {
                 id: "homebrewUpdate:formula:ripgrep:1:2",
@@ -693,7 +757,18 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Total updates")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
     expect(screen.getByText("Most updated apps")).toBeInTheDocument();
-    expect(screen.getByText("Sparkle")).toBeInTheDocument();
+    expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
+    const topAppRow = screen.getByText("Example").closest("li");
+    expect(topAppRow).not.toBeNull();
+    expect(topAppRow?.querySelector(".profile-top-app-icon img")).toHaveAttribute(
+      "src",
+      "data:image/png;base64,example-icon"
+    );
+    const topAppTiles = document.querySelectorAll(".profile-top-app-list li");
+    expect(topAppTiles).toHaveLength(3);
+    expect(screen.getByText("Stable App")).toBeInTheDocument();
+    expect(screen.getByText("Third App")).toBeInTheDocument();
+    expect(screen.queryByText("Fourth App")).not.toBeInTheDocument();
     expect(screen.getByText("Stats are private and stored only on this Mac.")).toBeInTheDocument();
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();
     expect(screen.queryByText("Verified")).not.toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -102,6 +102,7 @@ function installBaselineMock() {
     setSearchText: vi.fn(),
     setSelectedTab: vi.fn(),
     updatePreferences: vi.fn(),
+    acknowledgeProfileStatsReset: vi.fn(),
     toggleIgnoredApp: vi.fn(),
     toggleIgnoredHomebrew: vi.fn(),
     performAppUpdate: vi.fn(),
@@ -895,11 +896,17 @@ describe("renderer button parity", () => {
   });
 
   it("shows a profile stats warning only when local history was reset after tampering", () => {
+    const resetNotice = {
+      id: "tamper:2026-06-05T12:00:00.000Z",
+      occurredAt: "2026-06-05T12:00:00.000Z",
+      reason: "tamper" as const
+    };
     render(
       <SettingsView
         snapshot={snapshot({
           profileStats: {
             ...snapshot().profileStats,
+            resetNotice,
             integrityStatus: "resetAfterTamper"
           }
         })}
@@ -914,6 +921,33 @@ describe("renderer button parity", () => {
         "Baseline could not verify the local stats history, so it started a fresh one on this Mac."
       )
     ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss stats reset warning" }));
+    expect(window.baseline.acknowledgeProfileStatsReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the profile stats reset warning after acknowledgement", () => {
+    const resetNotice = {
+      id: "tamper:2026-06-05T12:00:00.000Z",
+      occurredAt: "2026-06-05T12:00:00.000Z",
+      reason: "tamper" as const
+    };
+    render(
+      <SettingsView
+        snapshot={snapshot({
+          profileStatsResetAcknowledgedID: resetNotice.id,
+          profileStats: {
+            ...snapshot().profileStats,
+            resetNotice,
+            integrityStatus: "resetAfterTamper"
+          }
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Profile" }));
+
+    expect(screen.queryByText("Stats were reset")).not.toBeInTheDocument();
   });
 
   it("returns from settings through the main window bridge", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -755,7 +755,7 @@ describe("renderer button parity", () => {
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Apps updated")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
-    expect(screen.getByText("Tracked for")).toBeInTheDocument();
+    expect(screen.getByText("Using Baseline since")).toBeInTheDocument();
     expect(screen.getByText("Up to date")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -755,8 +755,11 @@ describe("renderer button parity", () => {
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Apps updated")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
+    expect(screen.getByText("Tracked for")).toBeInTheDocument();
+    expect(screen.getByText("Up to date")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
-    expect(screen.getByText("Most updated apps")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Most updated apps" })).toBeInTheDocument();
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -734,6 +734,14 @@ describe("renderer button parity", () => {
                 displayName: "ripgrep",
                 channel: "homebrew",
                 occurredAt: "2026-06-03T12:00:00.000Z"
+              },
+              {
+                id: "homebrewInstall:cask:orion:1.0:2026-06-08T12:00:00.000Z",
+                type: "homebrewInstall",
+                targetID: "cask:orion",
+                displayName: "Orion",
+                channel: "homebrew",
+                occurredAt: "2026-06-08T12:00:00.000Z"
               }
             ]
           }
@@ -756,13 +764,16 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("heading", { name: "Time with Baseline" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
-    expect(screen.getByText("Different apps")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
+    expect(screen.getByText("Different apps")).toBeInTheDocument();
+    expect(screen.getByText("Installs")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
-    expect(screen.getByText("Apps up to date")).toBeInTheDocument();
     expect(
       [...document.querySelectorAll(".profile-metric > span")].map((metric) => metric.textContent)
-    ).toEqual(["Different apps", "Total updates", "Apps up to date", "Favorite source"]);
+    ).toEqual(["Total updates", "Different apps", "Installs", "Favorite source"]);
+    expect(
+      [...document.querySelectorAll(".profile-metric strong")].map((metric) => metric.textContent)
+    ).toEqual(["8", "4", "1", "Sparkle"]);
     expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
     expect(screen.getByText("Favorite source")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
@@ -773,7 +784,7 @@ describe("renderer button parity", () => {
     expect(
       screen.queryByText("Apps you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
-    expect(screen.getAllByText("Sparkle 63%")).toHaveLength(1);
+    expect(screen.getAllByText("Sparkle 56%")).toHaveLength(1);
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();
@@ -795,7 +806,7 @@ describe("renderer button parity", () => {
     expect([...topAppTiles].some((tile) => tile.textContent?.includes("Fourth App"))).toBe(false);
     expect(
       screen.getByText(
-        "Stats only count apps updated with Baseline. They are private and stored only on this Mac."
+        "Stats only count updates and installs completed with Baseline. They are private and stored only on this Mac."
       )
     ).toBeInTheDocument();
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -831,7 +831,7 @@ describe("renderer button parity", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Profile" }));
 
-    expect(screen.getByText("No history yet")).toBeInTheDocument();
+    expect(screen.getByText("No history")).toBeInTheDocument();
     expect(
       screen.getByText("Update or install something with Baseline to build a source history.")
     ).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -793,7 +793,11 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Stable App")).toBeInTheDocument();
     expect(screen.getByText("Third App")).toBeInTheDocument();
     expect([...topAppTiles].some((tile) => tile.textContent?.includes("Fourth App"))).toBe(false);
-    expect(screen.getByText("Stats are private and stored only on this Mac.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Stats only count apps updated with Baseline. They are private and stored only on this Mac."
+      )
+    ).toBeInTheDocument();
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();
     expect(screen.queryByText("Verified")).not.toBeInTheDocument();
     expect(screen.queryByText("Stats were reset")).not.toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -599,7 +599,7 @@ describe("renderer button parity", () => {
     );
 
     expect(within(container).getByRole("button", { name: "Back to app" })).toBeInTheDocument();
-    for (const label of ["General", "Appearance", "Diagnostics"]) {
+    for (const label of ["General", "Profile", "Appearance", "Diagnostics"]) {
       expect(within(container).getByRole("button", { name: label })).toBeInTheDocument();
     }
     const settingsNav = container.querySelector(".source-list");
@@ -622,6 +622,77 @@ describe("renderer button parity", () => {
     expect(screen.queryByRole("button", { name: "All" })).not.toBeInTheDocument();
     expect(screen.queryByText("Stable App")).not.toBeInTheDocument();
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+  });
+
+  it("shows local profile stats in a settings tab below general", () => {
+    render(
+      <SettingsView
+        snapshot={snapshot({
+          apps: [
+            app,
+            {
+              ...app,
+              id: "app:stable",
+              displayName: "Stable App",
+              bundleIdentifier: "com.example.stable"
+            }
+          ],
+          updates: [],
+          homebrewItems: [
+            {
+              id: "formula:ripgrep",
+              token: "ripgrep",
+              name: "ripgrep",
+              kind: "formula",
+              installedVersion: version("1.0.0"),
+              isOutdated: false
+            }
+          ],
+          profileStats: {
+            createdAt: "2026-06-01T12:00:00.000Z",
+            integrityStatus: "verified",
+            signature: "signed",
+            events: [
+              {
+                id: "appUpdate:example:1:2::",
+                type: "appUpdate",
+                targetID: app.id,
+                displayName: "Example",
+                channel: "sparkle",
+                occurredAt: "2026-06-02T12:00:00.000Z"
+              },
+              {
+                id: "homebrewUpdate:formula:ripgrep:1:2",
+                type: "homebrewUpdate",
+                targetID: "formula:ripgrep",
+                displayName: "ripgrep",
+                channel: "homebrew",
+                occurredAt: "2026-06-03T12:00:00.000Z"
+              }
+            ]
+          }
+        })}
+      />
+    );
+
+    const sourceNav = document.querySelector(".source-list");
+    expect(sourceNav).not.toBeNull();
+    const buttons = within(sourceNav as HTMLElement).getAllByRole("button");
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "General",
+      "Profile",
+      "Appearance"
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Profile" }));
+
+    expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(2);
+    expect(screen.getByText("Apps updated")).toBeInTheDocument();
+    expect(screen.getByText("Total updates")).toBeInTheDocument();
+    expect(screen.getByText("Favorite channel")).toBeInTheDocument();
+    expect(screen.getByText("Most updated apps")).toBeInTheDocument();
+    expect(screen.getByText("Sparkle")).toBeInTheDocument();
+    expect(screen.getByText("Verified")).toBeInTheDocument();
   });
 
   it("returns from settings through the main window bridge", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -782,6 +782,13 @@ describe("renderer button parity", () => {
     );
     const topAppTiles = document.querySelectorAll(".profile-top-app-list li");
     expect(topAppTiles).toHaveLength(3);
+    expect(
+      [...document.querySelectorAll(".profile-top-app-rank")].map((rank) => rank.className)
+    ).toEqual([
+      "profile-top-app-rank profile-top-app-rank-1",
+      "profile-top-app-rank profile-top-app-rank-2",
+      "profile-top-app-rank profile-top-app-rank-3"
+    ]);
     expect(screen.getByText("Stable App")).toBeInTheDocument();
     expect(screen.getByText("Third App")).toBeInTheDocument();
     expect(screen.queryByText("Fourth App")).not.toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -887,7 +887,9 @@ describe("renderer button parity", () => {
       screen.getByText("Update or install something with Baseline to build a source history.")
     ).toBeInTheDocument();
     expect(screen.getByText("Apps you update with Baseline will appear here.")).toBeInTheDocument();
-    expect(screen.getByText("Tools you update with Baseline will appear here.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Tools you update with Baseline will appear here.")
+    ).toBeInTheDocument();
     expect(document.querySelectorAll(".profile-source-chip")).toHaveLength(0);
     expect(document.querySelectorAll(".profile-top-app-list li")).toHaveLength(0);
   });

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -666,6 +666,7 @@ describe("renderer button parity", () => {
           ],
           profileStats: {
             createdAt: "2026-06-01T12:00:00.000Z",
+            startedUsingAt: "2026-05-15T12:00:00.000Z",
             integrityStatus: "verified",
             signature: "signed",
             events: [
@@ -755,7 +756,8 @@ describe("renderer button parity", () => {
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Apps updated")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
-    expect(screen.getByText("Using Baseline since")).toBeInTheDocument();
+    expect(screen.getByText("Started using Baseline")).toBeInTheDocument();
+    expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
     expect(screen.getByText("Up to date")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -753,16 +753,16 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Profile" }));
 
     expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(1);
+    expect(screen.getByRole("heading", { name: "Time with Baseline" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Apps updated")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
-    expect(screen.getByText("Started using Baseline")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
     expect(screen.getByText("Apps up to date")).toBeInTheDocument();
     expect(
-      [...document.querySelectorAll(".profile-metric span")].map((metric) => metric.textContent)
-    ).toEqual(["Apps updated", "Total updates", "Apps up to date", "Started using Baseline"]);
+      [...document.querySelectorAll(".profile-metric > span")].map((metric) => metric.textContent)
+    ).toEqual(["Apps updated", "Total updates", "Apps up to date", "Favorite source"]);
     expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
     expect(screen.getByText("Favorite source")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -758,10 +758,12 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Total updates")).toBeInTheDocument();
     expect(screen.getByText("Started using Baseline")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
-    expect(screen.getByText("Up to date")).toBeInTheDocument();
+    expect(screen.getByText("Current apps up to date")).toBeInTheDocument();
     expect(screen.getByText("Favorite channel")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Most updated apps" })).toBeInTheDocument();
+    expect(screen.queryByText("No update source history yet.")).not.toBeInTheDocument();
+    expect(screen.queryByText("No updated apps yet.")).not.toBeInTheDocument();
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();
@@ -778,6 +780,30 @@ describe("renderer button parity", () => {
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();
     expect(screen.queryByText("Verified")).not.toBeInTheDocument();
     expect(screen.queryByText("Stats were reset")).not.toBeInTheDocument();
+  });
+
+  it("shows intentional empty states for first-run profile stats", () => {
+    render(
+      <SettingsView
+        snapshot={snapshot({
+          apps: [app],
+          updates: [],
+          homebrewItems: [],
+          profileStats: {
+            ...snapshot().profileStats,
+            events: []
+          }
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Profile" }));
+
+    expect(screen.getByText("No history yet")).toBeInTheDocument();
+    expect(screen.getByText("No update source history yet.")).toBeInTheDocument();
+    expect(screen.getByText("No updated apps yet.")).toBeInTheDocument();
+    expect(document.querySelectorAll(".profile-source-chip")).toHaveLength(0);
+    expect(document.querySelectorAll(".profile-top-app-list li")).toHaveLength(0);
   });
 
   it("shows a profile stats warning only when local history was reset after tampering", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -756,13 +756,13 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("heading", { name: "Time with Baseline" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
-    expect(screen.getByText("Apps updated")).toBeInTheDocument();
+    expect(screen.getByText("Different apps")).toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
     expect(screen.getByText("Apps up to date")).toBeInTheDocument();
     expect(
       [...document.querySelectorAll(".profile-metric > span")].map((metric) => metric.textContent)
-    ).toEqual(["Apps updated", "Total updates", "Apps up to date", "Favorite source"]);
+    ).toEqual(["Different apps", "Total updates", "Apps up to date", "Favorite source"]);
     expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
     expect(screen.getByText("Favorite source")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -765,12 +765,12 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Privacy" })).not.toBeInTheDocument();
     expect(screen.getByText("Total updates")).toBeInTheDocument();
-    expect(screen.getByText("Different apps")).toBeInTheDocument();
+    expect(screen.getByText("Unique apps")).toBeInTheDocument();
     expect(screen.getByText("Installs")).toBeInTheDocument();
     expect(screen.getByText(/Since .*2026/)).toBeInTheDocument();
     expect(
       [...document.querySelectorAll(".profile-metric > span")].map((metric) => metric.textContent)
-    ).toEqual(["Total updates", "Different apps", "Installs", "Favorite source"]);
+    ).toEqual(["Total updates", "Unique apps", "Installs", "Favorite source"]);
     expect(
       [...document.querySelectorAll(".profile-metric strong")].map((metric) => metric.textContent)
     ).toEqual(["8", "4", "1", "Sparkle"]);
@@ -806,7 +806,7 @@ describe("renderer button parity", () => {
     expect([...topAppTiles].some((tile) => tile.textContent?.includes("Fourth App"))).toBe(false);
     expect(
       screen.getByText(
-        "Stats only count updates and installs completed with Baseline. They are private and stored only on this Mac."
+        "Only updates and installs completed with Baseline are counted. Stats stay private on this Mac."
       )
     ).toBeInTheDocument();
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -20,7 +20,7 @@ import type {
   HomebrewManagedItem,
   UpdateRecord
 } from "../src/shared/domain";
-import { defaultPersistedSnapshot } from "../src/shared/domain";
+import { defaultPersistedSnapshot, profileStatsSignatureVersion } from "../src/shared/domain";
 import { version } from "../src/shared/version";
 
 const app: AppRecord = {
@@ -667,6 +667,7 @@ describe("renderer button parity", () => {
           profileStats: {
             createdAt: "2026-06-01T12:00:00.000Z",
             startedUsingAt: "2026-05-15T12:00:00.000Z",
+            signatureVersion: profileStatsSignatureVersion,
             integrityStatus: "verified",
             signature: "signed",
             events: [

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -662,6 +662,24 @@ describe("renderer button parity", () => {
               kind: "formula",
               installedVersion: version("1.0.0"),
               isOutdated: false
+            },
+            {
+              id: "cask:aws-vault",
+              token: "aws-vault",
+              name: "aws-vault",
+              kind: "cask",
+              presentation: "cli",
+              installedVersion: version("1.0.0"),
+              isOutdated: false
+            },
+            {
+              id: "cask:orion",
+              token: "orion",
+              name: "Orion",
+              kind: "cask",
+              presentation: "app",
+              installedVersion: version("1.0.0"),
+              isOutdated: false
             }
           ],
           profileStats: {
@@ -736,6 +754,22 @@ describe("renderer button parity", () => {
                 occurredAt: "2026-06-03T12:00:00.000Z"
               },
               {
+                id: "homebrewUpdate:cask:aws-vault:1:2",
+                type: "homebrewUpdate",
+                targetID: "cask:aws-vault",
+                displayName: "aws-vault",
+                channel: "homebrew",
+                occurredAt: "2026-06-04T12:00:00.000Z"
+              },
+              {
+                id: "homebrewUpdate:cask:orion:1:2",
+                type: "homebrewUpdate",
+                targetID: "cask:orion",
+                displayName: "Orion",
+                channel: "homebrew",
+                occurredAt: "2026-06-04T13:00:00.000Z"
+              },
+              {
                 id: "homebrewInstall:cask:orion:1.0:2026-06-08T12:00:00.000Z",
                 type: "homebrewInstall",
                 targetID: "cask:orion",
@@ -773,18 +807,22 @@ describe("renderer button parity", () => {
     ).toEqual(["Total updates", "Unique apps", "Installs", "Favorite source"]);
     expect(
       [...document.querySelectorAll(".profile-metric strong")].map((metric) => metric.textContent)
-    ).toEqual(["8", "4", "1", "Sparkle"]);
+    ).toEqual(["10", "4", "1", "Sparkle"]);
     expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
     expect(screen.getByText("Favorite source")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Most updated apps" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Most updated tools" })).toBeInTheDocument();
     expect(
       screen.queryByText("Update or install something with Baseline to build a source history.")
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Apps you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
-    expect(screen.getAllByText("Sparkle 56%")).toHaveLength(1);
+    expect(
+      screen.queryByText("Tools you update with Baseline will appear here.")
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("Sparkle 45%")).toHaveLength(1);
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();
@@ -792,10 +830,16 @@ describe("renderer button parity", () => {
       "src",
       "data:image/png;base64,example-icon"
     );
-    const topAppTiles = document.querySelectorAll(".profile-top-app-list li");
+    const topAppTiles = document.querySelectorAll(
+      ".profile-top-app-list:not(.profile-top-tool-list) li"
+    );
     expect(topAppTiles).toHaveLength(3);
     expect(
-      [...document.querySelectorAll(".profile-top-app-rank")].map((rank) => rank.className)
+      [
+        ...document.querySelectorAll(
+          ".profile-top-app-list:not(.profile-top-tool-list) .profile-top-app-rank"
+        )
+      ].map((rank) => rank.className)
     ).toEqual([
       "profile-top-app-rank profile-top-app-rank-1",
       "profile-top-app-rank profile-top-app-rank-2",
@@ -804,6 +848,13 @@ describe("renderer button parity", () => {
     expect(screen.getByText("Stable App")).toBeInTheDocument();
     expect(screen.getByText("Third App")).toBeInTheDocument();
     expect([...topAppTiles].some((tile) => tile.textContent?.includes("Fourth App"))).toBe(false);
+    const topToolTiles = document.querySelectorAll(".profile-top-tool-list li");
+    expect(topToolTiles).toHaveLength(2);
+    expect(screen.getByText("aws-vault")).toBeInTheDocument();
+    expect(screen.getByText("1 update · CLI Cask")).toBeInTheDocument();
+    expect(screen.getByText("ripgrep")).toBeInTheDocument();
+    expect(screen.getByText("1 update · Formula")).toBeInTheDocument();
+    expect([...topToolTiles].some((tile) => tile.textContent?.includes("Orion"))).toBe(false);
     expect(
       screen.getByText(
         "Only updates and installs completed with Baseline are counted. Stats stay private on this Mac."
@@ -836,6 +887,7 @@ describe("renderer button parity", () => {
       screen.getByText("Update or install something with Baseline to build a source history.")
     ).toBeInTheDocument();
     expect(screen.getByText("Apps you update with Baseline will appear here.")).toBeInTheDocument();
+    expect(screen.getByText("Tools you update with Baseline will appear here.")).toBeInTheDocument();
     expect(document.querySelectorAll(".profile-source-chip")).toHaveLength(0);
     expect(document.querySelectorAll(".profile-top-app-list li")).toHaveLength(0);
   });

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1584,6 +1584,118 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("records profile stats for batch upgrades completed before maintenance fails", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => ({
+      success: command[0] !== "cleanup",
+      status: command[0] === "cleanup" ? 1 : 0,
+      output: command[0] === "cleanup" ? "Error: cleanup failed" : ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            installedVersion: version("14.0.0"),
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "cask:visual-studio-code",
+            token: "visual-studio-code",
+            name: "Visual Studio Code",
+            kind: "cask",
+            installedVersion: version("1.99.0"),
+            latestVersion: version("1.100.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["upgrade", "--cask", "--greedy", "visual-studio-code"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "formula:ripgrep",
+        displayName: "ripgrep",
+        channel: "homebrew"
+      }),
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "cask:visual-studio-code",
+        displayName: "Visual Studio Code",
+        channel: "homebrew"
+      })
+    ]);
+  });
+
+  it("does not record profile stats for batch upgrade commands that fail", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => ({
+      success: !command.includes("--cask"),
+      status: command.includes("--cask") ? 1 : 0,
+      output: command.includes("--cask") ? "Error: cask upgrade failed" : ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:ripgrep",
+            token: "ripgrep",
+            name: "ripgrep",
+            kind: "formula",
+            installedVersion: version("14.0.0"),
+            latestVersion: version("14.1.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "cask:visual-studio-code",
+            token: "visual-studio-code",
+            name: "Visual Studio Code",
+            kind: "cask",
+            installedVersion: version("1.99.0"),
+            latestVersion: version("1.100.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["upgrade", "--cask", "--greedy", "visual-studio-code"]
+    ]);
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "formula:ripgrep",
+        displayName: "ripgrep",
+        channel: "homebrew"
+      })
+    ]);
+  });
+
   it("excludes hidden app-backed casks from batch Homebrew updates", async () => {
     const ignoredApp = appRecord({
       bundlePath: "/Applications/Managed.app",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2316,6 +2316,109 @@ describe("update store helpers", () => {
     }
   });
 
+  it("records profile stats when refresh proves an app update completed", async () => {
+    const installedApp = appRecord({
+      bundlePath: "/Applications/Profiled App.app",
+      displayName: "Profiled App",
+      localVersion: version("1.0.0")
+    });
+    const refreshedApp = {
+      ...installedApp,
+      localVersion: version("2.0.0")
+    };
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [installedApp],
+        updates: [
+          {
+            id: installedApp.id,
+            appID: installedApp.id,
+            source: "sparkle",
+            supportLevel: "limited",
+            localVersion: version("1.0.0"),
+            remoteVersion: version("2.0.0"),
+            checkedAt: "2026-06-01T12:00:00.000Z"
+          }
+        ]
+      },
+      clients: {
+        scanner: { scanApplications: async () => [refreshedApp] }
+      }
+    });
+
+    await store.refresh(false);
+    await store.refresh(false);
+
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "appUpdate",
+        targetID: installedApp.id,
+        displayName: "Profiled App",
+        channel: "sparkle"
+      })
+    ]);
+  });
+
+  it("records profile stats for successful Homebrew Discover installs", async () => {
+    const store = await makeStore();
+
+    await store.installHomebrewItem({
+      id: "formula:bat",
+      kind: "formula",
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    });
+
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewInstall",
+        targetID: "formula:bat",
+        displayName: "bat",
+        channel: "homebrew"
+      })
+    ]);
+  });
+
+  it("resets profile stats when the local integrity seal fails", async () => {
+    const profileStatsIntegrity = {
+      verifyOrInitialize: vi.fn(async () => ({
+        ...defaultPersistedSnapshot().profileStats,
+        createdAt: "2026-06-05T12:00:00.000Z",
+        integrityStatus: "resetAfterTamper" as const,
+        signature: "sealed"
+      })),
+      seal: vi.fn(async (stats) => ({ ...stats, signature: "sealed" }))
+    };
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        profileStats: {
+          createdAt: "2026-06-01T12:00:00.000Z",
+          integrityStatus: "pending",
+          signature: "edited",
+          events: [
+            {
+              id: "appUpdate:edited",
+              type: "appUpdate",
+              targetID: "app:edited",
+              displayName: "Edited",
+              channel: "appStore",
+              occurredAt: "2026-06-02T12:00:00.000Z"
+            }
+          ]
+        }
+      },
+      profileStatsIntegrity
+    });
+
+    await store.verifyProfileStatsIntegrity();
+
+    expect(store.getSnapshot().profileStats.events).toEqual([]);
+    expect(store.getSnapshot().profileStats.integrityStatus).toBe("resetAfterTamper");
+  });
+
   it("does not run Discover installs when Homebrew is unavailable", async () => {
     const item = {
       id: "cask:missing-brew-discover",
@@ -2351,6 +2454,10 @@ async function makeStore({
   runMasCommand = async () => ({ success: true, status: 0, output: "" }),
   openExternalURL = async () => true,
   openAppBundle = async () => undefined,
+  profileStatsIntegrity = {
+    verifyOrInitialize: async (stats) => ({ ...stats, integrityStatus: "verified" as const }),
+    seal: async (stats) => ({ ...stats, signature: "sealed" })
+  },
   currentAppVersion,
   successRefreshDelayMS = 0,
   onUserData
@@ -2361,6 +2468,7 @@ async function makeStore({
   runMasCommand?: ConstructorParameters<typeof UpdateStore>[0]["runMasCommand"];
   openExternalURL?: ConstructorParameters<typeof UpdateStore>[0]["openExternalURL"];
   openAppBundle?: ConstructorParameters<typeof UpdateStore>[0]["openAppBundle"];
+  profileStatsIntegrity?: ConstructorParameters<typeof UpdateStore>[0]["profileStatsIntegrity"];
   currentAppVersion?: ConstructorParameters<typeof UpdateStore>[0]["currentAppVersion"];
   successRefreshDelayMS?: ConstructorParameters<typeof UpdateStore>[0]["successRefreshDelayMS"];
   onUserData?: (directory: string) => void;
@@ -2373,6 +2481,7 @@ async function makeStore({
     persisted,
     openExternalURL,
     openAppBundle,
+    profileStatsIntegrity,
     currentAppVersion,
     runBrewCommand,
     runMasCommand,

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1696,6 +1696,63 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("does not complete same-token casks from formula batch output", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command, onOutputLine = () => undefined) => {
+      if (command[0] === "upgrade" && !command.includes("--cask")) {
+        onOutputLine("🍺  /opt/homebrew/Cellar/shared/1.0: 10 files");
+      }
+      return {
+        success: !command.includes("--cask"),
+        status: command.includes("--cask") ? 1 : 0,
+        output: command.includes("--cask") ? "Error: cask upgrade failed" : ""
+      };
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:shared",
+            token: "shared",
+            name: "shared",
+            kind: "formula",
+            installedVersion: version("1.0.0"),
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          }),
+          homebrewItem({
+            id: "cask:shared",
+            token: "shared",
+            name: "Shared",
+            kind: "cask",
+            installedVersion: version("1.0.0"),
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdateAll();
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "shared"],
+      ["upgrade", "--cask", "--greedy", "shared"]
+    ]);
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "formula:shared",
+        displayName: "shared",
+        channel: "homebrew"
+      })
+    ]);
+  });
+
   it("excludes hidden app-backed casks from batch Homebrew updates", async () => {
     const ignoredApp = appRecord({
       bundlePath: "/Applications/Managed.app",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -8,7 +8,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   emptyHomebrewCaskIndex,
   emptyHomebrewFormulaIndex,
-  defaultPersistedSnapshot
+  defaultPersistedSnapshot,
+  profileStatsSignatureVersion
 } from "../src/shared/domain";
 import { SnapshotPersistence } from "../src/main/persistence";
 import {
@@ -2430,6 +2431,28 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("does not persist unsigned profile stats events when sealing is unavailable", async () => {
+    const profileStatsIntegrity = {
+      verifyOrInitialize: vi.fn(async (stats) => ({
+        ...stats,
+        integrityStatus: "verified" as const
+      })),
+      seal: vi.fn(async (stats) => ({ ...stats, integrityStatus: "unavailable" as const }))
+    };
+    const store = await makeStore({ profileStatsIntegrity });
+
+    await store.installHomebrewItem({
+      id: "formula:bat",
+      kind: "formula",
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    });
+
+    expect(store.getSnapshot().profileStats.integrityStatus).toBe("unavailable");
+    expect(store.getSnapshot().profileStats.events).toEqual([]);
+  });
+
   it("resets profile stats when the local integrity seal fails", async () => {
     const profileStatsIntegrity = {
       verifyOrInitialize: vi.fn(async () => ({
@@ -2446,6 +2469,7 @@ describe("update store helpers", () => {
         profileStats: {
           createdAt: "2026-06-01T12:00:00.000Z",
           startedUsingAt: "2026-05-15T12:00:00.000Z",
+          signatureVersion: profileStatsSignatureVersion,
           integrityStatus: "pending",
           signature: "edited",
           events: [

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1540,6 +1540,20 @@ describe("update store helpers", () => {
       ["autoremove"],
       ["cleanup"]
     ]);
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "formula:ripgrep",
+        displayName: "ripgrep",
+        channel: "homebrew"
+      }),
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "cask:visual-studio-code",
+        displayName: "Visual Studio Code",
+        channel: "homebrew"
+      })
+    ]);
   });
 
   it("excludes hidden app-backed casks from batch Homebrew updates", async () => {
@@ -1785,6 +1799,14 @@ describe("update store helpers", () => {
     await successfulStore.performAppUpdate(app.id);
 
     expect(successfulMas).toHaveBeenCalledWith(["upgrade", "123"]);
+    expect(successfulStore.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "appUpdate",
+        targetID: app.id,
+        displayName: "App Store Managed",
+        channel: "appStore"
+      })
+    ]);
 
     const failingMas = vi.fn(async () => ({ success: false, status: 1, output: "" }));
     const openedExternalURLs: string[] = [];
@@ -1801,6 +1823,7 @@ describe("update store helpers", () => {
 
     expect(failingMas).toHaveBeenCalledWith(["upgrade", "123"]);
     expect(openedExternalURLs).toEqual(["https://apps.apple.com/app/example"]);
+    expect(fallbackStore.getSnapshot().profileStats.events).toEqual([]);
   });
 
   it("blocks unsafe external URLs before invoking the platform opener", async () => {
@@ -1858,6 +1881,14 @@ describe("update store helpers", () => {
       ["upgrade", "--cask", "homebrew-managed"],
       expect.any(Function)
     );
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "cask:homebrew-managed",
+        displayName: "Homebrew Managed",
+        channel: "homebrew"
+      })
+    ]);
   });
 
   it("routes Homebrew-backed app updates through installed casks even when cask outdated metadata is missing", async () => {
@@ -2316,7 +2347,7 @@ describe("update store helpers", () => {
     }
   });
 
-  it("records profile stats when refresh proves an app update completed", async () => {
+  it("does not record profile stats when refresh detects an external app update", async () => {
     const installedApp = appRecord({
       bundlePath: "/Applications/Profiled App.app",
       displayName: "Profiled App",
@@ -2350,14 +2381,7 @@ describe("update store helpers", () => {
     await store.refresh(false);
     await store.refresh(false);
 
-    expect(store.getSnapshot().profileStats.events).toEqual([
-      expect.objectContaining({
-        type: "appUpdate",
-        targetID: installedApp.id,
-        displayName: "Profiled App",
-        channel: "sparkle"
-      })
-    ]);
+    expect(store.getSnapshot().profileStats.events).toEqual([]);
   });
 
   it("records profile stats for successful Homebrew Discover installs", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1910,8 +1910,8 @@ describe("update store helpers", () => {
     );
     expect(store.getSnapshot().profileStats.events).toEqual([
       expect.objectContaining({
-        type: "homebrewUpdate",
-        targetID: "cask:homebrew-managed",
+        type: "appUpdate",
+        targetID: app.id,
         displayName: "Homebrew Managed",
         channel: "homebrew"
       })

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2480,13 +2480,11 @@ describe("update store helpers", () => {
     await Promise.all([firstInstall, secondInstall]);
 
     expect(
-      store
-        .getSnapshot()
-        .profileStats.events.map((event) => ({
-          type: event.type,
-          targetID: event.targetID,
-          displayName: event.displayName
-        }))
+      store.getSnapshot().profileStats.events.map((event) => ({
+        type: event.type,
+        targetID: event.targetID,
+        displayName: event.displayName
+      }))
     ).toEqual([
       { type: "homebrewInstall", targetID: "formula:fd", displayName: "fd" },
       { type: "homebrewInstall", targetID: "formula:bat", displayName: "bat" }

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2515,6 +2515,47 @@ describe("update store helpers", () => {
     expect(store.getSnapshot().profileStats.events).toEqual([]);
   });
 
+  it("does not seal populated unsigned profile stats history after a successful action", async () => {
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        profileStats: {
+          ...defaultPersistedSnapshot().profileStats,
+          signature: undefined,
+          integrityStatus: "unavailable",
+          events: [
+            {
+              id: "appUpdate:edited",
+              type: "appUpdate",
+              targetID: "app:edited",
+              displayName: "Edited",
+              channel: "appStore",
+              occurredAt: "2026-06-01T12:00:00.000Z"
+            }
+          ]
+        }
+      }
+    });
+
+    await store.installHomebrewItem({
+      id: "formula:bat",
+      kind: "formula",
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    });
+
+    expect(store.getSnapshot().profileStats.integrityStatus).toBe("resetAfterTamper");
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewInstall",
+        targetID: "formula:bat",
+        displayName: "bat",
+        channel: "homebrew"
+      })
+    ]);
+  });
+
   it("preserves profile stats events recorded while launch verification is pending", async () => {
     let resolveVerification: (() => void) | undefined;
     const profileStatsIntegrity = {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -21,7 +21,8 @@ import type {
   AppRecord,
   HomebrewCaskIndex,
   HomebrewManagedItem,
-  PersistedSnapshot
+  PersistedSnapshot,
+  ProfileStats
 } from "../src/shared/domain";
 import { version } from "../src/shared/version";
 
@@ -2451,6 +2452,49 @@ describe("update store helpers", () => {
 
     expect(store.getSnapshot().profileStats.integrityStatus).toBe("unavailable");
     expect(store.getSnapshot().profileStats.events).toEqual([]);
+  });
+
+  it("preserves profile stats events recorded while launch verification is pending", async () => {
+    let resolveVerification: (() => void) | undefined;
+    const profileStatsIntegrity = {
+      verifyOrInitialize: vi.fn(
+        async (stats) =>
+          new Promise<ProfileStats>((resolve) => {
+            resolveVerification = () =>
+              resolve({
+                ...stats,
+                integrityStatus: "verified" as const,
+                signature: "initial-sealed"
+              });
+          })
+      ),
+      seal: vi.fn(async (stats) => ({
+        ...stats,
+        integrityStatus: stats.integrityStatus,
+        signature: "sealed"
+      }))
+    };
+    const store = await makeStore({ profileStatsIntegrity });
+
+    const verificationTask = store.verifyProfileStatsIntegrity();
+    await store.installHomebrewItem({
+      id: "formula:bat",
+      kind: "formula",
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    });
+    resolveVerification?.();
+    await verificationTask;
+
+    expect(store.getSnapshot().profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewInstall",
+        targetID: "formula:bat",
+        displayName: "bat",
+        channel: "homebrew"
+      })
+    ]);
   });
 
   it("resets profile stats when the local integrity seal fails", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  defaultProfileStatsAfterTamper,
   emptyHomebrewCaskIndex,
   emptyHomebrewFormulaIndex,
   defaultPersistedSnapshot,
@@ -2602,7 +2603,7 @@ describe("update store helpers", () => {
   it("resets profile stats when the local integrity seal fails", async () => {
     const profileStatsIntegrity = {
       verifyOrInitialize: vi.fn(async () => ({
-        ...defaultPersistedSnapshot().profileStats,
+        ...defaultProfileStatsAfterTamper("2026-06-05T12:00:00.000Z"),
         createdAt: "2026-06-05T12:00:00.000Z",
         integrityStatus: "resetAfterTamper" as const,
         signature: "sealed"
@@ -2637,6 +2638,38 @@ describe("update store helpers", () => {
 
     expect(store.getSnapshot().profileStats.events).toEqual([]);
     expect(store.getSnapshot().profileStats.integrityStatus).toBe("resetAfterTamper");
+    expect(store.getSnapshot().profileStats.resetNotice).toMatchObject({
+      reason: "tamper"
+    });
+  });
+
+  it("persists acknowledgement of the current profile stats reset notice", async () => {
+    let userData = "";
+    const resetNotice = {
+      id: "tamper:2026-06-05T12:00:00.000Z",
+      occurredAt: "2026-06-05T12:00:00.000Z",
+      reason: "tamper" as const
+    };
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        profileStats: {
+          ...defaultPersistedSnapshot().profileStats,
+          resetNotice,
+          integrityStatus: "resetAfterTamper"
+        }
+      },
+      onUserData: (directory) => {
+        userData = directory;
+      }
+    });
+
+    await store.acknowledgeProfileStatsReset();
+
+    expect(store.getSnapshot().profileStatsResetAcknowledgedID).toBe(resetNotice.id);
+    await expect(new SnapshotPersistence(userData).load()).resolves.toMatchObject({
+      profileStatsResetAcknowledgedID: resetNotice.id
+    });
   });
 
   it("does not run Discover installs when Homebrew is unavailable", async () => {

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -294,6 +294,31 @@ describe("update store helpers", () => {
     });
   });
 
+  it("persists the started using date through store saves", async () => {
+    let userData = "";
+    const startedUsingAt = "2026-06-01T12:00:00.000Z";
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        profileStats: {
+          ...defaultPersistedSnapshot().profileStats,
+          startedUsingAt
+        }
+      },
+      onUserData: (directory) => {
+        userData = directory;
+      }
+    });
+
+    await store.updatePreferences({ showMenuBarIcon: false });
+
+    await expect(new SnapshotPersistence(userData).load()).resolves.toMatchObject({
+      profileStats: {
+        startedUsingAt
+      }
+    });
+  });
+
   it("scans default directories before additional directories", async () => {
     const scannedDirectories: string[][] = [];
     const store = await makeStore({
@@ -2420,6 +2445,7 @@ describe("update store helpers", () => {
         ...defaultPersistedSnapshot(),
         profileStats: {
           createdAt: "2026-06-01T12:00:00.000Z",
+          startedUsingAt: "2026-05-15T12:00:00.000Z",
           integrityStatus: "pending",
           signature: "edited",
           events: [

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2432,6 +2432,67 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("preserves profile stats from concurrent successful actions", async () => {
+    let resolveFirstSeal: (() => void) | undefined;
+    let resolveFirstSealStarted: (() => void) | undefined;
+    const firstSealStarted = new Promise<void>((resolve) => {
+      resolveFirstSealStarted = resolve;
+    });
+    let sealCount = 0;
+    const profileStatsIntegrity = {
+      verifyOrInitialize: vi.fn(async (stats) => ({
+        ...stats,
+        integrityStatus: "verified" as const
+      })),
+      seal: vi.fn(async (stats: ProfileStats) => {
+        sealCount += 1;
+        if (sealCount === 1) {
+          resolveFirstSealStarted?.();
+          await new Promise<void>((resolve) => {
+            resolveFirstSeal = resolve;
+          });
+        }
+        return { ...stats, signature: `sealed-${sealCount}` };
+      })
+    };
+    const store = await makeStore({ profileStatsIntegrity });
+
+    const firstInstall = store.installHomebrewItem({
+      id: "formula:bat",
+      kind: "formula",
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    });
+    await firstSealStarted;
+
+    const secondInstall = store.installHomebrewItem({
+      id: "formula:fd",
+      kind: "formula",
+      token: "fd",
+      displayName: "fd",
+      version: version("1.0.0")
+    });
+    await Promise.resolve();
+    expect(profileStatsIntegrity.seal).toHaveBeenCalledTimes(1);
+
+    resolveFirstSeal?.();
+    await Promise.all([firstInstall, secondInstall]);
+
+    expect(
+      store
+        .getSnapshot()
+        .profileStats.events.map((event) => ({
+          type: event.type,
+          targetID: event.targetID,
+          displayName: event.displayName
+        }))
+    ).toEqual([
+      { type: "homebrewInstall", targetID: "formula:fd", displayName: "fd" },
+      { type: "homebrewInstall", targetID: "formula:bat", displayName: "bat" }
+    ]);
+  });
+
   it("does not persist unsigned profile stats events when sealing is unavailable", async () => {
     const profileStatsIntegrity = {
       verifyOrInitialize: vi.fn(async (stats) => ({
@@ -2477,15 +2538,17 @@ describe("update store helpers", () => {
     const store = await makeStore({ profileStatsIntegrity });
 
     const verificationTask = store.verifyProfileStatsIntegrity();
-    await store.installHomebrewItem({
+    await Promise.resolve();
+    const installTask = store.installHomebrewItem({
       id: "formula:bat",
       kind: "formula",
       token: "bat",
       displayName: "bat",
       version: version("1.0.0")
     });
+    await Promise.resolve();
     resolveVerification?.();
-    await verificationTask;
+    await Promise.all([verificationTask, installTask]);
 
     expect(store.getSnapshot().profileStats.events).toEqual([
       expect.objectContaining({

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 
 const expectedBaselineAPI = [
+  "acknowledgeProfileStatsReset",
   "chooseDirectory",
   "copyDiagnostics",
   "getAppMetadata",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -419,6 +419,9 @@ function wireIpc(): void {
   ipcMain.handle(ipcChannels.updatePreferences, (_event, patch: PreferencePatch) =>
     store.updatePreferences(patch)
   );
+  ipcMain.handle(ipcChannels.acknowledgeProfileStatsReset, () =>
+    store.acknowledgeProfileStatsReset()
+  );
   ipcMain.handle(ipcChannels.toggleIgnoredApp, (_event, appID: string) =>
     store.toggleIgnoredApp(String(appID))
   );

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -91,6 +91,7 @@ if (hasSingleInstanceLock) {
       },
       currentAppVersion: metadata.version
     });
+    await store.verifyProfileStatsIntegrity();
 
     createMainWindow("main");
     wireStoreEvents();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -91,11 +91,11 @@ if (hasSingleInstanceLock) {
       },
       currentAppVersion: metadata.version
     });
-    await store.verifyProfileStatsIntegrity();
 
     createMainWindow("main");
     wireStoreEvents();
     wireIpc();
+    void verifyProfileStatsIntegrityAfterLaunch();
     updateTrayStatus(store.getSnapshot());
     if (process.env.BASELINE_SKIP_INITIAL_REFRESH === "1") {
       store.emit("snapshot", store.getSnapshot());
@@ -118,6 +118,14 @@ app.on("before-quit", () => {
   isQuitting = true;
 });
 app.on("did-resign-active", hideMenuWindowForNativeDismissal);
+
+async function verifyProfileStatsIntegrityAfterLaunch(): Promise<void> {
+  try {
+    await store.verifyProfileStatsIntegrity();
+  } catch {
+    // Profile stats should never block app launch or normal update checks.
+  }
+}
 
 function createMainWindow(route: "main" | "settings"): BrowserWindow {
   if (mainWindow) {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -105,6 +105,10 @@ function normalizeProfileStats(
         : typeof legacyStartedUsingAt === "string"
           ? legacyStartedUsingAt
           : defaults.startedUsingAt,
+    signatureVersion:
+      typeof input?.signatureVersion === "number"
+        ? input.signatureVersion
+        : defaults.signatureVersion,
     events,
     signature: typeof input?.signature === "string" ? input.signature : undefined,
     integrityStatus: "pending"

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -115,28 +115,32 @@ function normalizeProfileStats(
   };
 }
 
-function normalizeProfileStatsEvent(input: Partial<ProfileStatsEvent>): ProfileStatsEvent[] {
+function normalizeProfileStatsEvent(input: unknown): ProfileStatsEvent[] {
+  if (!input || typeof input !== "object") {
+    return [];
+  }
+  const event = input as Partial<ProfileStatsEvent>;
   if (
-    typeof input.id !== "string" ||
-    typeof input.targetID !== "string" ||
-    typeof input.displayName !== "string" ||
-    typeof input.occurredAt !== "string"
+    typeof event.id !== "string" ||
+    typeof event.targetID !== "string" ||
+    typeof event.displayName !== "string" ||
+    typeof event.occurredAt !== "string"
   ) {
     return [];
   }
-  const type = normalizeProfileStatsEventType(input.type);
-  const channel = normalizeProfileStatsChannel(input.channel);
+  const type = normalizeProfileStatsEventType(event.type);
+  const channel = normalizeProfileStatsChannel(event.channel);
   if (!type || !channel) {
     return [];
   }
   return [
     {
-      id: input.id,
+      id: event.id,
       type,
-      targetID: input.targetID,
-      displayName: input.displayName,
+      targetID: event.targetID,
+      displayName: event.displayName,
       channel,
-      occurredAt: input.occurredAt
+      occurredAt: event.occurredAt
     }
   ];
 }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3,8 +3,12 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { PersistedSnapshot } from "../shared/domain";
-import { defaultPersistedSnapshot, normalizeAppearancePreference } from "../shared/domain";
+import type { PersistedSnapshot, ProfileStats, ProfileStatsEvent } from "../shared/domain";
+import {
+  defaultPersistedSnapshot,
+  defaultProfileStats,
+  normalizeAppearancePreference
+} from "../shared/domain";
 import { version } from "../shared/version";
 export { defaultPersistedSnapshot };
 
@@ -73,6 +77,7 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
       fromVersion: version(record.fromVersion?.raw),
       toVersion: version(record.toVersion?.raw)
     })),
+    profileStats: normalizeProfileStats(input.profileStats),
     appearancePreference: normalizeAppearancePreference(input.appearancePreference),
     refreshIntervalMinutes: clamp(
       input.refreshIntervalMinutes ?? defaults.refreshIntervalMinutes,
@@ -80,6 +85,65 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
       1440
     )
   };
+}
+
+function normalizeProfileStats(input: Partial<ProfileStats> | undefined): ProfileStats {
+  const defaults = defaultProfileStats();
+  const events = Array.isArray(input?.events)
+    ? input.events.flatMap((event) => normalizeProfileStatsEvent(event))
+    : [];
+  return {
+    createdAt: typeof input?.createdAt === "string" ? input.createdAt : defaults.createdAt,
+    events,
+    signature: typeof input?.signature === "string" ? input.signature : undefined,
+    integrityStatus: "pending"
+  };
+}
+
+function normalizeProfileStatsEvent(input: Partial<ProfileStatsEvent>): ProfileStatsEvent[] {
+  if (
+    typeof input.id !== "string" ||
+    typeof input.targetID !== "string" ||
+    typeof input.displayName !== "string" ||
+    typeof input.occurredAt !== "string"
+  ) {
+    return [];
+  }
+  const type = normalizeProfileStatsEventType(input.type);
+  const channel = normalizeProfileStatsChannel(input.channel);
+  if (!type || !channel) {
+    return [];
+  }
+  return [
+    {
+      id: input.id,
+      type,
+      targetID: input.targetID,
+      displayName: input.displayName,
+      channel,
+      occurredAt: input.occurredAt
+    }
+  ];
+}
+
+function normalizeProfileStatsEventType(value: unknown): ProfileStatsEvent["type"] | undefined {
+  if (value === "appUpdate" || value === "homebrewUpdate" || value === "homebrewInstall") {
+    return value;
+  }
+  return undefined;
+}
+
+function normalizeProfileStatsChannel(value: unknown): ProfileStatsEvent["channel"] | undefined {
+  if (
+    value === "appStore" ||
+    value === "sparkle" ||
+    value === "homebrew" ||
+    value === "web" ||
+    value === "unknown"
+  ) {
+    return value;
+  }
+  return undefined;
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3,7 +3,12 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { PersistedSnapshot, ProfileStats, ProfileStatsEvent } from "../shared/domain";
+import type {
+  PersistedSnapshot,
+  ProfileStats,
+  ProfileStatsEvent,
+  ProfileStatsResetNotice
+} from "../shared/domain";
 import {
   defaultPersistedSnapshot,
   defaultProfileStats,
@@ -80,6 +85,10 @@ function normalizeSnapshot(
       toVersion: version(record.toVersion?.raw)
     })),
     profileStats: normalizeProfileStats(input.profileStats, input.startedUsingAt),
+    profileStatsResetAcknowledgedID:
+      typeof input.profileStatsResetAcknowledgedID === "string"
+        ? input.profileStatsResetAcknowledgedID
+        : undefined,
     appearancePreference: normalizeAppearancePreference(input.appearancePreference),
     refreshIntervalMinutes: clamp(
       input.refreshIntervalMinutes ?? defaults.refreshIntervalMinutes,
@@ -110,6 +119,7 @@ function normalizeProfileStats(
         ? input.signatureVersion
         : defaults.signatureVersion,
     events,
+    resetNotice: normalizeProfileStatsResetNotice(input?.resetNotice),
     signature: typeof input?.signature === "string" ? input.signature : undefined,
     integrityStatus: "pending"
   };
@@ -161,6 +171,25 @@ function normalizeProfileStatsChannel(value: unknown): ProfileStatsEvent["channe
     value === "unknown"
   ) {
     return value;
+  }
+  return undefined;
+}
+
+function normalizeProfileStatsResetNotice(input: unknown): ProfileStatsResetNotice | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+  const notice = input as Partial<ProfileStatsResetNotice>;
+  if (
+    typeof notice.id === "string" &&
+    typeof notice.occurredAt === "string" &&
+    notice.reason === "tamper"
+  ) {
+    return {
+      id: notice.id,
+      occurredAt: notice.occurredAt,
+      reason: notice.reason
+    };
   }
   return undefined;
 }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -34,7 +34,9 @@ export class SnapshotPersistence {
   }
 }
 
-function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot {
+function normalizeSnapshot(
+  input: Partial<PersistedSnapshot> & { startedUsingAt?: unknown }
+): PersistedSnapshot {
   const defaults = defaultPersistedSnapshot();
   return {
     ...defaults,
@@ -77,7 +79,7 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
       fromVersion: version(record.fromVersion?.raw),
       toVersion: version(record.toVersion?.raw)
     })),
-    profileStats: normalizeProfileStats(input.profileStats),
+    profileStats: normalizeProfileStats(input.profileStats, input.startedUsingAt),
     appearancePreference: normalizeAppearancePreference(input.appearancePreference),
     refreshIntervalMinutes: clamp(
       input.refreshIntervalMinutes ?? defaults.refreshIntervalMinutes,
@@ -87,13 +89,22 @@ function normalizeSnapshot(input: Partial<PersistedSnapshot>): PersistedSnapshot
   };
 }
 
-function normalizeProfileStats(input: Partial<ProfileStats> | undefined): ProfileStats {
+function normalizeProfileStats(
+  input: Partial<ProfileStats> | undefined,
+  legacyStartedUsingAt?: unknown
+): ProfileStats {
   const defaults = defaultProfileStats();
   const events = Array.isArray(input?.events)
     ? input.events.flatMap((event) => normalizeProfileStatsEvent(event))
     : [];
   return {
     createdAt: typeof input?.createdAt === "string" ? input.createdAt : defaults.createdAt,
+    startedUsingAt:
+      typeof input?.startedUsingAt === "string"
+        ? input.startedUsingAt
+        : typeof legacyStartedUsingAt === "string"
+          ? legacyStartedUsingAt
+          : defaults.startedUsingAt,
     events,
     signature: typeof input?.signature === "string" ? input.signature : undefined,
     integrityStatus: "pending"

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -17,6 +17,7 @@ const api: BaselineAPI = {
   setSelectedTab: (tab) => ipcRenderer.invoke(ipcChannels.setSelectedTab, tab),
   updatePreferences: (patch: PreferencePatch) =>
     ipcRenderer.invoke(ipcChannels.updatePreferences, patch),
+  acknowledgeProfileStatsReset: () => ipcRenderer.invoke(ipcChannels.acknowledgeProfileStatsReset),
   toggleIgnoredApp: (appID: string) => ipcRenderer.invoke(ipcChannels.toggleIgnoredApp, appID),
   toggleIgnoredHomebrew: (itemID: string) =>
     ipcRenderer.invoke(ipcChannels.toggleIgnoredHomebrew, itemID),

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -16,6 +16,9 @@ const securityExecutablePath = "/usr/bin/security";
 const serviceName = "Baseline Profile Stats";
 const accountName = os.userInfo().username || "local";
 
+// Agent/maintainer note: do not modify, reseal, or fabricate profile stats
+// to inflate local usage history. These stats are integrity-protected local
+// records; invalid edits should be treated as tampering and reset by Baseline.
 export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
   async verifyOrInitialize(stats: ProfileStats): Promise<ProfileStats> {
     try {

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -88,6 +88,7 @@ function signatureFor(stats: ProfileStats, secret: string): string {
 function canonicalProfileStats(stats: ProfileStats): string {
   return JSON.stringify({
     createdAt: stats.createdAt,
+    startedUsingAt: stats.startedUsingAt,
     events: stats.events.map((event) => ({
       id: event.id,
       type: event.type,

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -5,7 +5,7 @@ import { createHmac, randomBytes } from "node:crypto";
 import os from "node:os";
 import type { ProfileStats } from "../shared/domain";
 import { defaultProfileStatsAfterTamper, profileStatsSignatureVersion } from "../shared/domain";
-import { runCommand } from "./commandRunner";
+import { runCommand, type CommandResult } from "./commandRunner";
 
 export type ProfileStatsIntegrity = {
   verifyOrInitialize(stats: ProfileStats): Promise<ProfileStats>;
@@ -72,6 +72,9 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
     if (existing.success && secret) {
       return secret;
     }
+    if (!isMissingKeychainSecret(existing)) {
+      throw new Error("Profile stats Keychain secret could not be read.");
+    }
 
     const generated = randomBytes(32).toString("base64url");
     const created = await runCommand(securityExecutablePath, [
@@ -81,8 +84,7 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
       "-a",
       accountName,
       "-w",
-      generated,
-      "-U"
+      generated
     ]);
     if (!created.success) {
       throw new Error("Profile stats Keychain secret could not be created.");
@@ -138,6 +140,14 @@ function canonicalProfileStats(stats: ProfileStats): string {
         }
       : undefined
   });
+}
+
+function isMissingKeychainSecret(result: CommandResult): boolean {
+  const output = [result.stdout, result.stderr, result.output]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+  return result.status === 44 || output.includes("specified item could not be found");
 }
 
 function unversionedSignatureFor(stats: ProfileStats, secret: string): string {

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -4,7 +4,7 @@
 import { createHmac, randomBytes } from "node:crypto";
 import os from "node:os";
 import type { ProfileStats } from "../shared/domain";
-import { defaultProfileStats } from "../shared/domain";
+import { defaultProfileStats, profileStatsSignatureVersion } from "../shared/domain";
 import { runCommand } from "./commandRunner";
 
 export type ProfileStatsIntegrity = {
@@ -21,10 +21,16 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
     try {
       const secret = await this.keychainSecret();
       if (!stats.signature) {
+        if (stats.events.length > 0) {
+          return { ...stats, integrityStatus: "unavailable" };
+        }
         return sealProfileStats(stats, secret, "verified");
       }
       if (signatureFor(stats, secret) === stats.signature) {
-        return { ...stats, integrityStatus: "verified" };
+        return normalizeProfileStatsSignature(stats, secret);
+      }
+      if (unversionedSignatureFor(stats, secret) === stats.signature) {
+        return sealProfileStats(stats, secret, "verified");
       }
       if (legacySignatureFor(stats, secret) === stats.signature) {
         return sealProfileStats(
@@ -46,7 +52,7 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
     try {
       return sealProfileStats(stats, await this.keychainSecret(), stats.integrityStatus);
     } catch {
-      return { ...stats, signature: undefined, integrityStatus: "unavailable" };
+      return { ...stats, integrityStatus: "unavailable" };
     }
   }
 
@@ -87,7 +93,7 @@ function sealProfileStats(
   secret: string,
   integrityStatus: ProfileStats["integrityStatus"]
 ): ProfileStats {
-  const sealed = { ...stats, integrityStatus };
+  const sealed = { ...stats, signatureVersion: profileStatsSignatureVersion, integrityStatus };
   return { ...sealed, signature: signatureFor(sealed, secret) };
 }
 
@@ -95,8 +101,16 @@ function signatureFor(stats: ProfileStats, secret: string): string {
   return createHmac("sha256", secret).update(canonicalProfileStats(stats)).digest("base64url");
 }
 
+function normalizeProfileStatsSignature(stats: ProfileStats, secret: string): ProfileStats {
+  if (stats.signatureVersion === profileStatsSignatureVersion) {
+    return { ...stats, integrityStatus: "verified" };
+  }
+  return sealProfileStats(stats, secret, "verified");
+}
+
 function canonicalProfileStats(stats: ProfileStats): string {
   return JSON.stringify({
+    signatureVersion: stats.signatureVersion,
     createdAt: stats.createdAt,
     startedUsingAt: stats.startedUsingAt,
     events: stats.events.map((event) => ({
@@ -108,6 +122,25 @@ function canonicalProfileStats(stats: ProfileStats): string {
       occurredAt: event.occurredAt
     }))
   });
+}
+
+function unversionedSignatureFor(stats: ProfileStats, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(
+      JSON.stringify({
+        createdAt: stats.createdAt,
+        startedUsingAt: stats.startedUsingAt,
+        events: stats.events.map((event) => ({
+          id: event.id,
+          type: event.type,
+          targetID: event.targetID,
+          displayName: event.displayName,
+          channel: event.channel,
+          occurredAt: event.occurredAt
+        }))
+      })
+    )
+    .digest("base64url");
 }
 
 function legacySignatureFor(stats: ProfileStats, secret: string): string {

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -4,7 +4,7 @@
 import { createHmac, randomBytes } from "node:crypto";
 import os from "node:os";
 import type { ProfileStats } from "../shared/domain";
-import { defaultProfileStats, profileStatsSignatureVersion } from "../shared/domain";
+import { defaultProfileStatsAfterTamper, profileStatsSignatureVersion } from "../shared/domain";
 import { runCommand } from "./commandRunner";
 
 export type ProfileStatsIntegrity = {
@@ -42,7 +42,7 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
           "verified"
         );
       }
-      return sealProfileStats(defaultProfileStats(), secret, "resetAfterTamper");
+      return sealProfileStats(defaultProfileStatsAfterTamper(), secret, "resetAfterTamper");
     } catch {
       return { ...stats, integrityStatus: "unavailable" };
     }
@@ -102,6 +102,12 @@ function signatureFor(stats: ProfileStats, secret: string): string {
 }
 
 function normalizeProfileStatsSignature(stats: ProfileStats, secret: string): ProfileStats {
+  if (stats.resetNotice) {
+    if (stats.signatureVersion === profileStatsSignatureVersion) {
+      return { ...stats, integrityStatus: "resetAfterTamper" };
+    }
+    return sealProfileStats(stats, secret, "resetAfterTamper");
+  }
   if (stats.signatureVersion === profileStatsSignatureVersion) {
     return { ...stats, integrityStatus: "verified" };
   }
@@ -120,7 +126,14 @@ function canonicalProfileStats(stats: ProfileStats): string {
       displayName: event.displayName,
       channel: event.channel,
       occurredAt: event.occurredAt
-    }))
+    })),
+    resetNotice: stats.resetNotice
+      ? {
+          id: stats.resetNotice.id,
+          occurredAt: stats.resetNotice.occurredAt,
+          reason: stats.resetNotice.reason
+        }
+      : undefined
   });
 }
 

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { createHmac, randomBytes } from "node:crypto";
+import os from "node:os";
+import type { ProfileStats } from "../shared/domain";
+import { defaultProfileStats } from "../shared/domain";
+import { runCommand } from "./commandRunner";
+
+export type ProfileStatsIntegrity = {
+  verifyOrInitialize(stats: ProfileStats): Promise<ProfileStats>;
+  seal(stats: ProfileStats): Promise<ProfileStats>;
+};
+
+const securityExecutablePath = "/usr/bin/security";
+const serviceName = "Baseline Profile Stats";
+const accountName = os.userInfo().username || "local";
+
+export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
+  async verifyOrInitialize(stats: ProfileStats): Promise<ProfileStats> {
+    try {
+      const secret = await this.keychainSecret();
+      if (!stats.signature) {
+        return sealProfileStats(stats, secret, "verified");
+      }
+      if (signatureFor(stats, secret) === stats.signature) {
+        return { ...stats, integrityStatus: "verified" };
+      }
+      return sealProfileStats(defaultProfileStats(), secret, "resetAfterTamper");
+    } catch {
+      return { ...stats, integrityStatus: "unavailable" };
+    }
+  }
+
+  async seal(stats: ProfileStats): Promise<ProfileStats> {
+    try {
+      return sealProfileStats(stats, await this.keychainSecret(), stats.integrityStatus);
+    } catch {
+      return { ...stats, signature: undefined, integrityStatus: "unavailable" };
+    }
+  }
+
+  private async keychainSecret(): Promise<string> {
+    const existing = await runCommand(securityExecutablePath, [
+      "find-generic-password",
+      "-s",
+      serviceName,
+      "-a",
+      accountName,
+      "-w"
+    ]);
+    const secret = existing.stdout?.trim();
+    if (existing.success && secret) {
+      return secret;
+    }
+
+    const generated = randomBytes(32).toString("base64url");
+    const created = await runCommand(securityExecutablePath, [
+      "add-generic-password",
+      "-s",
+      serviceName,
+      "-a",
+      accountName,
+      "-w",
+      generated,
+      "-U"
+    ]);
+    if (!created.success) {
+      throw new Error("Profile stats Keychain secret could not be created.");
+    }
+    return generated;
+  }
+}
+
+function sealProfileStats(
+  stats: ProfileStats,
+  secret: string,
+  integrityStatus: ProfileStats["integrityStatus"]
+): ProfileStats {
+  const sealed = { ...stats, integrityStatus };
+  return { ...sealed, signature: signatureFor(sealed, secret) };
+}
+
+function signatureFor(stats: ProfileStats, secret: string): string {
+  return createHmac("sha256", secret).update(canonicalProfileStats(stats)).digest("base64url");
+}
+
+function canonicalProfileStats(stats: ProfileStats): string {
+  return JSON.stringify({
+    createdAt: stats.createdAt,
+    events: stats.events.map((event) => ({
+      id: event.id,
+      type: event.type,
+      targetID: event.targetID,
+      displayName: event.displayName,
+      channel: event.channel,
+      occurredAt: event.occurredAt
+    }))
+  });
+}

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -26,6 +26,16 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
       if (signatureFor(stats, secret) === stats.signature) {
         return { ...stats, integrityStatus: "verified" };
       }
+      if (legacySignatureFor(stats, secret) === stats.signature) {
+        return sealProfileStats(
+          {
+            ...stats,
+            startedUsingAt: stats.createdAt
+          },
+          secret,
+          "verified"
+        );
+      }
       return sealProfileStats(defaultProfileStats(), secret, "resetAfterTamper");
     } catch {
       return { ...stats, integrityStatus: "unavailable" };
@@ -98,4 +108,22 @@ function canonicalProfileStats(stats: ProfileStats): string {
       occurredAt: event.occurredAt
     }))
   });
+}
+
+function legacySignatureFor(stats: ProfileStats, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(
+      JSON.stringify({
+        createdAt: stats.createdAt,
+        events: stats.events.map((event) => ({
+          id: event.id,
+          type: event.type,
+          targetID: event.targetID,
+          displayName: event.displayName,
+          channel: event.channel,
+          occurredAt: event.occurredAt
+        }))
+      })
+    )
+    .digest("base64url");
 }

--- a/src/main/profileStatsIntegrity.ts
+++ b/src/main/profileStatsIntegrity.ts
@@ -25,7 +25,7 @@ export class KeychainProfileStatsIntegrity implements ProfileStatsIntegrity {
       const secret = await this.keychainSecret();
       if (!stats.signature) {
         if (stats.events.length > 0) {
-          return { ...stats, integrityStatus: "unavailable" };
+          return sealProfileStats(defaultProfileStatsAfterTamper(), secret, "resetAfterTamper");
         }
         return sealProfileStats(stats, secret, "verified");
       }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1196,9 +1196,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       ...currentProfileStats,
       events: [...newEvents, ...currentProfileStats.events].slice(0, 1000),
       integrityStatus:
-        currentProfileStats.integrityStatus === "resetAfterTamper"
-          ? "resetAfterTamper"
-          : "verified"
+        currentProfileStats.integrityStatus === "resetAfterTamper" ? "resetAfterTamper" : "verified"
     });
     if (sealed.integrityStatus === "unavailable") {
       return { ...currentProfileStats, integrityStatus: "unavailable" };

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -22,6 +22,7 @@ import type {
   UpdateRecord
 } from "../shared/domain";
 import {
+  defaultProfileStatsAfterTamper,
   emptyHomebrewCaskIndex,
   emptyHomebrewFormulaIndex,
   homebrewDiscoverID,
@@ -281,6 +282,15 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     const ignored = new Set(this.state.ignoredHomebrewItemIDs);
     toggleSet(ignored, itemID);
     this.patch({ ignoredHomebrewItemIDs: [...ignored].sort() });
+    await this.persist();
+  }
+
+  async acknowledgeProfileStatsReset(): Promise<void> {
+    const resetID = this.state.profileStats.resetNotice?.id;
+    if (!resetID || this.state.profileStatsResetAcknowledgedID === resetID) {
+      return;
+    }
+    this.patch({ profileStatsResetAcknowledgedID: resetID });
     await this.persist();
   }
 
@@ -1182,10 +1192,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.state.profileStats.signature || this.state.profileStats.events.length === 0
         ? this.state.profileStats
         : {
-            ...this.state.profileStats,
+            ...defaultProfileStatsAfterTamper(),
             events: [],
-            signature: undefined,
-            integrityStatus: "resetAfterTamper" as const
+            signature: undefined
           };
     const eventIDs = new Set(currentProfileStats.events.map((event) => event.id));
     const newEvents = events.filter((event) => !eventIDs.has(event.id));
@@ -1255,6 +1264,7 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     useMasForAppStoreUpdates: snapshot.useMasForAppStoreUpdates,
     showMenuBarIcon: snapshot.showMenuBarIcon,
     profileStats: snapshot.profileStats,
+    profileStatsResetAcknowledgedID: snapshot.profileStatsResetAcknowledgedID,
     lastRefreshDate: snapshot.lastRefreshDate
   };
 }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1178,21 +1178,30 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   private async profileStatsWithEvents(events: ProfileStatsEvent[]): Promise<ProfileStats> {
-    const eventIDs = new Set(this.state.profileStats.events.map((event) => event.id));
+    const currentProfileStats =
+      this.state.profileStats.signature || this.state.profileStats.events.length === 0
+        ? this.state.profileStats
+        : {
+            ...this.state.profileStats,
+            events: [],
+            signature: undefined,
+            integrityStatus: "resetAfterTamper" as const
+          };
+    const eventIDs = new Set(currentProfileStats.events.map((event) => event.id));
     const newEvents = events.filter((event) => !eventIDs.has(event.id));
     if (newEvents.length === 0) {
-      return this.state.profileStats;
+      return currentProfileStats;
     }
     const sealed = await this.profileStatsIntegrity.seal({
-      ...this.state.profileStats,
-      events: [...newEvents, ...this.state.profileStats.events].slice(0, 1000),
+      ...currentProfileStats,
+      events: [...newEvents, ...currentProfileStats.events].slice(0, 1000),
       integrityStatus:
-        this.state.profileStats.integrityStatus === "resetAfterTamper"
+        currentProfileStats.integrityStatus === "resetAfterTamper"
           ? "resetAfterTamper"
           : "verified"
     });
     if (sealed.integrityStatus === "unavailable") {
-      return { ...this.state.profileStats, integrityStatus: "unavailable" };
+      return { ...currentProfileStats, integrityStatus: "unavailable" };
     }
     return sealed;
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1157,7 +1157,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (newEvents.length === 0) {
       return this.state.profileStats;
     }
-    return this.profileStatsIntegrity.seal({
+    const sealed = await this.profileStatsIntegrity.seal({
       ...this.state.profileStats,
       events: [...newEvents, ...this.state.profileStats.events].slice(0, 1000),
       integrityStatus:
@@ -1165,6 +1165,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           ? "resetAfterTamper"
           : "verified"
     });
+    if (sealed.integrityStatus === "unavailable") {
+      return { ...this.state.profileStats, integrityStatus: "unavailable" };
+    }
+    return sealed;
   }
 
   private patch(patch: Partial<BaselineSnapshot>): void {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -97,6 +97,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private latestHomebrewIndex: HomebrewCaskIndex = emptyHomebrewCaskIndex;
   private latestHomebrewFormulaIndex: HomebrewFormulaIndex = emptyHomebrewFormulaIndex;
   private hasCheckedHomebrewAvailability = false;
+  private profileStatsMutationQueue: Promise<void> = Promise.resolve();
 
   private state: BaselineSnapshot;
 
@@ -175,16 +176,18 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   async verifyProfileStatsIntegrity(): Promise<void> {
-    const profileStatsBeforeVerification = this.state.profileStats;
-    const verifiedProfileStats = await this.profileStatsIntegrity.verifyOrInitialize(
-      profileStatsBeforeVerification
-    );
-    const profileStats = await this.reconcileVerifiedProfileStats(
-      profileStatsBeforeVerification,
-      verifiedProfileStats
-    );
-    this.patch({ profileStats });
-    await this.persist();
+    await this.runProfileStatsMutation(async () => {
+      const profileStatsBeforeVerification = this.state.profileStats;
+      const verifiedProfileStats = await this.profileStatsIntegrity.verifyOrInitialize(
+        profileStatsBeforeVerification
+      );
+      const profileStats = await this.reconcileVerifiedProfileStats(
+        profileStatsBeforeVerification,
+        verifiedProfileStats
+      );
+      this.patch({ profileStats });
+      await this.persist();
+    });
   }
 
   async refresh(lightweight = false): Promise<void> {
@@ -1161,9 +1164,17 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   private async recordProfileStatsEvents(events: ProfileStatsEvent[]): Promise<void> {
-    const profileStats = await this.profileStatsWithEvents(events);
-    this.patch({ profileStats });
-    await this.persist();
+    await this.runProfileStatsMutation(async () => {
+      const profileStats = await this.profileStatsWithEvents(events);
+      this.patch({ profileStats });
+      await this.persist();
+    });
+  }
+
+  private async runProfileStatsMutation(operation: () => Promise<void>): Promise<void> {
+    const mutation = this.profileStatsMutationQueue.then(operation, operation);
+    this.profileStatsMutationQueue = mutation.catch(() => undefined);
+    await mutation;
   }
 
   private async profileStatsWithEvents(events: ProfileStatsEvent[]): Promise<ProfileStats> {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -18,7 +18,6 @@ import type {
   PersistedSnapshot,
   ProfileStats,
   ProfileStatsEvent,
-  RecentlyUpdatedRecord,
   SelfUpdateRecord,
   UpdateRecord
 } from "../shared/domain";
@@ -331,6 +330,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           this.patch({
             appUpdatedPendingRefreshIDs: addToArray(this.state.appUpdatedPendingRefreshIDs, appID)
           });
+          await this.recordProfileStatsEvents([
+            appUpdateProfileStatsEvent({
+              appRecord,
+              update,
+              occurredAt: new Date().toISOString()
+            })
+          ]);
           await this.holdSuccessfulUpdate();
           await this.refresh();
         } else {
@@ -410,6 +416,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             [itemID]: 1
           }
         });
+        await this.recordProfileStatsEvents([
+          homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
+        ]);
         await this.holdSuccessfulUpdate();
       } else {
         this.patch({
@@ -530,6 +539,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (!success) {
       this.scheduleHomebrewBatchFailureClear(affectedIDs);
     } else {
+      const occurredAt = new Date().toISOString();
+      await this.recordProfileStatsEvents(
+        affected.map((item) => homebrewUpdateProfileStatsEvent({ item, occurredAt }))
+      );
       await this.holdSuccessfulUpdate();
     }
     await this.refresh();
@@ -764,17 +777,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         reconciledHomebrewItems,
         now
       );
-      const profileStats = await this.profileStatsWithEvents([
-        ...recentlyUpdated.map(appRecentProfileStatsEvent),
-        ...homebrewRecentlyUpdated.map(homebrewRecentProfileStatsEvent)
-      ]);
       this.patch({
         apps,
         updates,
         homebrewItems: reconciledHomebrewItems,
         recentlyUpdated,
         homebrewRecentlyUpdated,
-        profileStats,
         lastRefreshDate: now,
         isRefreshing: false,
         lastRefreshNoticeMessage: homebrewInventory.warning,
@@ -1188,32 +1196,47 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
   };
 }
 
-function appRecentProfileStatsEvent(record: RecentlyUpdatedRecord): ProfileStatsEvent {
+function appUpdateProfileStatsEvent({
+  appRecord,
+  update,
+  occurredAt
+}: {
+  appRecord: AppRecord;
+  update: UpdateRecord;
+  occurredAt: string;
+}): ProfileStatsEvent {
   return {
     id: [
       "appUpdate",
-      record.appID,
-      record.fromVersion.raw,
-      record.toVersion.raw,
-      record.fromBuildVersion?.raw ?? "",
-      record.toBuildVersion?.raw ?? ""
+      appRecord.id,
+      update.localVersion.raw,
+      update.remoteVersion.raw,
+      update.localBuildVersion?.raw ?? "",
+      update.remoteBuildVersion?.raw ?? "",
+      occurredAt
     ].join(":"),
     type: "appUpdate",
-    targetID: record.appID,
-    displayName: record.displayName,
-    channel: profileStatsChannel(record.source),
-    occurredAt: record.updatedAt
+    targetID: appRecord.id,
+    displayName: appRecord.displayName,
+    channel: profileStatsChannel(update.source),
+    occurredAt
   };
 }
 
-function homebrewRecentProfileStatsEvent(record: HomebrewRecentlyUpdatedRecord): ProfileStatsEvent {
+function homebrewUpdateProfileStatsEvent({
+  item,
+  occurredAt
+}: {
+  item: HomebrewManagedItem;
+  occurredAt: string;
+}): ProfileStatsEvent {
   return {
-    id: ["homebrewUpdate", record.itemID, record.fromVersion.raw, record.toVersion.raw].join(":"),
+    id: ["homebrewUpdate", item.id, item.installedVersion.raw, occurredAt].join(":"),
     type: "homebrewUpdate",
-    targetID: record.itemID,
-    displayName: record.displayName,
+    targetID: item.id,
+    displayName: item.name,
     channel: "homebrew",
-    occurredAt: record.updatedAt
+    occurredAt
   };
 }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -175,8 +175,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   async verifyProfileStatsIntegrity(): Promise<void> {
-    const profileStats = await this.profileStatsIntegrity.verifyOrInitialize(
-      this.state.profileStats
+    const profileStatsBeforeVerification = this.state.profileStats;
+    const verifiedProfileStats = await this.profileStatsIntegrity.verifyOrInitialize(
+      profileStatsBeforeVerification
+    );
+    const profileStats = await this.reconcileVerifiedProfileStats(
+      profileStatsBeforeVerification,
+      verifiedProfileStats
     );
     this.patch({ profileStats });
     await this.persist();
@@ -1167,6 +1172,32 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     });
     if (sealed.integrityStatus === "unavailable") {
       return { ...this.state.profileStats, integrityStatus: "unavailable" };
+    }
+    return sealed;
+  }
+
+  private async reconcileVerifiedProfileStats(
+    statsBeforeVerification: ProfileStats,
+    verifiedStats: ProfileStats
+  ): Promise<ProfileStats> {
+    const previousEventIDs = new Set(statsBeforeVerification.events.map((event) => event.id));
+    const currentStats = this.state.profileStats;
+    const concurrentEvents = currentStats.events.filter((event) => !previousEventIDs.has(event.id));
+    if (concurrentEvents.length === 0) {
+      return verifiedStats;
+    }
+
+    const concurrentEventIDs = new Set(concurrentEvents.map((event) => event.id));
+    const profileStats = {
+      ...verifiedStats,
+      events: [
+        ...concurrentEvents,
+        ...verifiedStats.events.filter((event) => !concurrentEventIDs.has(event.id))
+      ].slice(0, 1000)
+    };
+    const sealed = await this.profileStatsIntegrity.seal(profileStats);
+    if (sealed.integrityStatus === "unavailable") {
+      return { ...currentStats, integrityStatus: "unavailable" };
     }
     return sealed;
   }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -533,16 +533,29 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       ["autoremove"],
       ["cleanup"]
     ];
+    const completedItemIDs = new Set<string>();
     let success = true;
     for (const command of sequence) {
       const result = await this.runBrewWithEvents(command, (event) => {
-        this.applyHomebrewProgressEvent(event, parser, affectedByToken);
+        this.applyHomebrewProgressEvent(event, parser, affectedByToken, completedItemIDs);
       });
+      if (result) {
+        const upgradedKind = homebrewUpgradeKindForCommand(command);
+        if (upgradedKind) {
+          for (const item of affected.filter((candidate) => candidate.kind === upgradedKind)) {
+            completedItemIDs.add(item.id);
+          }
+        }
+      }
       if (!result) {
         success = false;
         break;
       }
     }
+    const completedIDs = success
+      ? affectedIDs
+      : affectedIDs.filter((id) => completedItemIDs.has(id));
+    const failedIDs = affectedIDs.filter((id) => !completedItemIDs.has(id));
 
     this.patch({
       isRunningHomebrewMaintenance: false,
@@ -554,23 +567,29 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         : [
             ...new Set([
               ...this.state.homebrewBatchFailedItemIDs,
-              ...affectedIDs.filter(
+              ...failedIDs.filter(
                 (id) => !this.state.homebrewUpdatedPendingRefreshItemIDs.includes(id)
               )
             ])
           ],
-      homebrewUpdatedPendingRefreshItemIDs: success
-        ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...affectedIDs])]
-        : this.state.homebrewUpdatedPendingRefreshItemIDs,
+      homebrewUpdatedPendingRefreshItemIDs:
+        completedIDs.length > 0
+          ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...completedIDs])]
+          : this.state.homebrewUpdatedPendingRefreshItemIDs,
       refreshErrorMessage: success ? undefined : "Homebrew maintenance cycle failed."
     });
     if (!success) {
-      this.scheduleHomebrewBatchFailureClear(affectedIDs);
-    } else {
+      this.scheduleHomebrewBatchFailureClear(failedIDs);
+    }
+    if (completedIDs.length > 0) {
       const occurredAt = new Date().toISOString();
       await this.recordProfileStatsEvents(
-        affected.map((item) => homebrewUpdateProfileStatsEvent({ item, occurredAt }))
+        affected
+          .filter((item) => completedIDs.includes(item.id))
+          .map((item) => homebrewUpdateProfileStatsEvent({ item, occurredAt }))
       );
+    }
+    if (success) {
       await this.holdSuccessfulUpdate();
     }
     await this.refresh();
@@ -935,7 +954,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private applyHomebrewProgressEvent(
     event: HomebrewMaintenanceRunEvent,
     parser: HomebrewMaintenanceOutputParser,
-    affectedByToken: Map<string, string[]>
+    affectedByToken: Map<string, string[]>,
+    completedItemIDs?: Set<string>
   ): void {
     if (event.type === "commandStarted") {
       return;
@@ -959,6 +979,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
               homebrewBatchFailedItemIDs: addToArray(this.state.homebrewBatchFailedItemIDs, id)
             });
           } else {
+            completedItemIDs?.add(id);
             this.patch({
               homebrewBatchProgressByItemID: {
                 ...this.state.homebrewBatchProgressByItemID,
@@ -1323,6 +1344,14 @@ function homebrewInstallProfileStatsEvent(item: HomebrewCaskDiscoveryItem): Prof
     channel: "homebrew",
     occurredAt
   };
+}
+
+function homebrewUpgradeKindForCommand(command: string[]): HomebrewManagedItemKind | undefined {
+  const normalized = command.map((part) => part.toLowerCase());
+  if (normalized[0] !== "upgrade") {
+    return undefined;
+  }
+  return normalized.includes("--cask") || normalized.includes("--casks") ? "cask" : "formula";
 }
 
 function profileStatsChannel(

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -502,6 +502,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         item.id
       ]);
     }
+    const affectedKindByID = new Map(affected.map((item) => [item.id, item.kind]));
 
     this.patch({
       isRunningHomebrewMaintenance: true,
@@ -537,7 +538,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     let success = true;
     for (const command of sequence) {
       const result = await this.runBrewWithEvents(command, (event) => {
-        this.applyHomebrewProgressEvent(event, parser, affectedByToken, completedItemIDs);
+        this.applyHomebrewProgressEvent(
+          event,
+          parser,
+          affectedByToken,
+          affectedKindByID,
+          completedItemIDs
+        );
       });
       if (result) {
         const upgradedKind = homebrewUpgradeKindForCommand(command);
@@ -955,6 +962,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     event: HomebrewMaintenanceRunEvent,
     parser: HomebrewMaintenanceOutputParser,
     affectedByToken: Map<string, string[]>,
+    affectedKindByID?: Map<string, HomebrewManagedItemKind>,
     completedItemIDs?: Set<string>
   ): void {
     if (event.type === "commandStarted") {
@@ -962,7 +970,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     }
     if (event.type === "outputLine") {
       for (const parsed of parser.parse(event.line, event.command)) {
-        const ids = affectedByToken.get(parsed.token) ?? [];
+        const ids = (affectedByToken.get(parsed.token) ?? []).filter(
+          (id) =>
+            !parsed.kindHint || !affectedKindByID || affectedKindByID.get(id) === parsed.kindHint
+        );
         for (const id of ids) {
           if (parsed.kind.type === "progress") {
             this.patch({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -16,6 +16,9 @@ import type {
   HomebrewRecentlyUpdatedRecord,
   MenuTab,
   PersistedSnapshot,
+  ProfileStats,
+  ProfileStatsEvent,
+  RecentlyUpdatedRecord,
   SelfUpdateRecord,
   UpdateRecord
 } from "../shared/domain";
@@ -56,6 +59,7 @@ import { HomebrewCaskClient } from "./homebrewCaskClient";
 import { HomebrewFormulaClient } from "./homebrewFormulaClient";
 import { HomebrewInventoryClient, type HomebrewInventoryResult } from "./homebrewInventoryClient";
 import { SnapshotPersistence } from "./persistence";
+import { KeychainProfileStatsIntegrity, type ProfileStatsIntegrity } from "./profileStatsIntegrity";
 import { SelfUpdateClient } from "./selfUpdateClient";
 import { SparkleAppcastClient } from "./sparkleAppcastClient";
 
@@ -84,6 +88,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   private readonly runMasCommand: typeof defaultRunMasCommand;
   private readonly openExternalURL: (url: string) => Promise<boolean>;
   private readonly openAppBundle: (bundlePath: string) => Promise<void>;
+  private readonly profileStatsIntegrity: ProfileStatsIntegrity;
   private readonly successRefreshDelayMS: number;
   private refreshTask?: Promise<void>;
   private refreshSequence = 0;
@@ -113,6 +118,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     currentAppVersion?: string;
     runBrewCommand?: typeof defaultRunBrewCommand;
     runMasCommand?: typeof defaultRunMasCommand;
+    profileStatsIntegrity?: ProfileStatsIntegrity;
     successRefreshDelayMS?: number;
   }) {
     super();
@@ -129,6 +135,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     this.runMasCommand = options.runMasCommand ?? defaultRunMasCommand;
     this.openExternalURL = options.openExternalURL;
     this.openAppBundle = options.openAppBundle;
+    this.profileStatsIntegrity =
+      options.profileStatsIntegrity ?? new KeychainProfileStatsIntegrity();
     this.successRefreshDelayMS = options.successRefreshDelayMS ?? successfulUpdateHoldMs;
     this.state = {
       ...options.persisted,
@@ -165,6 +173,14 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   getSnapshot(): BaselineSnapshot {
     return structuredClone(this.state);
+  }
+
+  async verifyProfileStatsIntegrity(): Promise<void> {
+    const profileStats = await this.profileStatsIntegrity.verifyOrInitialize(
+      this.state.profileStats
+    );
+    this.patch({ profileStats });
+    await this.persist();
   }
 
   async refresh(lightweight = false): Promise<void> {
@@ -574,6 +590,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (success) {
       this.hasCheckedHomebrewAvailability = true;
       this.patch({ isHomebrewInstalled: true });
+      await this.recordProfileStatsEvents([homebrewInstallProfileStatsEvent(item)]);
       await this.holdSuccessfulUpdate();
       await this.refresh();
     } else {
@@ -747,12 +764,17 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         reconciledHomebrewItems,
         now
       );
+      const profileStats = await this.profileStatsWithEvents([
+        ...recentlyUpdated.map(appRecentProfileStatsEvent),
+        ...homebrewRecentlyUpdated.map(homebrewRecentProfileStatsEvent)
+      ]);
       this.patch({
         apps,
         updates,
         homebrewItems: reconciledHomebrewItems,
         recentlyUpdated,
         homebrewRecentlyUpdated,
+        profileStats,
         lastRefreshDate: now,
         isRefreshing: false,
         lastRefreshNoticeMessage: homebrewInventory.warning,
@@ -1115,6 +1137,28 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     await this.persistence.save(snapshotForPersistence(this.state));
   }
 
+  private async recordProfileStatsEvents(events: ProfileStatsEvent[]): Promise<void> {
+    const profileStats = await this.profileStatsWithEvents(events);
+    this.patch({ profileStats });
+    await this.persist();
+  }
+
+  private async profileStatsWithEvents(events: ProfileStatsEvent[]): Promise<ProfileStats> {
+    const eventIDs = new Set(this.state.profileStats.events.map((event) => event.id));
+    const newEvents = events.filter((event) => !eventIDs.has(event.id));
+    if (newEvents.length === 0) {
+      return this.state.profileStats;
+    }
+    return this.profileStatsIntegrity.seal({
+      ...this.state.profileStats,
+      events: [...newEvents, ...this.state.profileStats.events].slice(0, 1000),
+      integrityStatus:
+        this.state.profileStats.integrityStatus === "resetAfterTamper"
+          ? "resetAfterTamper"
+          : "verified"
+    });
+  }
+
   private patch(patch: Partial<BaselineSnapshot>): void {
     this.state = { ...this.state, ...patch };
     this.emit("snapshot", this.getSnapshot());
@@ -1139,8 +1183,65 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     appearancePreference: snapshot.appearancePreference,
     useMasForAppStoreUpdates: snapshot.useMasForAppStoreUpdates,
     showMenuBarIcon: snapshot.showMenuBarIcon,
+    profileStats: snapshot.profileStats,
     lastRefreshDate: snapshot.lastRefreshDate
   };
+}
+
+function appRecentProfileStatsEvent(record: RecentlyUpdatedRecord): ProfileStatsEvent {
+  return {
+    id: [
+      "appUpdate",
+      record.appID,
+      record.fromVersion.raw,
+      record.toVersion.raw,
+      record.fromBuildVersion?.raw ?? "",
+      record.toBuildVersion?.raw ?? ""
+    ].join(":"),
+    type: "appUpdate",
+    targetID: record.appID,
+    displayName: record.displayName,
+    channel: profileStatsChannel(record.source),
+    occurredAt: record.updatedAt
+  };
+}
+
+function homebrewRecentProfileStatsEvent(record: HomebrewRecentlyUpdatedRecord): ProfileStatsEvent {
+  return {
+    id: ["homebrewUpdate", record.itemID, record.fromVersion.raw, record.toVersion.raw].join(":"),
+    type: "homebrewUpdate",
+    targetID: record.itemID,
+    displayName: record.displayName,
+    channel: "homebrew",
+    occurredAt: record.updatedAt
+  };
+}
+
+function homebrewInstallProfileStatsEvent(item: HomebrewCaskDiscoveryItem): ProfileStatsEvent {
+  const occurredAt = new Date().toISOString();
+  return {
+    id: ["homebrewInstall", item.id, item.version.raw, occurredAt].join(":"),
+    type: "homebrewInstall",
+    targetID: item.id,
+    displayName: item.displayName,
+    channel: "homebrew",
+    occurredAt
+  };
+}
+
+function profileStatsChannel(
+  source: UpdateRecord["source"] | undefined
+): ProfileStatsEvent["channel"] {
+  if (
+    source === "appStore" ||
+    source === "sparkle" ||
+    source === "homebrew" ||
+    source === "web" ||
+    source === "unknown"
+  ) {
+    return source;
+  }
+  return "unknown";
 }
 
 function homebrewCaskPageURL(token: string): string | undefined {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -360,7 +360,13 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       }
       const item = this.matchingHomebrewItemForApp(appRecord);
       if (item) {
-        await this.performHomebrewItemUpdate(item);
+        await this.performHomebrewItemUpdate(item, {
+          profileStatsEvent: appUpdateProfileStatsEvent({
+            appRecord,
+            update,
+            occurredAt: new Date().toISOString()
+          })
+        });
         return;
       }
       if (requiresHomebrewOwnershipProof(appRecord)) {
@@ -385,7 +391,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     await this.performHomebrewItemUpdate(item);
   }
 
-  private async performHomebrewItemUpdate(item: HomebrewManagedItem): Promise<void> {
+  private async performHomebrewItemUpdate(
+    item: HomebrewManagedItem,
+    options: { profileStatsEvent?: ProfileStatsEvent } = {}
+  ): Promise<void> {
     if (!isValidHomebrewToken(item.token)) {
       return;
     }
@@ -422,7 +431,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           }
         });
         await this.recordProfileStatsEvents([
-          homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
+          options.profileStatsEvent ??
+            homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
         ]);
         await this.holdSuccessfulUpdate();
       } else {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -39,6 +39,8 @@ import type {
   HomebrewCaskDiscoveryItem,
   HomebrewManagedItem,
   MenuTab,
+  ProfileStatsChannel,
+  ProfileStatsEvent,
   RecentlyUpdatedRecord,
   UpdateRecord
 } from "../shared/domain";
@@ -72,7 +74,7 @@ type RowUpdateMenuAction = {
   disabled?: boolean;
   onAction: () => void;
 };
-type SettingsSectionID = "general" | "appearance" | "diagnostics";
+type SettingsSectionID = "general" | "profile" | "appearance" | "diagnostics";
 
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
@@ -83,6 +85,7 @@ const settingsSidebarItems: Array<{
   icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
 }> = [
   { id: "general", label: "General", icon: Settings },
+  { id: "profile", label: "Profile", icon: CheckCircle2 },
   { id: "appearance", label: "Appearance", icon: Monitor },
   { id: "diagnostics", label: "Diagnostics", icon: Terminal }
 ];
@@ -2602,6 +2605,8 @@ function SettingsPane({
           </section>
         </>
       );
+    case "profile":
+      return <ProfileSection snapshot={snapshot} />;
     case "appearance":
       return (
         <>
@@ -2666,6 +2671,82 @@ function SettingsPane({
         </>
       );
   }
+}
+
+function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
+  const profile = useMemo(() => buildProfileSummary(snapshot), [snapshot]);
+  return (
+    <section className="panel settings-panel">
+      <PanelTitle title="Profile" />
+      <div className="settings-panel-box profile-panel-box">
+        <div className="profile-stat-grid">
+          <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
+          <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
+          <ProfileMetric label="Using Baseline for" value={profile.daysTrackedLabel} />
+          <ProfileMetric label="Freshness" value={profile.freshnessLabel} />
+        </div>
+        <div className="settings-row settings-row-action">
+          <SettingsRowText
+            label="Favorite channel"
+            description={profile.favoriteChannelDescription}
+          />
+          <strong className="settings-row-value">{profile.favoriteChannelLabel}</strong>
+        </div>
+        <div className="settings-row profile-source-row">
+          <SettingsRowText label="Source mix" description="Updates and installs by source." />
+          <div className="profile-source-list">
+            {profile.sourceMix.map((source) => (
+              <div className="profile-source-item" key={source.channel}>
+                <span>{source.label}</span>
+                <div className="profile-source-meter" aria-hidden="true">
+                  <span style={{ width: `${source.percent}%` }} />
+                </div>
+                <strong>{source.count}</strong>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="settings-row profile-top-apps-row">
+          <SettingsRowText label="Most updated apps" description={profile.topAppsDescription} />
+          {profile.topApps.length > 0 && (
+            <ol className="profile-top-app-list">
+              {profile.topApps.map((app) => (
+                <li key={app.targetID}>
+                  <span>{app.displayName}</span>
+                  <strong>{app.count}</strong>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+        <div className="settings-row settings-row-action">
+          <SettingsRowText
+            label="Private stats"
+            description="Stored only on this Mac and sealed with a local Keychain secret when available."
+          />
+          <span
+            className={
+              profile.integrityStatus === "Verified"
+                ? "settings-status-label enabled"
+                : "settings-status-label muted"
+            }
+          >
+            <span className="settings-status-glyph" aria-hidden="true" />
+            <span>{profile.integrityStatus}</span>
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProfileMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="profile-metric">
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
 }
 
 type TogglePatch = Exclude<
@@ -2949,6 +3030,126 @@ function ToolStatus({
       </span>
     </div>
   );
+}
+
+type ProfileSummary = {
+  appUpdates: number;
+  totalUpdates: number;
+  daysTrackedLabel: string;
+  favoriteChannelLabel: string;
+  favoriteChannelDescription: string;
+  freshnessLabel: string;
+  sourceMix: Array<{
+    channel: ProfileStatsChannel;
+    label: string;
+    count: number;
+    percent: number;
+  }>;
+  topApps: Array<{ targetID: string; displayName: string; count: number }>;
+  topAppsDescription: string;
+  integrityStatus: string;
+};
+
+function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
+  const events = snapshot.profileStats.events;
+  const sourceMix = buildProfileSourceMix(events);
+  const favorite = sourceMix.reduce((best, item) => (item.count > best.count ? item : best));
+  const topApps = buildTopUpdatedApps(events);
+  const totalUpdates = events.filter(
+    (event) => event.type === "appUpdate" || event.type === "homebrewUpdate"
+  ).length;
+  const favoriteChannelLabel = favorite.count > 0 ? favorite.label : "No history yet";
+  return {
+    appUpdates: events.filter((event) => event.type === "appUpdate").length,
+    totalUpdates,
+    daysTrackedLabel: daysTrackedLabel(snapshot.profileStats.createdAt),
+    favoriteChannelLabel,
+    favoriteChannelDescription:
+      favorite.count > 0
+        ? `${favorite.count} profile event${favorite.count === 1 ? "" : "s"} from ${favorite.label}.`
+        : "Update history starts after Baseline sees an app or Homebrew item update.",
+    freshnessLabel: freshnessLabel(snapshot),
+    sourceMix,
+    topApps,
+    topAppsDescription:
+      topApps.length > 0
+        ? "Apps with the most locally recorded updates."
+        : "App rankings appear after Baseline records app version changes.",
+    integrityStatus: profileIntegrityLabel(snapshot.profileStats.integrityStatus)
+  };
+}
+
+function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sourceMix"] {
+  const channels: ProfileStatsChannel[] = ["appStore", "sparkle", "homebrew", "web", "unknown"];
+  const counts = new Map<ProfileStatsChannel, number>(channels.map((channel) => [channel, 0]));
+  for (const event of events) {
+    counts.set(event.channel, (counts.get(event.channel) ?? 0) + 1);
+  }
+  const total = Math.max(1, events.length);
+  return channels
+    .map((channel) => ({
+      channel,
+      label: sourceDisplayName(channel),
+      count: counts.get(channel) ?? 0,
+      percent: Math.round(((counts.get(channel) ?? 0) / total) * 100)
+    }))
+    .sort((first, second) => second.count - first.count || first.label.localeCompare(second.label));
+}
+
+function buildTopUpdatedApps(events: ProfileStatsEvent[]): ProfileSummary["topApps"] {
+  const counts = new Map<string, { targetID: string; displayName: string; count: number }>();
+  for (const event of events) {
+    if (event.type !== "appUpdate") {
+      continue;
+    }
+    const current = counts.get(event.targetID);
+    counts.set(event.targetID, {
+      targetID: event.targetID,
+      displayName: event.displayName,
+      count: (current?.count ?? 0) + 1
+    });
+  }
+  return [...counts.values()]
+    .sort(
+      (first, second) =>
+        second.count - first.count || first.displayName.localeCompare(second.displayName)
+    )
+    .slice(0, 5);
+}
+
+function daysTrackedLabel(createdAt: string): string {
+  const created = new Date(createdAt).getTime();
+  if (!Number.isFinite(created)) {
+    return "1 day";
+  }
+  const days = Math.max(1, Math.floor((Date.now() - created) / 86_400_000) + 1);
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+function freshnessLabel(snapshot: BaselineSnapshot): string {
+  const trackedCount = snapshot.apps.length + snapshot.homebrewItems.length;
+  if (trackedCount === 0) {
+    return "No apps yet";
+  }
+  const outdatedCount =
+    snapshot.updates.length + snapshot.homebrewItems.filter((item) => item.isOutdated).length;
+  const freshCount = Math.max(0, trackedCount - outdatedCount);
+  return `${Math.round((freshCount / trackedCount) * 100)}%`;
+}
+
+function profileIntegrityLabel(
+  status: BaselineSnapshot["profileStats"]["integrityStatus"]
+): string {
+  if (status === "verified") {
+    return "Verified";
+  }
+  if (status === "resetAfterTamper") {
+    return "Reset";
+  }
+  if (status === "unavailable") {
+    return "Not sealed";
+  }
+  return "Checking";
 }
 
 function sourceLabel(update: UpdateRecord): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2678,6 +2678,9 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   const profile = useMemo(() => buildProfileSummary(snapshot), [snapshot]);
   const activeSourceMix = profile.sourceMix.filter((source) => source.count > 0);
   const sourceMixTotal = profile.sourceMix.reduce((total, source) => total + source.count, 0);
+  const resetNotice = snapshot.profileStats.resetNotice;
+  const shouldShowResetWarning =
+    Boolean(resetNotice) && snapshot.profileStatsResetAcknowledgedID !== resetNotice?.id;
   return (
     <div className="profile-page">
       <div className="profile-stack">
@@ -2830,12 +2833,20 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
       </div>
       <section className="panel settings-panel profile-footer-panel">
         <div className="settings-panel-box">
-          {snapshot.profileStats.integrityStatus === "resetAfterTamper" && (
-            <div className="settings-row profile-warning-row">
+          {shouldShowResetWarning && (
+            <div className="settings-row settings-row-action profile-warning-row">
               <SettingsRowText
                 label="Stats were reset"
                 description="Baseline could not verify the local stats history, so it started a fresh one on this Mac."
               />
+              <button
+                className="toolbar-button"
+                onClick={() => void window.baseline.acknowledgeProfileStatsReset()}
+                title="Dismiss"
+                aria-label="Dismiss stats reset warning"
+              >
+                <X size={15} />
+              </button>
             </div>
           )}
           <div className="settings-row profile-footer-row">

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2687,7 +2687,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             <div className="profile-stat-grid">
               <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-              <ProfileMetric label="Current apps up to date" value={profile.freshnessLabel} />
+              <ProfileMetric label="Apps up to date" value={profile.freshnessLabel} />
               <ProfileMetric
                 label="Started using Baseline"
                 value={profile.startedUsing.relativeLabel}
@@ -2695,36 +2695,46 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                 title={profile.startedUsing.title}
               />
             </div>
-            <div className="settings-row settings-row-action">
-              <SettingsRowText label="Favorite channel" />
-              <strong
-                className="settings-row-value profile-channel-pill"
-                title={`Most recorded source: ${profile.favoriteChannelLabel}`}
-              >
-                {profile.favoriteChannel && (
-                  <span
-                    className={`profile-source-dot ${profileSourceClass(profile.favoriteChannel)}`}
-                    aria-hidden="true"
-                  />
-                )}
-                {profile.favoriteChannelLabel}
-              </strong>
-            </div>
           </div>
         </section>
-        <section className="panel settings-panel">
-          <PanelTitle title="Source mix" />
+        <section className="panel settings-panel profile-source-section">
+          <PanelTitle
+            title="Source mix"
+            action={
+              <span className="profile-favorite-source">
+                <span>Favorite source</span>
+                <strong className="settings-row-value profile-channel-pill">
+                  {profile.favoriteChannel && (
+                    <span
+                      className={`profile-source-dot ${profileSourceClass(profile.favoriteChannel)}`}
+                      aria-hidden="true"
+                    />
+                  )}
+                  {profile.favoriteChannelLabel}
+                </strong>
+              </span>
+            }
+          />
           <div className="settings-panel-box profile-source-panel-box">
             {activeSourceMix.length > 0 ? (
               <div className="profile-source-list">
-                <div className="profile-source-bar" aria-hidden="true">
+                <div
+                  className="profile-source-bar"
+                  aria-label={activeSourceMix
+                    .map((source) => profileSourceShareLabel(source, sourceMixTotal))
+                    .join(", ")}
+                  role="img"
+                >
                   {activeSourceMix.map((source) => (
                     <span
                       className={`profile-source-segment ${profileSourceClass(source.channel)}`}
                       key={source.channel}
                       style={{ flexGrow: source.count }}
-                      title={profileSourceShareLabel(source, sourceMixTotal)}
-                    />
+                    >
+                      <span className="profile-source-tooltip" aria-hidden="true">
+                        {profileSourcePercentLabel(source, sourceMixTotal)}
+                      </span>
+                    </span>
                   ))}
                 </div>
                 <div className="profile-source-legend">
@@ -2732,7 +2742,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                     <div
                       className="profile-source-chip"
                       key={source.channel}
-                      title={profileSourceShareLabel(source, sourceMixTotal)}
+                      aria-label={profileSourceShareLabel(source, sourceMixTotal)}
                     >
                       <span
                         className={`profile-source-dot ${profileSourceClass(source.channel)}`}
@@ -2745,7 +2755,9 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                 </div>
               </div>
             ) : (
-              <p className="profile-empty-state">No update source history yet.</p>
+              <p className="profile-empty-state">
+                Update or install something with Baseline to build a source history.
+              </p>
             )}
           </div>
         </section>
@@ -2786,7 +2798,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                 ))}
               </ol>
             ) : (
-              <p className="profile-empty-state">No updated apps yet.</p>
+              <p className="profile-empty-state">Apps you update with Baseline will appear here.</p>
             )}
           </div>
         </section>
@@ -3179,6 +3191,16 @@ function profileSourceShareLabel(
   }
   const percent = Math.round((source.count / total) * 100);
   return `${source.label}: ${source.count} event${source.count === 1 ? "" : "s"} (${percent}%)`;
+}
+
+function profileSourcePercentLabel(
+  source: ProfileSummary["sourceMix"][number],
+  total: number
+): string {
+  if (total <= 0) {
+    return `${source.label} 0%`;
+  }
+  return `${source.label} ${Math.round((source.count / total) * 100)}%`;
 }
 
 function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sourceMix"] {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2688,7 +2688,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             <div className="profile-stat-grid">
               <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-              <ProfileMetric label="Tracked for" value={profile.daysTrackedLabel} />
+              <ProfileMetric label="Using Baseline since" value={profile.startedUsingLabel} />
               <ProfileMetric label="Up to date" value={profile.freshnessLabel} />
             </div>
             <div className="settings-row settings-row-action">
@@ -3099,7 +3099,7 @@ function ToolStatus({
 type ProfileSummary = {
   appUpdates: number;
   totalUpdates: number;
-  daysTrackedLabel: string;
+  startedUsingLabel: string;
   favoriteChannelLabel: string;
   favoriteChannel?: ProfileStatsChannel;
   freshnessLabel: string;
@@ -3130,7 +3130,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   return {
     appUpdates: events.filter((event) => event.type === "appUpdate").length,
     totalUpdates,
-    daysTrackedLabel: daysTrackedLabel(snapshot.profileStats.createdAt),
+    startedUsingLabel: startedUsingLabel(snapshot.profileStats.createdAt),
     favoriteChannelLabel,
     favoriteChannel,
     freshnessLabel: freshnessLabel(snapshot),
@@ -3205,13 +3205,22 @@ function buildTopUpdatedApps(
     .map((app, index) => ({ ...app, rank: index + 1 }));
 }
 
-function daysTrackedLabel(createdAt: string): string {
+function startedUsingLabel(createdAt: string): string {
   const created = new Date(createdAt).getTime();
   if (!Number.isFinite(created)) {
-    return "1 day";
+    return "Today";
   }
-  const days = Math.max(1, Math.floor((Date.now() - created) / 86_400_000) + 1);
-  return `${days} day${days === 1 ? "" : "s"}`;
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: new Date(created).getFullYear() === new Date().getFullYear() ? undefined : "numeric"
+  });
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  if (created >= startOfToday.getTime()) {
+    return "Today";
+  }
+  return formatter.format(new Date(created));
 }
 
 function freshnessLabel(snapshot: BaselineSnapshot): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2761,7 +2761,9 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                       app.count === 1 ? "" : "s"
                     }`}
                   >
-                    <span className="profile-top-app-rank">{app.rank}</span>
+                    <span className={`profile-top-app-rank profile-top-app-rank-${app.rank}`}>
+                      {app.rank}
+                    </span>
                     <span
                       className={
                         app.iconDataURL ? "profile-top-app-icon has-image" : "profile-top-app-icon"

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2711,8 +2711,23 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
               <ol className="profile-top-app-list">
                 {profile.topApps.map((app) => (
                   <li key={app.targetID}>
-                    <span>{app.displayName}</span>
-                    <strong>{app.count}</strong>
+                    <span className="profile-top-app-rank">{app.rank}</span>
+                    <span
+                      className={
+                        app.iconDataURL ? "profile-top-app-icon has-image" : "profile-top-app-icon"
+                      }
+                      aria-hidden="true"
+                    >
+                      {app.iconDataURL ? (
+                        <img src={app.iconDataURL} alt="" draggable={false} />
+                      ) : (
+                        app.displayName.slice(0, 1).toUpperCase()
+                      )}
+                    </span>
+                    <span className="profile-top-app-name">{app.displayName}</span>
+                    <strong>
+                      {app.count} update{app.count === 1 ? "" : "s"}
+                    </strong>
                   </li>
                 ))}
               </ol>
@@ -3045,14 +3060,20 @@ type ProfileSummary = {
     count: number;
     percent: number;
   }>;
-  topApps: Array<{ targetID: string; displayName: string; count: number }>;
+  topApps: Array<{
+    targetID: string;
+    displayName: string;
+    count: number;
+    iconDataURL?: string;
+    rank: number;
+  }>;
 };
 
 function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   const events = snapshot.profileStats.events;
   const sourceMix = buildProfileSourceMix(events);
   const favorite = sourceMix.reduce((best, item) => (item.count > best.count ? item : best));
-  const topApps = buildTopUpdatedApps(events);
+  const topApps = buildTopUpdatedApps(events, snapshot.apps);
   const totalUpdates = events.filter(
     (event) => event.type === "appUpdate" || event.type === "homebrewUpdate"
   ).length;
@@ -3085,17 +3106,27 @@ function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sou
     .sort((first, second) => second.count - first.count || first.label.localeCompare(second.label));
 }
 
-function buildTopUpdatedApps(events: ProfileStatsEvent[]): ProfileSummary["topApps"] {
-  const counts = new Map<string, { targetID: string; displayName: string; count: number }>();
+function buildTopUpdatedApps(
+  events: ProfileStatsEvent[],
+  apps: AppRecord[]
+): ProfileSummary["topApps"] {
+  const appByID = new Map(apps.map((app) => [app.id, app]));
+  const counts = new Map<
+    string,
+    { targetID: string; displayName: string; count: number; iconDataURL?: string; rank: number }
+  >();
   for (const event of events) {
     if (event.type !== "appUpdate") {
       continue;
     }
     const current = counts.get(event.targetID);
+    const app = appByID.get(event.targetID);
     counts.set(event.targetID, {
       targetID: event.targetID,
-      displayName: event.displayName,
-      count: (current?.count ?? 0) + 1
+      displayName: app?.displayName ?? event.displayName,
+      count: (current?.count ?? 0) + 1,
+      iconDataURL: app?.iconDataURL,
+      rank: 0
     });
   }
   return [...counts.values()]
@@ -3103,7 +3134,8 @@ function buildTopUpdatedApps(events: ProfileStatsEvent[]): ProfileSummary["topAp
       (first, second) =>
         second.count - first.count || first.displayName.localeCompare(second.displayName)
     )
-    .slice(0, 5);
+    .slice(0, 3)
+    .map((app, index) => ({ ...app, rank: index + 1 }));
 }
 
 function daysTrackedLabel(createdAt: string): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2678,7 +2678,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   const profile = useMemo(() => buildProfileSummary(snapshot), [snapshot]);
   return (
     <section className="panel settings-panel">
-      <PanelTitle title="Profile" />
+      <PanelTitle title="Stats" />
       <div className="settings-panel-box profile-panel-box">
         <div className="profile-stat-grid">
           <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2687,13 +2687,13 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             <div className="profile-stat-grid">
               <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
+              <ProfileMetric label="Current apps up to date" value={profile.freshnessLabel} />
               <ProfileMetric
                 label="Started using Baseline"
                 value={profile.startedUsing.relativeLabel}
                 detail={profile.startedUsing.dateLabel}
                 title={profile.startedUsing.title}
               />
-              <ProfileMetric label="Current apps up to date" value={profile.freshnessLabel} />
             </div>
             <div className="settings-row settings-row-action">
               <SettingsRowText label="Favorite channel" />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2677,7 +2677,6 @@ function SettingsPane({
 function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   const profile = useMemo(() => buildProfileSummary(snapshot), [snapshot]);
   const activeSourceMix = profile.sourceMix.filter((source) => source.count > 0);
-  const displayedSourceMix = activeSourceMix.length > 0 ? activeSourceMix : profile.sourceMix;
   const sourceMixTotal = profile.sourceMix.reduce((total, source) => total + source.count, 0);
   return (
     <div className="profile-page">
@@ -2694,7 +2693,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                 detail={profile.startedUsing.dateLabel}
                 title={profile.startedUsing.title}
               />
-              <ProfileMetric label="Up to date" value={profile.freshnessLabel} />
+              <ProfileMetric label="Current apps up to date" value={profile.freshnessLabel} />
             </div>
             <div className="settings-row settings-row-action">
               <SettingsRowText label="Favorite channel" />
@@ -2716,44 +2715,44 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
         <section className="panel settings-panel">
           <PanelTitle title="Source mix" />
           <div className="settings-panel-box profile-source-panel-box">
-            <div className="profile-source-list">
-              <div className="profile-source-bar" aria-hidden="true">
-                {activeSourceMix.length > 0 ? (
-                  activeSourceMix.map((source) => (
+            {activeSourceMix.length > 0 ? (
+              <div className="profile-source-list">
+                <div className="profile-source-bar" aria-hidden="true">
+                  {activeSourceMix.map((source) => (
                     <span
                       className={`profile-source-segment ${profileSourceClass(source.channel)}`}
                       key={source.channel}
                       style={{ flexGrow: source.count }}
                       title={profileSourceShareLabel(source, sourceMixTotal)}
                     />
-                  ))
-                ) : (
-                  <span className="profile-source-empty" />
-                )}
+                  ))}
+                </div>
+                <div className="profile-source-legend">
+                  {activeSourceMix.map((source) => (
+                    <div
+                      className="profile-source-chip"
+                      key={source.channel}
+                      title={profileSourceShareLabel(source, sourceMixTotal)}
+                    >
+                      <span
+                        className={`profile-source-dot ${profileSourceClass(source.channel)}`}
+                        aria-hidden="true"
+                      />
+                      <span>{source.label}</span>
+                      <strong>{source.count}</strong>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div className="profile-source-legend">
-                {displayedSourceMix.map((source) => (
-                  <div
-                    className="profile-source-chip"
-                    key={source.channel}
-                    title={profileSourceShareLabel(source, sourceMixTotal)}
-                  >
-                    <span
-                      className={`profile-source-dot ${profileSourceClass(source.channel)}`}
-                      aria-hidden="true"
-                    />
-                    <span>{source.label}</span>
-                    <strong>{source.count}</strong>
-                  </div>
-                ))}
-              </div>
-            </div>
+            ) : (
+              <p className="profile-empty-state">No update source history yet.</p>
+            )}
           </div>
         </section>
         <section className="panel settings-panel">
           <PanelTitle title="Most updated apps" />
           <div className="settings-panel-box profile-top-apps-panel-box">
-            {profile.topApps.length > 0 && (
+            {profile.topApps.length > 0 ? (
               <ol className="profile-top-app-list">
                 {profile.topApps.map((app) => (
                   <li
@@ -2784,6 +2783,8 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                   </li>
                 ))}
               </ol>
+            ) : (
+              <p className="profile-empty-state">No updated apps yet.</p>
             )}
           </div>
         </section>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2698,7 +2698,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           <div className="settings-panel-box profile-panel-box">
             <div className="profile-stat-grid">
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-              <ProfileMetric label="Different apps" value={String(profile.differentApps)} />
+              <ProfileMetric label="Unique apps" value={String(profile.differentApps)} />
               <ProfileMetric label="Installs" value={String(profile.discoverInstalls)} />
               <ProfileMetric label="Favorite source" value={profile.favoriteChannelLabel} />
             </div>
@@ -2806,8 +2806,8 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           )}
           <div className="settings-row profile-footer-row">
             <span className="profile-footer-text">
-              Stats only count updates and installs completed with Baseline. They are private and
-              stored only on this Mac.
+              Only updates and installs completed with Baseline are counted. Stats stay private on
+              this Mac.
             </span>
           </div>
         </div>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -10,6 +10,7 @@ import {
   Beer,
   Check,
   CheckCircle2,
+  CircleUserRound,
   ChevronRight,
   Download,
   Eye,
@@ -85,7 +86,7 @@ const settingsSidebarItems: Array<{
   icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
 }> = [
   { id: "general", label: "General", icon: Settings },
-  { id: "profile", label: "Profile", icon: CheckCircle2 },
+  { id: "profile", label: "Profile", icon: CircleUserRound },
   { id: "appearance", label: "Appearance", icon: Monitor },
   { id: "diagnostics", label: "Diagnostics", icon: Terminal }
 ];

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2793,6 +2793,40 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             )}
           </div>
         </section>
+        <section className="panel settings-panel">
+          <PanelTitle title="Most updated tools" />
+          <div className="settings-panel-box profile-top-apps-panel-box">
+            {profile.topHomebrewItems.length > 0 ? (
+              <ol className="profile-top-app-list profile-top-tool-list">
+                {profile.topHomebrewItems.map((item) => (
+                  <li
+                    key={item.targetID}
+                    title={`${item.displayName}: #${item.rank} with ${item.count} update${
+                      item.count === 1 ? "" : "s"
+                    }`}
+                  >
+                    <span className={`profile-top-app-rank profile-top-app-rank-${item.rank}`}>
+                      {item.rank}
+                    </span>
+                    <span className="profile-top-app-icon profile-top-tool-icon" aria-hidden="true">
+                      <Terminal size={29} strokeWidth={2.2} />
+                    </span>
+                    <span className="profile-top-app-name" title={item.displayName}>
+                      {item.displayName}
+                    </span>
+                    <strong>
+                      {item.count} update{item.count === 1 ? "" : "s"} · {item.kindLabel}
+                    </strong>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="profile-empty-state">
+                Tools you update with Baseline will appear here.
+              </p>
+            )}
+          </div>
+        </section>
       </div>
       <section className="panel settings-panel profile-footer-panel">
         <div className="settings-panel-box">
@@ -3142,6 +3176,13 @@ type ProfileSummary = {
     iconDataURL?: string;
     rank: number;
   }>;
+  topHomebrewItems: Array<{
+    targetID: string;
+    displayName: string;
+    count: number;
+    kindLabel: string;
+    rank: number;
+  }>;
 };
 
 function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
@@ -3149,6 +3190,12 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   const sourceMix = buildProfileSourceMix(events);
   const favorite = sourceMix.reduce((best, item) => (item.count > best.count ? item : best));
   const topApps = buildTopUpdatedApps(events, snapshot.apps);
+  const topHomebrewItems = buildTopUpdatedHomebrewItems(
+    events,
+    snapshot.homebrewItems,
+    snapshot.apps,
+    snapshot.updates
+  );
   const totalUpdates = events.filter(
     (event) => event.type === "appUpdate" || event.type === "homebrewUpdate"
   ).length;
@@ -3166,7 +3213,8 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     favoriteChannelLabel,
     favoriteChannel,
     sourceMix,
-    topApps
+    topApps,
+    topHomebrewItems
   };
 }
 
@@ -3244,6 +3292,84 @@ function buildTopUpdatedApps(
     )
     .slice(0, 3)
     .map((app, index) => ({ ...app, rank: index + 1 }));
+}
+
+function buildTopUpdatedHomebrewItems(
+  events: ProfileStatsEvent[],
+  homebrewItems: HomebrewManagedItem[],
+  apps: AppRecord[],
+  updates: UpdateRecord[]
+): ProfileSummary["topHomebrewItems"] {
+  const itemsByID = new Map(homebrewItems.map((item) => [item.id, item]));
+  const updatesByAppID = new Map(updates.map((update) => [update.appID, update]));
+  const counts = new Map<
+    string,
+    {
+      targetID: string;
+      displayName: string;
+      count: number;
+      kindLabel: string;
+      rank: number;
+    }
+  >();
+  for (const event of events) {
+    if (event.type !== "homebrewUpdate") {
+      continue;
+    }
+    const item = itemsByID.get(event.targetID);
+    if (!isProfileHomebrewToolEvent(event, item, apps, updatesByAppID)) {
+      continue;
+    }
+    const current = counts.get(event.targetID);
+    counts.set(event.targetID, {
+      targetID: event.targetID,
+      displayName: item?.name ?? event.displayName,
+      count: (current?.count ?? 0) + 1,
+      kindLabel: profileHomebrewKindLabel(event, item),
+      rank: 0
+    });
+  }
+  return [...counts.values()]
+    .sort(
+      (first, second) =>
+        second.count - first.count || first.displayName.localeCompare(second.displayName)
+    )
+    .slice(0, 3)
+    .map((item, index) => ({ ...item, rank: index + 1 }));
+}
+
+function isProfileHomebrewToolEvent(
+  event: ProfileStatsEvent,
+  item: HomebrewManagedItem | undefined,
+  apps: AppRecord[],
+  updatesByAppID: Map<string, UpdateRecord>
+): boolean {
+  if (item?.kind === "formula" || event.targetID.startsWith("formula:")) {
+    return true;
+  }
+  if (!item) {
+    return false;
+  }
+  if (homebrewItemHasAppRepresentation(item, apps, updatesByAppID)) {
+    return false;
+  }
+  if (item.presentation === "app") {
+    return false;
+  }
+  return Boolean(item.presentation);
+}
+
+function profileHomebrewKindLabel(
+  event: ProfileStatsEvent,
+  item: HomebrewManagedItem | undefined
+): string {
+  if (item?.presentation) {
+    return homebrewPresentationLabel(item.kind, item.presentation);
+  }
+  if (item?.kind === "formula" || event.targetID.startsWith("formula:")) {
+    return "Formula";
+  }
+  return "Tool";
 }
 
 function startedUsingSummary(createdAt: string): ProfileSummary["startedUsing"] {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2724,7 +2724,9 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                         app.displayName.slice(0, 1).toUpperCase()
                       )}
                     </span>
-                    <span className="profile-top-app-name">{app.displayName}</span>
+                    <span className="profile-top-app-name" title={app.displayName}>
+                      {app.displayName}
+                    </span>
                     <strong>
                       {app.count} update{app.count === 1 ? "" : "s"}
                     </strong>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2684,15 +2684,17 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   return (
     <div className="profile-page">
       <div className="profile-stack">
-        <section className="panel settings-panel">
-          <PanelTitle title="Time with Baseline" />
+        <section className="panel settings-panel profile-start-section">
           <div
             className="settings-panel-box profile-start-panel-box"
             title={profile.startedUsing.title}
           >
             <div className="profile-start-summary">
-              <strong>{profile.startedUsing.relativeLabel}</strong>
-              <span>{profile.startedUsing.dateLabel}</span>
+              <strong>
+                <span className="profile-start-value">{profile.startedUsing.relativeLabel}</span>
+                <span className="profile-start-unit">with Baseline</span>
+              </strong>
+              <span className="profile-start-date">{profile.startedUsing.dateLabel}</span>
             </div>
           </div>
         </section>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2697,14 +2697,10 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           <PanelTitle title="Stats" />
           <div className="settings-panel-box profile-panel-box">
             <div className="profile-stat-grid">
-              <ProfileMetric label="Different apps" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-              <ProfileMetric label="Apps up to date" value={profile.freshnessLabel} />
-              <ProfileSourceMetric
-                channel={profile.favoriteChannel}
-                label="Favorite source"
-                value={profile.favoriteChannelLabel}
-              />
+              <ProfileMetric label="Different apps" value={String(profile.differentApps)} />
+              <ProfileMetric label="Installs" value={String(profile.discoverInstalls)} />
+              <ProfileMetric label="Favorite source" value={profile.favoriteChannelLabel} />
             </div>
           </div>
         </section>
@@ -2810,37 +2806,12 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           )}
           <div className="settings-row profile-footer-row">
             <span className="profile-footer-text">
-              Stats only count apps updated with Baseline. They are private and stored only on this
-              Mac.
+              Stats only count updates and installs completed with Baseline. They are private and
+              stored only on this Mac.
             </span>
           </div>
         </div>
       </section>
-    </div>
-  );
-}
-
-function ProfileSourceMetric({
-  label,
-  value,
-  channel
-}: {
-  label: string;
-  value: string;
-  channel?: ProfileStatsChannel;
-}) {
-  return (
-    <div className="profile-metric">
-      <strong className="profile-source-metric-value">
-        {channel && (
-          <span
-            className={`profile-source-dot ${profileSourceClass(channel)}`}
-            aria-hidden="true"
-          />
-        )}
-        {value}
-      </strong>
-      <span>{label}</span>
     </div>
   );
 }
@@ -3149,7 +3120,8 @@ function ToolStatus({
 }
 
 type ProfileSummary = {
-  appUpdates: number;
+  differentApps: number;
+  discoverInstalls: number;
   totalUpdates: number;
   startedUsing: {
     relativeLabel: string;
@@ -3158,7 +3130,6 @@ type ProfileSummary = {
   };
   favoriteChannelLabel: string;
   favoriteChannel?: ProfileStatsChannel;
-  freshnessLabel: string;
   sourceMix: Array<{
     channel: ProfileStatsChannel;
     label: string;
@@ -3181,15 +3152,19 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   const totalUpdates = events.filter(
     (event) => event.type === "appUpdate" || event.type === "homebrewUpdate"
   ).length;
+  const differentApps = new Set(
+    events.filter((event) => event.type === "appUpdate").map((event) => event.targetID)
+  ).size;
+  const discoverInstalls = events.filter((event) => event.type === "homebrewInstall").length;
   const favoriteChannelLabel = favorite.count > 0 ? favorite.label : "No history yet";
   const favoriteChannel = favorite.count > 0 ? favorite.channel : undefined;
   return {
-    appUpdates: events.filter((event) => event.type === "appUpdate").length,
+    differentApps,
+    discoverInstalls,
     totalUpdates,
     startedUsing: startedUsingSummary(snapshot.profileStats.startedUsingAt),
     favoriteChannelLabel,
     favoriteChannel,
-    freshnessLabel: freshnessLabel(snapshot),
     sourceMix,
     topApps
   };
@@ -3302,17 +3277,6 @@ function startedUsingSummary(createdAt: string): ProfileSummary["startedUsing"] 
     dateLabel: `Since ${exactDate}`,
     title: `Started using Baseline on ${exactDate}`
   };
-}
-
-function freshnessLabel(snapshot: BaselineSnapshot): string {
-  const trackedCount = snapshot.apps.length + snapshot.homebrewItems.length;
-  if (trackedCount === 0) {
-    return "No apps yet";
-  }
-  const outdatedCount =
-    snapshot.updates.length + snapshot.homebrewItems.filter((item) => item.isOutdated).length;
-  const freshCount = Math.max(0, trackedCount - outdatedCount);
-  return `${Math.round((freshCount / trackedCount) * 100)}%`;
 }
 
 function sourceLabel(update: UpdateRecord): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2688,11 +2688,11 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             <ProfileMetric label="Freshness" value={profile.freshnessLabel} />
           </div>
           <div className="settings-row settings-row-action">
-            <SettingsRowText label="Favorite channel" description="Most recorded update source." />
+            <SettingsRowText label="Favorite channel" />
             <strong className="settings-row-value">{profile.favoriteChannelLabel}</strong>
           </div>
           <div className="settings-row profile-source-row">
-            <SettingsRowText label="Source mix" description="Updates and installs by source." />
+            <SettingsRowText label="Source mix" />
             <div className="profile-source-list">
               {profile.sourceMix.map((source) => (
                 <div className="profile-source-item" key={source.channel}>
@@ -2706,7 +2706,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             </div>
           </div>
           <div className="settings-row profile-top-apps-row">
-            <SettingsRowText label="Most updated apps" description={profile.topAppsDescription} />
+            <SettingsRowText label="Most updated apps" />
             {profile.topApps.length > 0 && (
               <ol className="profile-top-app-list">
                 {profile.topApps.map((app) => (
@@ -2913,13 +2913,13 @@ function SettingsRowText({
   secondaryDescription
 }: {
   label: string;
-  description: string;
+  description?: string;
   secondaryDescription?: string;
 }) {
   return (
     <span className="settings-row-text">
       <span>{label}</span>
-      <span className="settings-row-subtext">{description}</span>
+      {description && <span className="settings-row-subtext">{description}</span>}
       {secondaryDescription && <span className="settings-row-subtext">{secondaryDescription}</span>}
     </span>
   );
@@ -3046,7 +3046,6 @@ type ProfileSummary = {
     percent: number;
   }>;
   topApps: Array<{ targetID: string; displayName: string; count: number }>;
-  topAppsDescription: string;
 };
 
 function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
@@ -3065,11 +3064,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     favoriteChannelLabel,
     freshnessLabel: freshnessLabel(snapshot),
     sourceMix,
-    topApps,
-    topAppsDescription:
-      topApps.length > 0
-        ? "Apps with the most locally recorded updates."
-        : "App rankings appear after Baseline records app version changes."
+    topApps
   };
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2688,7 +2688,12 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             <div className="profile-stat-grid">
               <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-              <ProfileMetric label="Using Baseline since" value={profile.startedUsingLabel} />
+              <ProfileMetric
+                label="Started using Baseline"
+                value={profile.startedUsing.relativeLabel}
+                detail={profile.startedUsing.dateLabel}
+                title={profile.startedUsing.title}
+              />
               <ProfileMetric label="Up to date" value={profile.freshnessLabel} />
             </div>
             <div className="settings-row settings-row-action">
@@ -2804,11 +2809,22 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   );
 }
 
-function ProfileMetric({ label, value }: { label: string; value: string }) {
+function ProfileMetric({
+  label,
+  value,
+  detail,
+  title
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  title?: string;
+}) {
   return (
-    <div className="profile-metric">
+    <div className="profile-metric" title={title}>
       <strong>{value}</strong>
       <span>{label}</span>
+      {detail && <small className="profile-metric-detail">{detail}</small>}
     </div>
   );
 }
@@ -3099,7 +3115,11 @@ function ToolStatus({
 type ProfileSummary = {
   appUpdates: number;
   totalUpdates: number;
-  startedUsingLabel: string;
+  startedUsing: {
+    relativeLabel: string;
+    dateLabel: string;
+    title: string;
+  };
   favoriteChannelLabel: string;
   favoriteChannel?: ProfileStatsChannel;
   freshnessLabel: string;
@@ -3130,7 +3150,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   return {
     appUpdates: events.filter((event) => event.type === "appUpdate").length,
     totalUpdates,
-    startedUsingLabel: startedUsingLabel(snapshot.profileStats.createdAt),
+    startedUsing: startedUsingSummary(snapshot.profileStats.startedUsingAt),
     favoriteChannelLabel,
     favoriteChannel,
     freshnessLabel: freshnessLabel(snapshot),
@@ -3205,22 +3225,37 @@ function buildTopUpdatedApps(
     .map((app, index) => ({ ...app, rank: index + 1 }));
 }
 
-function startedUsingLabel(createdAt: string): string {
+function startedUsingSummary(createdAt: string): ProfileSummary["startedUsing"] {
   const created = new Date(createdAt).getTime();
   if (!Number.isFinite(created)) {
-    return "Today";
+    return {
+      relativeLabel: "Today",
+      dateLabel: "Since today",
+      title: "Started using Baseline today"
+    };
   }
-  const formatter = new Intl.DateTimeFormat(undefined, {
+  const createdDate = new Date(created);
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
     month: "short",
     day: "numeric",
-    year: new Date(created).getFullYear() === new Date().getFullYear() ? undefined : "numeric"
+    year: "numeric"
   });
+  const exactDate = dateFormatter.format(createdDate);
+  const startOfCreatedDay = new Date(createdDate);
+  startOfCreatedDay.setHours(0, 0, 0, 0);
   const startOfToday = new Date();
   startOfToday.setHours(0, 0, 0, 0);
-  if (created >= startOfToday.getTime()) {
-    return "Today";
-  }
-  return formatter.format(new Date(created));
+  const elapsedDays = Math.max(
+    0,
+    Math.floor((startOfToday.getTime() - startOfCreatedDay.getTime()) / 86_400_000)
+  );
+  const relativeLabel =
+    elapsedDays === 0 ? "Today" : `${elapsedDays} day${elapsedDays === 1 ? "" : "s"}`;
+  return {
+    relativeLabel,
+    dateLabel: `Since ${exactDate}`,
+    title: `Started using Baseline on ${exactDate}`
+  };
 }
 
 function freshnessLabel(snapshot: BaselineSnapshot): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2682,39 +2682,34 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
     <div className="profile-page">
       <div className="profile-stack">
         <section className="panel settings-panel">
+          <PanelTitle title="Time with Baseline" />
+          <div
+            className="settings-panel-box profile-start-panel-box"
+            title={profile.startedUsing.title}
+          >
+            <div className="profile-start-summary">
+              <strong>{profile.startedUsing.relativeLabel}</strong>
+              <span>{profile.startedUsing.dateLabel}</span>
+            </div>
+          </div>
+        </section>
+        <section className="panel settings-panel">
           <PanelTitle title="Stats" />
           <div className="settings-panel-box profile-panel-box">
             <div className="profile-stat-grid">
               <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
               <ProfileMetric label="Apps up to date" value={profile.freshnessLabel} />
-              <ProfileMetric
-                label="Started using Baseline"
-                value={profile.startedUsing.relativeLabel}
-                detail={profile.startedUsing.dateLabel}
-                title={profile.startedUsing.title}
+              <ProfileSourceMetric
+                channel={profile.favoriteChannel}
+                label="Favorite source"
+                value={profile.favoriteChannelLabel}
               />
             </div>
           </div>
         </section>
         <section className="panel settings-panel profile-source-section">
-          <PanelTitle
-            title="Source mix"
-            action={
-              <span className="profile-favorite-source">
-                <span>Favorite source</span>
-                <strong className="settings-row-value profile-channel-pill">
-                  {profile.favoriteChannel && (
-                    <span
-                      className={`profile-source-dot ${profileSourceClass(profile.favoriteChannel)}`}
-                      aria-hidden="true"
-                    />
-                  )}
-                  {profile.favoriteChannelLabel}
-                </strong>
-              </span>
-            }
-          />
+          <PanelTitle title="Source mix" />
           <div className="settings-panel-box profile-source-panel-box">
             {activeSourceMix.length > 0 ? (
               <div className="profile-source-list">
@@ -2820,6 +2815,31 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           </div>
         </div>
       </section>
+    </div>
+  );
+}
+
+function ProfileSourceMetric({
+  label,
+  value,
+  channel
+}: {
+  label: string;
+  value: string;
+  channel?: ProfileStatsChannel;
+}) {
+  return (
+    <div className="profile-metric">
+      <strong className="profile-source-metric-value">
+        {channel && (
+          <span
+            className={`profile-source-dot ${profileSourceClass(channel)}`}
+            aria-hidden="true"
+          />
+        )}
+        {value}
+      </strong>
+      <span>{label}</span>
     </div>
   );
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2676,41 +2676,87 @@ function SettingsPane({
 
 function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   const profile = useMemo(() => buildProfileSummary(snapshot), [snapshot]);
+  const activeSourceMix = profile.sourceMix.filter((source) => source.count > 0);
+  const displayedSourceMix = activeSourceMix.length > 0 ? activeSourceMix : profile.sourceMix;
+  const sourceMixTotal = profile.sourceMix.reduce((total, source) => total + source.count, 0);
   return (
     <div className="profile-page">
-      <section className="panel settings-panel">
-        <PanelTitle title="Stats" />
-        <div className="settings-panel-box profile-panel-box">
-          <div className="profile-stat-grid">
-            <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
-            <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-            <ProfileMetric label="Using Baseline for" value={profile.daysTrackedLabel} />
-            <ProfileMetric label="Freshness" value={profile.freshnessLabel} />
-          </div>
-          <div className="settings-row settings-row-action">
-            <SettingsRowText label="Favorite channel" />
-            <strong className="settings-row-value">{profile.favoriteChannelLabel}</strong>
-          </div>
-          <div className="settings-row profile-source-row">
-            <SettingsRowText label="Source mix" />
-            <div className="profile-source-list">
-              {profile.sourceMix.map((source) => (
-                <div className="profile-source-item" key={source.channel}>
-                  <span>{source.label}</span>
-                  <div className="profile-source-meter" aria-hidden="true">
-                    <span style={{ width: `${source.percent}%` }} />
-                  </div>
-                  <strong>{source.count}</strong>
-                </div>
-              ))}
+      <div className="profile-stack">
+        <section className="panel settings-panel">
+          <PanelTitle title="Stats" />
+          <div className="settings-panel-box profile-panel-box">
+            <div className="profile-stat-grid">
+              <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
+              <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
+              <ProfileMetric label="Tracked for" value={profile.daysTrackedLabel} />
+              <ProfileMetric label="Up to date" value={profile.freshnessLabel} />
+            </div>
+            <div className="settings-row settings-row-action">
+              <SettingsRowText label="Favorite channel" />
+              <strong
+                className="settings-row-value profile-channel-pill"
+                title={`Most recorded source: ${profile.favoriteChannelLabel}`}
+              >
+                {profile.favoriteChannel && (
+                  <span
+                    className={`profile-source-dot ${profileSourceClass(profile.favoriteChannel)}`}
+                    aria-hidden="true"
+                  />
+                )}
+                {profile.favoriteChannelLabel}
+              </strong>
             </div>
           </div>
-          <div className="settings-row profile-top-apps-row">
-            <SettingsRowText label="Most updated apps" />
+        </section>
+        <section className="panel settings-panel">
+          <PanelTitle title="Source mix" />
+          <div className="settings-panel-box profile-source-panel-box">
+            <div className="profile-source-list">
+              <div className="profile-source-bar" aria-hidden="true">
+                {activeSourceMix.length > 0 ? (
+                  activeSourceMix.map((source) => (
+                    <span
+                      className={`profile-source-segment ${profileSourceClass(source.channel)}`}
+                      key={source.channel}
+                      style={{ flexGrow: source.count }}
+                      title={profileSourceShareLabel(source, sourceMixTotal)}
+                    />
+                  ))
+                ) : (
+                  <span className="profile-source-empty" />
+                )}
+              </div>
+              <div className="profile-source-legend">
+                {displayedSourceMix.map((source) => (
+                  <div
+                    className="profile-source-chip"
+                    key={source.channel}
+                    title={profileSourceShareLabel(source, sourceMixTotal)}
+                  >
+                    <span
+                      className={`profile-source-dot ${profileSourceClass(source.channel)}`}
+                      aria-hidden="true"
+                    />
+                    <span>{source.label}</span>
+                    <strong>{source.count}</strong>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+        <section className="panel settings-panel">
+          <PanelTitle title="Most updated apps" />
+          <div className="settings-panel-box profile-top-apps-panel-box">
             {profile.topApps.length > 0 && (
               <ol className="profile-top-app-list">
                 {profile.topApps.map((app) => (
-                  <li key={app.targetID}>
+                  <li
+                    key={app.targetID}
+                    title={`${app.displayName}: #${app.rank} with ${app.count} update${
+                      app.count === 1 ? "" : "s"
+                    }`}
+                  >
                     <span className="profile-top-app-rank">{app.rank}</span>
                     <span
                       className={
@@ -2735,8 +2781,8 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
               </ol>
             )}
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
       <section className="panel settings-panel profile-footer-panel">
         <div className="settings-panel-box">
           {snapshot.profileStats.integrityStatus === "resetAfterTamper" && (
@@ -3055,12 +3101,12 @@ type ProfileSummary = {
   totalUpdates: number;
   daysTrackedLabel: string;
   favoriteChannelLabel: string;
+  favoriteChannel?: ProfileStatsChannel;
   freshnessLabel: string;
   sourceMix: Array<{
     channel: ProfileStatsChannel;
     label: string;
     count: number;
-    percent: number;
   }>;
   topApps: Array<{
     targetID: string;
@@ -3080,15 +3126,36 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     (event) => event.type === "appUpdate" || event.type === "homebrewUpdate"
   ).length;
   const favoriteChannelLabel = favorite.count > 0 ? favorite.label : "No history yet";
+  const favoriteChannel = favorite.count > 0 ? favorite.channel : undefined;
   return {
     appUpdates: events.filter((event) => event.type === "appUpdate").length,
     totalUpdates,
     daysTrackedLabel: daysTrackedLabel(snapshot.profileStats.createdAt),
     favoriteChannelLabel,
+    favoriteChannel,
     freshnessLabel: freshnessLabel(snapshot),
     sourceMix,
     topApps
   };
+}
+
+function profileSourceClass(channel: ProfileStatsChannel): string {
+  if (channel === "appStore") return "source-app-store";
+  if (channel === "sparkle") return "source-sparkle";
+  if (channel === "homebrew") return "source-homebrew";
+  if (channel === "web") return "source-web";
+  return "source-unknown";
+}
+
+function profileSourceShareLabel(
+  source: ProfileSummary["sourceMix"][number],
+  total: number
+): string {
+  if (total <= 0) {
+    return `${source.label}: no recorded events`;
+  }
+  const percent = Math.round((source.count / total) * 100);
+  return `${source.label}: ${source.count} event${source.count === 1 ? "" : "s"} (${percent}%)`;
 }
 
 function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sourceMix"] {
@@ -3097,13 +3164,11 @@ function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sou
   for (const event of events) {
     counts.set(event.channel, (counts.get(event.channel) ?? 0) + 1);
   }
-  const total = Math.max(1, events.length);
   return channels
     .map((channel) => ({
       channel,
       label: sourceDisplayName(channel),
-      count: counts.get(channel) ?? 0,
-      percent: Math.round(((counts.get(channel) ?? 0) / total) * 100)
+      count: counts.get(channel) ?? 0
     }))
     .sort((first, second) => second.count - first.count || first.label.localeCompare(second.label));
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2697,7 +2697,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           <PanelTitle title="Stats" />
           <div className="settings-panel-box profile-panel-box">
             <div className="profile-stat-grid">
-              <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
+              <ProfileMetric label="Different apps" value={String(profile.appUpdates)} />
               <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
               <ProfileMetric label="Apps up to date" value={profile.freshnessLabel} />
               <ProfileSourceMetric

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2677,67 +2677,70 @@ function SettingsPane({
 function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
   const profile = useMemo(() => buildProfileSummary(snapshot), [snapshot]);
   return (
-    <section className="panel settings-panel">
-      <PanelTitle title="Stats" />
-      <div className="settings-panel-box profile-panel-box">
-        <div className="profile-stat-grid">
-          <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
-          <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
-          <ProfileMetric label="Using Baseline for" value={profile.daysTrackedLabel} />
-          <ProfileMetric label="Freshness" value={profile.freshnessLabel} />
-        </div>
-        <div className="settings-row settings-row-action">
-          <SettingsRowText
-            label="Favorite channel"
-            description={profile.favoriteChannelDescription}
-          />
-          <strong className="settings-row-value">{profile.favoriteChannelLabel}</strong>
-        </div>
-        <div className="settings-row profile-source-row">
-          <SettingsRowText label="Source mix" description="Updates and installs by source." />
-          <div className="profile-source-list">
-            {profile.sourceMix.map((source) => (
-              <div className="profile-source-item" key={source.channel}>
-                <span>{source.label}</span>
-                <div className="profile-source-meter" aria-hidden="true">
-                  <span style={{ width: `${source.percent}%` }} />
+    <div className="profile-page">
+      <section className="panel settings-panel">
+        <PanelTitle title="Stats" />
+        <div className="settings-panel-box profile-panel-box">
+          <div className="profile-stat-grid">
+            <ProfileMetric label="Apps updated" value={String(profile.appUpdates)} />
+            <ProfileMetric label="Total updates" value={String(profile.totalUpdates)} />
+            <ProfileMetric label="Using Baseline for" value={profile.daysTrackedLabel} />
+            <ProfileMetric label="Freshness" value={profile.freshnessLabel} />
+          </div>
+          <div className="settings-row settings-row-action">
+            <SettingsRowText
+              label="Favorite channel"
+              description={profile.favoriteChannelDescription}
+            />
+            <strong className="settings-row-value">{profile.favoriteChannelLabel}</strong>
+          </div>
+          <div className="settings-row profile-source-row">
+            <SettingsRowText label="Source mix" description="Updates and installs by source." />
+            <div className="profile-source-list">
+              {profile.sourceMix.map((source) => (
+                <div className="profile-source-item" key={source.channel}>
+                  <span>{source.label}</span>
+                  <div className="profile-source-meter" aria-hidden="true">
+                    <span style={{ width: `${source.percent}%` }} />
+                  </div>
+                  <strong>{source.count}</strong>
                 </div>
-                <strong>{source.count}</strong>
-              </div>
-            ))}
+              ))}
+            </div>
+          </div>
+          <div className="settings-row profile-top-apps-row">
+            <SettingsRowText label="Most updated apps" description={profile.topAppsDescription} />
+            {profile.topApps.length > 0 && (
+              <ol className="profile-top-app-list">
+                {profile.topApps.map((app) => (
+                  <li key={app.targetID}>
+                    <span>{app.displayName}</span>
+                    <strong>{app.count}</strong>
+                  </li>
+                ))}
+              </ol>
+            )}
           </div>
         </div>
-        <div className="settings-row profile-top-apps-row">
-          <SettingsRowText label="Most updated apps" description={profile.topAppsDescription} />
-          {profile.topApps.length > 0 && (
-            <ol className="profile-top-app-list">
-              {profile.topApps.map((app) => (
-                <li key={app.targetID}>
-                  <span>{app.displayName}</span>
-                  <strong>{app.count}</strong>
-                </li>
-              ))}
-            </ol>
+      </section>
+      <section className="panel settings-panel profile-footer-panel">
+        <div className="settings-panel-box">
+          {snapshot.profileStats.integrityStatus === "resetAfterTamper" && (
+            <div className="settings-row profile-warning-row">
+              <SettingsRowText
+                label="Stats were reset"
+                description="Baseline could not verify the local stats history, so it started a fresh one on this Mac."
+              />
+            </div>
           )}
+          <div className="settings-row profile-footer-row">
+            <span className="profile-footer-text">
+              Stats are private and stored only on this Mac.
+            </span>
+          </div>
         </div>
-        <div className="settings-row settings-row-action">
-          <SettingsRowText
-            label="Private stats"
-            description="Stored only on this Mac and sealed with a local Keychain secret when available."
-          />
-          <span
-            className={
-              profile.integrityStatus === "Verified"
-                ? "settings-status-label enabled"
-                : "settings-status-label muted"
-            }
-          >
-            <span className="settings-status-glyph" aria-hidden="true" />
-            <span>{profile.integrityStatus}</span>
-          </span>
-        </div>
-      </div>
-    </section>
+      </section>
+    </div>
   );
 }
 
@@ -3048,7 +3051,6 @@ type ProfileSummary = {
   }>;
   topApps: Array<{ targetID: string; displayName: string; count: number }>;
   topAppsDescription: string;
-  integrityStatus: string;
 };
 
 function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
@@ -3075,8 +3077,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     topAppsDescription:
       topApps.length > 0
         ? "Apps with the most locally recorded updates."
-        : "App rankings appear after Baseline records app version changes.",
-    integrityStatus: profileIntegrityLabel(snapshot.profileStats.integrityStatus)
+        : "App rankings appear after Baseline records app version changes."
   };
 }
 
@@ -3136,21 +3137,6 @@ function freshnessLabel(snapshot: BaselineSnapshot): string {
     snapshot.updates.length + snapshot.homebrewItems.filter((item) => item.isOutdated).length;
   const freshCount = Math.max(0, trackedCount - outdatedCount);
   return `${Math.round((freshCount / trackedCount) * 100)}%`;
-}
-
-function profileIntegrityLabel(
-  status: BaselineSnapshot["profileStats"]["integrityStatus"]
-): string {
-  if (status === "verified") {
-    return "Verified";
-  }
-  if (status === "resetAfterTamper") {
-    return "Reset";
-  }
-  if (status === "unavailable") {
-    return "Not sealed";
-  }
-  return "Checking";
 }
 
 function sourceLabel(update: UpdateRecord): string {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2688,10 +2688,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             <ProfileMetric label="Freshness" value={profile.freshnessLabel} />
           </div>
           <div className="settings-row settings-row-action">
-            <SettingsRowText
-              label="Favorite channel"
-              description={profile.favoriteChannelDescription}
-            />
+            <SettingsRowText label="Favorite channel" description="Most recorded update source." />
             <strong className="settings-row-value">{profile.favoriteChannelLabel}</strong>
           </div>
           <div className="settings-row profile-source-row">
@@ -3041,7 +3038,6 @@ type ProfileSummary = {
   totalUpdates: number;
   daysTrackedLabel: string;
   favoriteChannelLabel: string;
-  favoriteChannelDescription: string;
   freshnessLabel: string;
   sourceMix: Array<{
     channel: ProfileStatsChannel;
@@ -3067,10 +3063,6 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     totalUpdates,
     daysTrackedLabel: daysTrackedLabel(snapshot.profileStats.createdAt),
     favoriteChannelLabel,
-    favoriteChannelDescription:
-      favorite.count > 0
-        ? `${favorite.count} profile event${favorite.count === 1 ? "" : "s"} from ${favorite.label}.`
-        : "Update history starts after Baseline sees an app or Homebrew item update.",
     freshnessLabel: freshnessLabel(snapshot),
     sourceMix,
     topApps,

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2810,7 +2810,8 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           )}
           <div className="settings-row profile-footer-row">
             <span className="profile-footer-text">
-              Stats are private and stored only on this Mac.
+              Stats only count apps updated with Baseline. They are private and stored only on this
+              Mac.
             </span>
           </div>
         </div>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3156,7 +3156,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     events.filter((event) => event.type === "appUpdate").map((event) => event.targetID)
   ).size;
   const discoverInstalls = events.filter((event) => event.type === "homebrewInstall").length;
-  const favoriteChannelLabel = favorite.count > 0 ? favorite.label : "No history yet";
+  const favoriteChannelLabel = favorite.count > 0 ? favorite.label : "No history";
   const favoriteChannel = favorite.count > 0 ? favorite.channel : undefined;
   return {
     differentApps,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1521,6 +1521,14 @@ button:disabled {
   line-height: 1.25;
 }
 
+.profile-metric-detail {
+  color: rgba(60, 60, 67, 0.44);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 .profile-source-list,
 .profile-top-app-list {
   display: grid;
@@ -1982,6 +1990,7 @@ button:disabled {
   .empty,
   .settings-row-subtext,
   .profile-metric span,
+  .profile-metric-detail,
   .profile-source-chip,
   .profile-top-app-list li {
     color: rgba(235, 235, 245, 0.5);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1539,8 +1539,7 @@ button:disabled {
   padding: 0;
 }
 
-.profile-source-item,
-.profile-top-app-list li {
+.profile-source-item {
   display: grid;
   grid-template-columns: minmax(76px, 0.42fr) minmax(80px, 1fr) minmax(24px, auto);
   align-items: center;
@@ -1549,8 +1548,7 @@ button:disabled {
   font-size: 12px;
 }
 
-.profile-source-item strong,
-.profile-top-app-list strong {
+.profile-source-item strong {
   color: #1c1c1e;
   font-size: 12px;
   font-weight: 600;
@@ -1574,7 +1572,7 @@ button:disabled {
 .profile-top-app-list {
   list-style: none;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  gap: 12px;
 }
 
 .profile-top-app-list li {
@@ -1583,21 +1581,24 @@ button:disabled {
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
   align-content: start;
-  gap: 7px;
+  gap: 9px;
   min-width: 0;
-  min-height: 116px;
-  padding: 12px 8px 10px;
+  min-height: 132px;
+  padding: 17px 12px 14px;
   border: 0.5px solid rgba(60, 60, 67, 0.1);
-  border-radius: 8px;
-  background: rgba(60, 60, 67, 0.035);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(60, 60, 67, 0.028));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.78),
+    0 1px 2px rgba(0, 0, 0, 0.03);
   text-align: center;
 }
 
 .profile-top-app-name {
   max-width: 100%;
   color: #1c1c1e;
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: 600;
   line-height: 1.2;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1605,28 +1606,30 @@ button:disabled {
 }
 
 .profile-top-app-list strong {
-  color: rgba(60, 60, 67, 0.56);
+  color: rgba(60, 60, 67, 0.52);
   font-size: 11px;
   font-weight: 500;
+  line-height: 1.25;
   text-align: center;
 }
 
 .profile-top-app-icon {
   display: grid;
   place-items: center;
-  width: 46px;
-  height: 46px;
-  border-radius: 11px;
+  width: 62px;
+  height: 62px;
+  border-radius: 15px;
   overflow: hidden;
   background: linear-gradient(180deg, #85858c, #595961);
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.11);
   color: white;
-  font-size: 18px;
+  font-size: 22px;
   font-weight: 700;
 }
 
 .profile-top-app-icon img {
-  width: 46px;
-  height: 46px;
+  width: 62px;
+  height: 62px;
   object-fit: cover;
   transform: scale(1.16);
 }
@@ -1637,16 +1640,16 @@ button:disabled {
 
 .profile-top-app-rank {
   position: absolute;
-  top: 7px;
-  left: 7px;
+  top: 8px;
+  left: 8px;
   display: grid;
   place-items: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
   border-radius: 999px;
-  background: rgba(60, 60, 67, 0.08);
-  color: rgba(60, 60, 67, 0.64);
+  background: rgba(60, 60, 67, 0.07);
+  color: rgba(60, 60, 67, 0.5);
   font-size: 10px;
   font-weight: 600;
 }
@@ -2045,11 +2048,18 @@ button:disabled {
 
   .profile-top-app-list li {
     border-color: rgba(235, 235, 245, 0.1);
-    background: rgba(235, 235, 245, 0.055);
+    background: linear-gradient(180deg, rgba(235, 235, 245, 0.08), rgba(235, 235, 245, 0.04));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 1px 2px rgba(0, 0, 0, 0.18);
   }
 
   .profile-top-app-name {
     color: rgba(255, 255, 255, 0.86);
+  }
+
+  .profile-top-app-list strong {
+    color: rgba(235, 235, 245, 0.56);
   }
 
   .profile-top-app-rank {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1753,6 +1753,30 @@ button:disabled {
   font-weight: 600;
 }
 
+.profile-top-app-rank-1 {
+  background: linear-gradient(180deg, #ffe8a3, #d6a51f);
+  color: #5b3a00;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 1px 3px rgba(153, 111, 0, 0.18);
+}
+
+.profile-top-app-rank-2 {
+  background: linear-gradient(180deg, #f0f2f5, #aeb4bd);
+  color: #3b424c;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.76),
+    0 1px 3px rgba(75, 85, 99, 0.16);
+}
+
+.profile-top-app-rank-3 {
+  background: linear-gradient(180deg, #efc69c, #b06a2b);
+  color: #4b2408;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.58),
+    0 1px 3px rgba(120, 62, 18, 0.18);
+}
+
 .profile-empty-state {
   margin: 0;
   min-height: 28px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1493,7 +1493,6 @@ button:disabled {
 .profile-stat-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  border-bottom: 0.5px solid var(--settings-row-divider);
 }
 
 .profile-metric {
@@ -1542,9 +1541,29 @@ button:disabled {
   gap: 11px;
 }
 
+.profile-source-section {
+  position: relative;
+  z-index: 2;
+}
+
 .profile-source-panel-box,
 .profile-top-apps-panel-box {
   padding: 12px;
+}
+
+.profile-source-panel-box {
+  overflow: visible;
+}
+
+.profile-favorite-source {
+  display: inline-grid;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: 8px;
+  color: rgba(60, 60, 67, 0.5);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
 }
 
 .profile-channel-pill {
@@ -1553,7 +1572,7 @@ button:disabled {
   align-items: center;
   justify-content: end;
   gap: 7px;
-  min-height: 26px;
+  min-height: 24px;
   padding: 4px 10px;
   border: 0.5px solid rgba(60, 60, 67, 0.1);
   border-radius: 999px;
@@ -1572,13 +1591,15 @@ button:disabled {
 
 .profile-source-bar {
   display: flex;
-  overflow: hidden;
+  position: relative;
+  z-index: 1;
   height: 8px;
   border-radius: 999px;
   background: rgba(60, 60, 67, 0.075);
 }
 
 .profile-source-segment {
+  position: relative;
   flex-basis: 0;
   min-width: 4px;
   transition:
@@ -1587,6 +1608,7 @@ button:disabled {
 }
 
 .profile-source-segment:hover {
+  z-index: 6;
   filter: saturate(1.18);
   opacity: 0.9;
 }
@@ -1598,6 +1620,7 @@ button:disabled {
 }
 
 .profile-source-chip {
+  position: relative;
   display: inline-grid;
   grid-template-columns: 7px minmax(0, auto) auto;
   align-items: center;
@@ -1626,6 +1649,53 @@ button:disabled {
 .profile-source-chip strong {
   color: #1c1c1e;
   font-weight: 600;
+}
+
+.profile-source-tooltip {
+  position: absolute;
+  bottom: calc(100% + 7px);
+  left: 50%;
+  z-index: 20;
+  width: max-content;
+  max-width: 190px;
+  padding: 6px 8px;
+  border: 0.5px solid rgba(60, 60, 67, 0.12);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  color: rgba(28, 28, 30, 0.82);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 3px);
+  transition:
+    opacity 70ms ease,
+    transform 70ms ease;
+  white-space: normal;
+}
+
+.profile-source-chip:hover .profile-source-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.profile-source-segment:first-child {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+.profile-source-segment:last-child {
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
+.profile-source-segment:hover .profile-source-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .profile-source-dot {
@@ -2182,6 +2252,10 @@ button:disabled {
     background: rgba(235, 235, 245, 0.11);
   }
 
+  .profile-favorite-source {
+    color: rgba(235, 235, 245, 0.5);
+  }
+
   .profile-source-bar {
     background: rgba(235, 235, 245, 0.11);
   }
@@ -2195,6 +2269,15 @@ button:disabled {
     border-color: rgba(235, 235, 245, 0.14);
     background: rgba(235, 235, 245, 0.07);
     color: rgba(235, 235, 245, 0.62);
+  }
+
+  .profile-source-tooltip {
+    border-color: rgba(235, 235, 245, 0.12);
+    background: rgba(38, 38, 40, 0.96);
+    box-shadow:
+      0 8px 22px rgba(0, 0, 0, 0.34),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    color: rgba(235, 235, 245, 0.82);
   }
 
   .source-unknown {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1486,6 +1486,10 @@ button:disabled {
   gap: 18px;
 }
 
+.profile-start-section {
+  margin-bottom: 12px;
+}
+
 .profile-footer-panel {
   margin-top: auto;
 }
@@ -1569,14 +1573,28 @@ button:disabled {
 }
 
 .profile-start-summary strong {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
   color: #1c1c1e;
-  font-size: 28px;
   font-weight: 600;
   letter-spacing: 0;
   line-height: 1.05;
 }
 
-.profile-start-summary span {
+.profile-start-value {
+  font-size: 28px;
+}
+
+.profile-start-unit {
+  color: rgba(60, 60, 67, 0.46);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.15;
+}
+
+.profile-start-date {
   justify-self: end;
   min-height: 24px;
   padding: 5px 9px;
@@ -1593,7 +1611,7 @@ button:disabled {
     color 140ms ease;
 }
 
-.profile-start-summary span:hover {
+.profile-start-date:hover {
   border-color: rgba(60, 60, 67, 0.14);
   background: rgba(255, 255, 255, 0.74);
   color: rgba(60, 60, 67, 0.68);
@@ -2326,13 +2344,17 @@ button:disabled {
     color: rgba(255, 255, 255, 0.86);
   }
 
-  .profile-start-summary span {
+  .profile-start-unit {
+    color: rgba(235, 235, 245, 0.42);
+  }
+
+  .profile-start-date {
     border-color: rgba(235, 235, 245, 0.09);
     background: rgba(235, 235, 245, 0.075);
     color: rgba(235, 235, 245, 0.5);
   }
 
-  .profile-start-summary span:hover {
+  .profile-start-date:hover {
     border-color: rgba(235, 235, 245, 0.15);
     background: rgba(235, 235, 245, 0.105);
     color: rgba(235, 235, 245, 0.62);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1516,12 +1516,18 @@ button:disabled {
   line-height: 1.25;
 }
 
-.profile-source-row,
-.profile-top-apps-row {
+.profile-source-row {
   display: grid;
   grid-template-columns: minmax(0, 0.8fr) minmax(220px, 1fr);
   align-items: start;
   gap: 18px;
+}
+
+.profile-top-apps-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 12px;
 }
 
 .profile-source-list,
@@ -1567,16 +1573,82 @@ button:disabled {
 
 .profile-top-app-list {
   list-style: none;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
 }
 
 .profile-top-app-list li {
-  grid-template-columns: minmax(0, 1fr) minmax(24px, auto);
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: center;
+  align-content: start;
+  gap: 7px;
+  min-width: 0;
+  min-height: 116px;
+  padding: 12px 8px 10px;
+  border: 0.5px solid rgba(60, 60, 67, 0.1);
+  border-radius: 8px;
+  background: rgba(60, 60, 67, 0.035);
+  text-align: center;
 }
 
-.profile-top-app-list span {
+.profile-top-app-name {
+  max-width: 100%;
+  color: #1c1c1e;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.profile-top-app-list strong {
+  color: rgba(60, 60, 67, 0.56);
+  font-size: 11px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.profile-top-app-icon {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 11px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #85858c, #595961);
+  color: white;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.profile-top-app-icon img {
+  width: 46px;
+  height: 46px;
+  object-fit: cover;
+  transform: scale(1.16);
+}
+
+.profile-top-app-icon.has-image {
+  background: transparent;
+}
+
+.profile-top-app-rank {
+  position: absolute;
+  top: 7px;
+  left: 7px;
+  display: grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: rgba(60, 60, 67, 0.08);
+  color: rgba(60, 60, 67, 0.64);
+  font-size: 10px;
+  font-weight: 600;
 }
 
 .profile-warning-row {
@@ -1727,8 +1799,7 @@ button:disabled {
     border-top: 0.5px solid var(--settings-row-divider);
   }
 
-  .profile-source-row,
-  .profile-top-apps-row {
+  .profile-source-row {
     grid-template-columns: 1fr;
   }
 
@@ -1970,6 +2041,20 @@ button:disabled {
 
   .profile-source-meter {
     background: rgba(235, 235, 245, 0.11);
+  }
+
+  .profile-top-app-list li {
+    border-color: rgba(235, 235, 245, 0.1);
+    background: rgba(235, 235, 245, 0.055);
+  }
+
+  .profile-top-app-name {
+    color: rgba(255, 255, 255, 0.86);
+  }
+
+  .profile-top-app-rank {
+    background: rgba(235, 235, 245, 0.1);
+    color: rgba(235, 235, 245, 0.64);
   }
 
   .profile-warning-row {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1531,11 +1531,22 @@ button:disabled {
 }
 
 .profile-start-panel-box {
-  padding: 14px var(--settings-row-padding-inline);
+  position: relative;
+  overflow: hidden;
+  padding: 18px 16px 16px;
+  border-color: rgba(60, 60, 67, 0.13);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.42) 52%),
+    linear-gradient(180deg, rgba(214, 165, 31, 0.08), rgba(60, 60, 67, 0.018));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 1px 2px rgba(0, 0, 0, 0.025);
 }
 
 .profile-start-summary {
   display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
   gap: 5px;
   cursor: default;
   user-select: none;
@@ -1543,17 +1554,33 @@ button:disabled {
 
 .profile-start-summary strong {
   color: #1c1c1e;
-  font-size: 22px;
+  font-size: 28px;
   font-weight: 600;
   letter-spacing: 0;
   line-height: 1.05;
 }
 
 .profile-start-summary span {
-  color: rgba(60, 60, 67, 0.5);
+  justify-self: end;
+  min-height: 24px;
+  padding: 5px 9px;
+  border: 0.5px solid rgba(60, 60, 67, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.58);
+  color: rgba(60, 60, 67, 0.58);
   font-size: 12px;
   font-weight: 500;
-  line-height: 1.25;
+  line-height: 1.15;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    color 140ms ease;
+}
+
+.profile-start-summary span:hover {
+  border-color: rgba(60, 60, 67, 0.14);
+  background: rgba(255, 255, 255, 0.74);
+  color: rgba(60, 60, 67, 0.68);
 }
 
 .profile-source-metric-value {
@@ -2011,6 +2038,14 @@ button:disabled {
     border-top: 0.5px solid var(--settings-row-divider);
   }
 
+  .profile-start-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-start-summary span {
+    justify-self: start;
+  }
+
   .inspector {
     display: none;
   }
@@ -2249,12 +2284,30 @@ button:disabled {
     background: rgba(235, 235, 245, 0.42);
   }
 
+  .profile-start-panel-box {
+    border-color: rgba(235, 235, 245, 0.12);
+    background:
+      linear-gradient(135deg, rgba(235, 235, 245, 0.1), rgba(235, 235, 245, 0.045) 58%),
+      linear-gradient(180deg, rgba(214, 165, 31, 0.11), rgba(235, 235, 245, 0.025));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 1px 2px rgba(0, 0, 0, 0.18);
+  }
+
   .profile-start-summary strong {
     color: rgba(255, 255, 255, 0.86);
   }
 
   .profile-start-summary span {
+    border-color: rgba(235, 235, 245, 0.09);
+    background: rgba(235, 235, 245, 0.075);
     color: rgba(235, 235, 245, 0.5);
+  }
+
+  .profile-start-summary span:hover {
+    border-color: rgba(235, 235, 245, 0.15);
+    background: rgba(235, 235, 245, 0.105);
+    color: rgba(235, 235, 245, 0.62);
   }
 
   .profile-source-bar {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2400,15 +2400,21 @@ button:disabled {
   }
 
   .profile-footer-row {
-    background: rgba(235, 235, 245, 0.035);
+    background: rgba(235, 235, 245, 0.018);
   }
 
   .profile-footer-text {
-    color: rgba(235, 235, 245, 0.58);
+    color: rgba(235, 235, 245, 0.44);
   }
 
   .profile-footer-row .settings-row-text > span:first-child {
-    color: rgba(235, 235, 245, 0.58);
+    color: rgba(235, 235, 245, 0.44);
+  }
+
+  .profile-footer-panel .settings-panel-box {
+    --settings-panel-border: rgba(235, 235, 245, 0.055);
+
+    background: rgba(235, 235, 245, 0.018);
   }
 
   .toolbar-button.refresh-button,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1553,6 +1553,7 @@ button:disabled {
 
 .profile-source-panel-box {
   overflow: visible;
+  padding-top: 14px;
 }
 
 .profile-favorite-source {
@@ -1564,6 +1565,8 @@ button:disabled {
   font-size: 12px;
   font-weight: 500;
   line-height: 1.2;
+  cursor: default;
+  user-select: none;
 }
 
 .profile-channel-pill {
@@ -1634,10 +1637,12 @@ button:disabled {
   color: rgba(60, 60, 67, 0.58);
   font-size: 12px;
   line-height: 1.25;
+  cursor: default;
   transition:
     border-color 140ms ease,
     background 140ms ease,
     color 140ms ease;
+  user-select: none;
 }
 
 .profile-source-chip:hover {
@@ -1746,12 +1751,14 @@ button:disabled {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.78),
     0 1px 2px rgba(0, 0, 0, 0.03);
+  cursor: default;
   text-align: center;
   transition:
     border-color 140ms ease,
     background 140ms ease,
     box-shadow 140ms ease,
     transform 140ms ease;
+  user-select: none;
 }
 
 .profile-top-app-list li:hover {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1468,6 +1468,104 @@ button:disabled {
   border-top: 0.5px solid var(--settings-row-divider);
 }
 
+.profile-panel-box {
+  gap: 0;
+}
+
+.profile-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-bottom: 0.5px solid var(--settings-row-divider);
+}
+
+.profile-metric {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 14px var(--settings-row-padding-inline);
+}
+
+.profile-metric + .profile-metric {
+  border-left: 0.5px solid var(--settings-row-divider);
+}
+
+.profile-metric strong {
+  color: #1c1c1e;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.05;
+}
+
+.profile-metric span {
+  color: rgba(60, 60, 67, 0.56);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.profile-source-row,
+.profile-top-apps-row {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(220px, 1fr);
+  align-items: start;
+  gap: 18px;
+}
+
+.profile-source-list,
+.profile-top-app-list {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.profile-source-item,
+.profile-top-app-list li {
+  display: grid;
+  grid-template-columns: minmax(76px, 0.42fr) minmax(80px, 1fr) minmax(24px, auto);
+  align-items: center;
+  gap: 8px;
+  color: rgba(60, 60, 67, 0.64);
+  font-size: 12px;
+}
+
+.profile-source-item strong,
+.profile-top-app-list strong {
+  color: #1c1c1e;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: right;
+}
+
+.profile-source-meter {
+  overflow: hidden;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(60, 60, 67, 0.1);
+}
+
+.profile-source-meter span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: rgb(var(--update-accent-rgb));
+}
+
+.profile-top-app-list {
+  list-style: none;
+}
+
+.profile-top-app-list li {
+  grid-template-columns: minmax(0, 1fr) minmax(24px, auto);
+}
+
+.profile-top-app-list span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .settings-number-input {
   width: 68px;
   height: 26px;
@@ -1581,6 +1679,23 @@ button:disabled {
     grid-template-columns: 1fr;
   }
 
+  .profile-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .profile-metric:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .profile-metric:nth-child(n + 3) {
+    border-top: 0.5px solid var(--settings-row-divider);
+  }
+
+  .profile-source-row,
+  .profile-top-apps-row {
+    grid-template-columns: 1fr;
+  }
+
   .inspector {
     display: none;
   }
@@ -1663,12 +1778,18 @@ button:disabled {
   .row-main p,
   .muted,
   .empty,
-  .settings-row-subtext {
+  .settings-row-subtext,
+  .profile-metric span,
+  .profile-source-item,
+  .profile-top-app-list li {
     color: rgba(235, 235, 245, 0.5);
   }
 
   .settings-key-value-list strong,
-  .settings-row-value {
+  .settings-row-value,
+  .profile-metric strong,
+  .profile-source-item strong,
+  .profile-top-app-list strong {
     color: rgba(255, 255, 255, 0.86);
   }
 
@@ -1809,6 +1930,10 @@ button:disabled {
 
   .settings-status-label.muted .settings-status-glyph {
     background: rgba(235, 235, 245, 0.42);
+  }
+
+  .profile-source-meter {
+    background: rgba(235, 235, 245, 0.11);
   }
 
   .toolbar-button.refresh-button,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1500,6 +1500,8 @@ button:disabled {
   gap: 5px;
   min-width: 0;
   padding: 14px var(--settings-row-padding-inline);
+  cursor: default;
+  user-select: none;
 }
 
 .profile-metric + .profile-metric {
@@ -1528,6 +1530,41 @@ button:disabled {
   white-space: nowrap;
 }
 
+.profile-start-panel-box {
+  padding: 14px var(--settings-row-padding-inline);
+}
+
+.profile-start-summary {
+  display: grid;
+  gap: 5px;
+  cursor: default;
+  user-select: none;
+}
+
+.profile-start-summary strong {
+  color: #1c1c1e;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.05;
+}
+
+.profile-start-summary span {
+  color: rgba(60, 60, 67, 0.5);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.profile-source-metric-value {
+  display: inline-grid;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: start;
+  gap: 7px;
+  min-width: 0;
+}
+
 .profile-source-list,
 .profile-top-app-list {
   display: grid;
@@ -1554,42 +1591,6 @@ button:disabled {
 .profile-source-panel-box {
   overflow: visible;
   padding-top: 14px;
-}
-
-.profile-favorite-source {
-  display: inline-grid;
-  grid-auto-flow: column;
-  align-items: center;
-  gap: 8px;
-  color: rgba(60, 60, 67, 0.5);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1.2;
-  cursor: default;
-  user-select: none;
-}
-
-.profile-channel-pill {
-  display: inline-grid;
-  grid-auto-flow: column;
-  align-items: center;
-  justify-content: end;
-  gap: 7px;
-  min-height: 24px;
-  padding: 4px 10px;
-  border: 0.5px solid rgba(60, 60, 67, 0.1);
-  border-radius: 999px;
-  background: rgba(60, 60, 67, 0.045);
-  color: #1c1c1e;
-  line-height: 1;
-  transition:
-    border-color 140ms ease,
-    background 140ms ease;
-}
-
-.profile-channel-pill:hover {
-  border-color: rgba(60, 60, 67, 0.16);
-  background: rgba(60, 60, 67, 0.07);
 }
 
 .profile-source-bar {
@@ -2248,18 +2249,11 @@ button:disabled {
     background: rgba(235, 235, 245, 0.42);
   }
 
-  .profile-channel-pill {
-    border-color: rgba(235, 235, 245, 0.1);
-    background: rgba(235, 235, 245, 0.08);
+  .profile-start-summary strong {
     color: rgba(255, 255, 255, 0.86);
   }
 
-  .profile-channel-pill:hover {
-    border-color: rgba(235, 235, 245, 0.16);
-    background: rgba(235, 235, 245, 0.11);
-  }
-
-  .profile-favorite-source {
+  .profile-start-summary span {
     color: rgba(235, 235, 245, 0.5);
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1591,11 +1591,6 @@ button:disabled {
   opacity: 0.9;
 }
 
-.profile-source-empty {
-  flex: 1;
-  background: rgba(60, 60, 67, 0.12);
-}
-
 .profile-source-legend {
   display: flex;
   flex-wrap: wrap;
@@ -1756,6 +1751,14 @@ button:disabled {
   color: rgba(60, 60, 67, 0.5);
   font-size: 10px;
   font-weight: 600;
+}
+
+.profile-empty-state {
+  margin: 0;
+  min-height: 28px;
+  color: rgba(60, 60, 67, 0.48);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .profile-warning-row {
@@ -1991,6 +1994,7 @@ button:disabled {
   .settings-row-subtext,
   .profile-metric span,
   .profile-metric-detail,
+  .profile-empty-state,
   .profile-source-chip,
   .profile-top-app-list li {
     color: rgba(235, 235, 245, 0.5);
@@ -2156,10 +2160,6 @@ button:disabled {
 
   .profile-source-bar {
     background: rgba(235, 235, 245, 0.11);
-  }
-
-  .profile-source-empty {
-    background: rgba(235, 235, 245, 0.14);
   }
 
   .profile-source-chip {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1849,6 +1849,17 @@ button:disabled {
   background: transparent;
 }
 
+.profile-top-tool-icon {
+  border: 0.5px solid rgba(60, 60, 67, 0.08);
+  background:
+    linear-gradient(145deg, rgba(232, 154, 23, 0.18), rgba(60, 60, 67, 0.05)),
+    rgba(60, 60, 67, 0.04);
+  color: #9b650b;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 5px 14px rgba(0, 0, 0, 0.07);
+}
+
 .profile-top-app-rank {
   position: absolute;
   top: 8px;
@@ -2377,6 +2388,17 @@ button:disabled {
 
   .profile-top-app-list strong {
     color: rgba(235, 235, 245, 0.56);
+  }
+
+  .profile-top-tool-icon {
+    border-color: rgba(235, 235, 245, 0.08);
+    background:
+      linear-gradient(145deg, rgba(232, 154, 23, 0.2), rgba(235, 235, 245, 0.045)),
+      rgba(235, 235, 245, 0.045);
+    color: #f0b044;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 5px 14px rgba(0, 0, 0, 0.18);
   }
 
   .profile-top-app-rank {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1477,8 +1477,13 @@ button:disabled {
 .profile-page {
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 28px;
   min-height: calc(100vh - 90px);
+}
+
+.profile-stack {
+  display: grid;
+  gap: 18px;
 }
 
 .profile-footer-panel {
@@ -1516,20 +1521,6 @@ button:disabled {
   line-height: 1.25;
 }
 
-.profile-source-row {
-  display: grid;
-  grid-template-columns: minmax(0, 0.8fr) minmax(220px, 1fr);
-  align-items: start;
-  gap: 18px;
-}
-
-.profile-top-apps-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: start;
-  gap: 12px;
-}
-
 .profile-source-list,
 .profile-top-app-list {
   display: grid;
@@ -1539,34 +1530,125 @@ button:disabled {
   padding: 0;
 }
 
-.profile-source-item {
-  display: grid;
-  grid-template-columns: minmax(76px, 0.42fr) minmax(80px, 1fr) minmax(24px, auto);
+.profile-source-list {
+  gap: 11px;
+}
+
+.profile-source-panel-box,
+.profile-top-apps-panel-box {
+  padding: 12px;
+}
+
+.profile-channel-pill {
+  display: inline-grid;
+  grid-auto-flow: column;
   align-items: center;
-  gap: 8px;
-  color: rgba(60, 60, 67, 0.64);
-  font-size: 12px;
-}
-
-.profile-source-item strong {
-  color: #1c1c1e;
-  font-size: 12px;
-  font-weight: 600;
-  text-align: right;
-}
-
-.profile-source-meter {
-  overflow: hidden;
-  height: 5px;
+  justify-content: end;
+  gap: 7px;
+  min-height: 26px;
+  padding: 4px 10px;
+  border: 0.5px solid rgba(60, 60, 67, 0.1);
   border-radius: 999px;
-  background: rgba(60, 60, 67, 0.1);
+  background: rgba(60, 60, 67, 0.045);
+  color: #1c1c1e;
+  line-height: 1;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease;
 }
 
-.profile-source-meter span {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
+.profile-channel-pill:hover {
+  border-color: rgba(60, 60, 67, 0.16);
+  background: rgba(60, 60, 67, 0.07);
+}
+
+.profile-source-bar {
+  display: flex;
+  overflow: hidden;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(60, 60, 67, 0.075);
+}
+
+.profile-source-segment {
+  flex-basis: 0;
+  min-width: 4px;
+  transition:
+    filter 140ms ease,
+    opacity 140ms ease;
+}
+
+.profile-source-segment:hover {
+  filter: saturate(1.18);
+  opacity: 0.9;
+}
+
+.profile-source-empty {
+  flex: 1;
+  background: rgba(60, 60, 67, 0.12);
+}
+
+.profile-source-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.profile-source-chip {
+  display: inline-grid;
+  grid-template-columns: 7px minmax(0, auto) auto;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  min-width: 0;
+  padding: 4px 8px;
+  border: 0.5px solid rgba(60, 60, 67, 0.08);
+  border-radius: 999px;
+  background: rgba(60, 60, 67, 0.035);
+  color: rgba(60, 60, 67, 0.58);
+  font-size: 12px;
+  line-height: 1.25;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    color 140ms ease;
+}
+
+.profile-source-chip:hover {
+  border-color: rgba(60, 60, 67, 0.14);
+  background: rgba(60, 60, 67, 0.055);
+  color: rgba(60, 60, 67, 0.68);
+}
+
+.profile-source-chip strong {
+  color: #1c1c1e;
+  font-weight: 600;
+}
+
+.profile-source-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+}
+
+.source-app-store {
   background: rgb(var(--update-accent-rgb));
+}
+
+.source-sparkle {
+  background: #74c7ec;
+}
+
+.source-homebrew {
+  background: #e89a17;
+}
+
+.source-web {
+  background: #3bbf62;
+}
+
+.source-unknown {
+  background: rgba(60, 60, 67, 0.32);
 }
 
 .profile-top-app-list {
@@ -1592,6 +1674,20 @@ button:disabled {
     inset 0 1px 0 rgba(255, 255, 255, 0.78),
     0 1px 2px rgba(0, 0, 0, 0.03);
   text-align: center;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.profile-top-app-list li:hover {
+  border-color: rgba(60, 60, 67, 0.16);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(60, 60, 67, 0.04));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 4px 14px rgba(0, 0, 0, 0.055);
+  transform: translateY(-1px);
 }
 
 .profile-top-app-name {
@@ -1802,10 +1898,6 @@ button:disabled {
     border-top: 0.5px solid var(--settings-row-divider);
   }
 
-  .profile-source-row {
-    grid-template-columns: 1fr;
-  }
-
   .inspector {
     display: none;
   }
@@ -1890,7 +1982,7 @@ button:disabled {
   .empty,
   .settings-row-subtext,
   .profile-metric span,
-  .profile-source-item,
+  .profile-source-chip,
   .profile-top-app-list li {
     color: rgba(235, 235, 245, 0.5);
   }
@@ -1898,7 +1990,7 @@ button:disabled {
   .settings-key-value-list strong,
   .settings-row-value,
   .profile-metric strong,
-  .profile-source-item strong,
+  .profile-source-chip strong,
   .profile-top-app-list strong {
     color: rgba(255, 255, 255, 0.86);
   }
@@ -2042,8 +2134,38 @@ button:disabled {
     background: rgba(235, 235, 245, 0.42);
   }
 
-  .profile-source-meter {
+  .profile-channel-pill {
+    border-color: rgba(235, 235, 245, 0.1);
+    background: rgba(235, 235, 245, 0.08);
+    color: rgba(255, 255, 255, 0.86);
+  }
+
+  .profile-channel-pill:hover {
+    border-color: rgba(235, 235, 245, 0.16);
     background: rgba(235, 235, 245, 0.11);
+  }
+
+  .profile-source-bar {
+    background: rgba(235, 235, 245, 0.11);
+  }
+
+  .profile-source-empty {
+    background: rgba(235, 235, 245, 0.14);
+  }
+
+  .profile-source-chip {
+    border-color: rgba(235, 235, 245, 0.08);
+    background: rgba(235, 235, 245, 0.045);
+  }
+
+  .profile-source-chip:hover {
+    border-color: rgba(235, 235, 245, 0.14);
+    background: rgba(235, 235, 245, 0.07);
+    color: rgba(235, 235, 245, 0.62);
+  }
+
+  .source-unknown {
+    background: rgba(235, 235, 245, 0.34);
   }
 
   .profile-top-app-list li {
@@ -2052,6 +2174,14 @@ button:disabled {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 1px 2px rgba(0, 0, 0, 0.18);
+  }
+
+  .profile-top-app-list li:hover {
+    border-color: rgba(235, 235, 245, 0.16);
+    background: linear-gradient(180deg, rgba(235, 235, 245, 0.1), rgba(235, 235, 245, 0.055));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.1),
+      0 4px 14px rgba(0, 0, 0, 0.24);
   }
 
   .profile-top-app-name {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1599,15 +1599,6 @@ button:disabled {
   color: rgba(60, 60, 67, 0.68);
 }
 
-.profile-source-metric-value {
-  display: inline-grid;
-  grid-auto-flow: column;
-  align-items: center;
-  justify-content: start;
-  gap: 7px;
-  min-width: 0;
-}
-
 .profile-source-list,
 .profile-top-app-list {
   display: grid;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2367,6 +2367,30 @@ button:disabled {
     color: rgba(235, 235, 245, 0.64);
   }
 
+  .profile-top-app-rank-1 {
+    background: linear-gradient(180deg, #f8d675, #b98511);
+    color: #3f2800;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.42),
+      0 1px 5px rgba(214, 165, 31, 0.28);
+  }
+
+  .profile-top-app-rank-2 {
+    background: linear-gradient(180deg, #d8dde5, #8e96a3);
+    color: #262c35;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.46),
+      0 1px 5px rgba(174, 180, 189, 0.2);
+  }
+
+  .profile-top-app-rank-3 {
+    background: linear-gradient(180deg, #d7965d, #8f4f1f);
+    color: #2f1605;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.32),
+      0 1px 5px rgba(176, 106, 43, 0.24);
+  }
+
   .profile-warning-row {
     background: rgba(255, 69, 58, 0.12);
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1293,10 +1293,12 @@ button:disabled {
 
 .settings-content {
   display: block;
+  flex: 1 1 auto;
 }
 
 .settings-content .stack {
   gap: 40px;
+  min-height: 100%;
 }
 
 .settings-panel {
@@ -1472,6 +1474,17 @@ button:disabled {
   gap: 0;
 }
 
+.profile-page {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  min-height: calc(100vh - 90px);
+}
+
+.profile-footer-panel {
+  margin-top: auto;
+}
+
 .profile-stat-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -1564,6 +1577,29 @@ button:disabled {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.profile-warning-row {
+  background: rgba(255, 59, 48, 0.08);
+}
+
+.profile-warning-row .settings-row-text > span:first-child {
+  color: #b42318;
+  font-weight: 500;
+}
+
+.profile-footer-row {
+  background: rgba(60, 60, 67, 0.035);
+}
+
+.profile-footer-text {
+  color: rgba(60, 60, 67, 0.64);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.profile-footer-row .settings-row-text > span:first-child {
+  color: rgba(60, 60, 67, 0.64);
 }
 
 .settings-number-input {
@@ -1934,6 +1970,26 @@ button:disabled {
 
   .profile-source-meter {
     background: rgba(235, 235, 245, 0.11);
+  }
+
+  .profile-warning-row {
+    background: rgba(255, 69, 58, 0.12);
+  }
+
+  .profile-warning-row .settings-row-text > span:first-child {
+    color: #ff6961;
+  }
+
+  .profile-footer-row {
+    background: rgba(235, 235, 245, 0.035);
+  }
+
+  .profile-footer-text {
+    color: rgba(235, 235, 245, 0.58);
+  }
+
+  .profile-footer-row .settings-row-text > span:first-child {
+    color: rgba(235, 235, 245, 0.58);
   }
 
   .toolbar-button.refresh-button,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1541,6 +1541,22 @@ button:disabled {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.82),
     0 1px 2px rgba(0, 0, 0, 0.025);
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.profile-start-panel-box:hover {
+  border-color: rgba(60, 60, 67, 0.17);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.5) 52%),
+    linear-gradient(180deg, rgba(214, 165, 31, 0.11), rgba(60, 60, 67, 0.024));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.86),
+    0 5px 16px rgba(0, 0, 0, 0.045);
+  transform: translateY(-1px);
 }
 
 .profile-start-summary {
@@ -2292,6 +2308,16 @@ button:disabled {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 1px 2px rgba(0, 0, 0, 0.18);
+  }
+
+  .profile-start-panel-box:hover {
+    border-color: rgba(235, 235, 245, 0.16);
+    background:
+      linear-gradient(135deg, rgba(235, 235, 245, 0.13), rgba(235, 235, 245, 0.06) 58%),
+      linear-gradient(180deg, rgba(214, 165, 31, 0.14), rgba(235, 235, 245, 0.032));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.1),
+      0 5px 16px rgba(0, 0, 0, 0.24);
   }
 
   .profile-start-summary strong {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -124,6 +124,32 @@ export type HomebrewRecentlyUpdatedRecord = {
   updatedAt: string;
 };
 
+export type ProfileStatsChannel = "appStore" | "sparkle" | "homebrew" | "web" | "unknown";
+
+export type ProfileStatsEventType = "appUpdate" | "homebrewUpdate" | "homebrewInstall";
+
+export type ProfileStatsEvent = {
+  id: string;
+  type: ProfileStatsEventType;
+  targetID: string;
+  displayName: string;
+  channel: ProfileStatsChannel;
+  occurredAt: string;
+};
+
+export type ProfileStatsIntegrityStatus =
+  | "pending"
+  | "verified"
+  | "unavailable"
+  | "resetAfterTamper";
+
+export type ProfileStats = {
+  createdAt: string;
+  events: ProfileStatsEvent[];
+  signature?: string;
+  integrityStatus: ProfileStatsIntegrityStatus;
+};
+
 export type HomebrewManagedItem = {
   id: string;
   token: string;
@@ -163,6 +189,7 @@ export type PersistedSnapshot = {
   appearancePreference: AppearancePreference;
   useMasForAppStoreUpdates: boolean;
   showMenuBarIcon: boolean;
+  profileStats: ProfileStats;
   lastRefreshDate?: string;
 };
 
@@ -232,7 +259,16 @@ export function defaultPersistedSnapshot(): PersistedSnapshot {
     refreshIntervalMinutes: 60,
     appearancePreference: "system",
     useMasForAppStoreUpdates: true,
-    showMenuBarIcon: true
+    showMenuBarIcon: true,
+    profileStats: defaultProfileStats()
+  };
+}
+
+export function defaultProfileStats(now = new Date().toISOString()): ProfileStats {
+  return {
+    createdAt: now,
+    events: [],
+    integrityStatus: "pending"
   };
 }
 

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -143,11 +143,18 @@ export type ProfileStatsIntegrityStatus =
   | "unavailable"
   | "resetAfterTamper";
 
+export type ProfileStatsResetNotice = {
+  id: string;
+  occurredAt: string;
+  reason: "tamper";
+};
+
 export type ProfileStats = {
   createdAt: string;
   startedUsingAt: string;
   signatureVersion: number;
   events: ProfileStatsEvent[];
+  resetNotice?: ProfileStatsResetNotice;
   signature?: string;
   integrityStatus: ProfileStatsIntegrityStatus;
 };
@@ -194,6 +201,7 @@ export type PersistedSnapshot = {
   useMasForAppStoreUpdates: boolean;
   showMenuBarIcon: boolean;
   profileStats: ProfileStats;
+  profileStatsResetAcknowledgedID?: string;
   lastRefreshDate?: string;
 };
 
@@ -275,6 +283,18 @@ export function defaultProfileStats(now = new Date().toISOString()): ProfileStat
     signatureVersion: profileStatsSignatureVersion,
     events: [],
     integrityStatus: "pending"
+  };
+}
+
+export function defaultProfileStatsAfterTamper(now = new Date().toISOString()): ProfileStats {
+  return {
+    ...defaultProfileStats(now),
+    resetNotice: {
+      id: `tamper:${now}`,
+      occurredAt: now,
+      reason: "tamper"
+    },
+    integrityStatus: "resetAfterTamper"
   };
 }
 

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -145,6 +145,7 @@ export type ProfileStatsIntegrityStatus =
 
 export type ProfileStats = {
   createdAt: string;
+  startedUsingAt: string;
   events: ProfileStatsEvent[];
   signature?: string;
   integrityStatus: ProfileStatsIntegrityStatus;
@@ -242,7 +243,7 @@ export const emptyHomebrewFormulaIndex: HomebrewFormulaIndex = {
   byToken: {}
 };
 
-export function defaultPersistedSnapshot(): PersistedSnapshot {
+export function defaultPersistedSnapshot(now = new Date().toISOString()): PersistedSnapshot {
   return {
     apps: [],
     updates: [],
@@ -260,13 +261,14 @@ export function defaultPersistedSnapshot(): PersistedSnapshot {
     appearancePreference: "system",
     useMasForAppStoreUpdates: true,
     showMenuBarIcon: true,
-    profileStats: defaultProfileStats()
+    profileStats: defaultProfileStats(now)
   };
 }
 
 export function defaultProfileStats(now = new Date().toISOString()): ProfileStats {
   return {
     createdAt: now,
+    startedUsingAt: now,
     events: [],
     integrityStatus: "pending"
   };

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -146,10 +146,13 @@ export type ProfileStatsIntegrityStatus =
 export type ProfileStats = {
   createdAt: string;
   startedUsingAt: string;
+  signatureVersion: number;
   events: ProfileStatsEvent[];
   signature?: string;
   integrityStatus: ProfileStatsIntegrityStatus;
 };
+
+export const profileStatsSignatureVersion = 2;
 
 export type HomebrewManagedItem = {
   id: string;
@@ -269,6 +272,7 @@ export function defaultProfileStats(now = new Date().toISOString()): ProfileStat
   return {
     createdAt: now,
     startedUsingAt: now,
+    signatureVersion: profileStatsSignatureVersion,
     events: [],
     integrityStatus: "pending"
   };

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,7 @@ export const ipcChannels = {
   setSearchText: "baseline:setSearchText",
   setSelectedTab: "baseline:setSelectedTab",
   updatePreferences: "baseline:updatePreferences",
+  acknowledgeProfileStatsReset: "baseline:acknowledgeProfileStatsReset",
   toggleIgnoredApp: "baseline:toggleIgnoredApp",
   toggleIgnoredHomebrew: "baseline:toggleIgnoredHomebrew",
   performAppUpdate: "baseline:performAppUpdate",
@@ -62,6 +63,7 @@ export type BaselineAPI = {
   setSearchText(searchText: string): Promise<void>;
   setSelectedTab(tab: MenuTab): Promise<void>;
   updatePreferences(patch: PreferencePatch): Promise<void>;
+  acknowledgeProfileStatsReset(): Promise<void>;
   toggleIgnoredApp(appID: string): Promise<void>;
   toggleIgnoredHomebrew(itemID: string): Promise<void>;
   performAppUpdate(appID: string): Promise<void>;


### PR DESCRIPTION
## Summary
- Add a Settings > Profile tab with private local stats for Baseline-driven updates and installs, including total updates, unique apps, installs, favorite source, source mix, top updated apps, and top updated Homebrew tools.
- Track a signed “with Baseline” start date and a local profile stats ledger for app updates, Homebrew tool updates, and Homebrew installs, with migration support for older persisted state.
- Seal profile stats with a Keychain-backed HMAC, migrate versioned and legacy signatures, serialize concurrent stats mutations, reset unsigned or tampered local history, persist reset warning acknowledgement, and preserve existing seals when Keychain reads are unavailable.

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run build
