### PR TITLE
Polish app and Homebrew icon treatments

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -829,19 +829,8 @@ describe("renderer button parity", () => {
     expect(document.querySelector(".profile-start-panel-box")?.hasAttribute("title")).toBe(false);
     const sourceSegment = document.querySelector(".profile-source-segment") as HTMLElement;
     expect(sourceSegment).not.toBeNull();
-    vi.spyOn(sourceSegment, "getBoundingClientRect").mockReturnValue({
-      x: 10,
-      y: 0,
-      width: 120,
-      height: 8,
-      top: 0,
-      right: 130,
-      bottom: 8,
-      left: 10,
-      toJSON: () => ({})
-    });
     fireEvent.pointerMove(sourceSegment, { clientX: 45 });
-    expect(sourceSegment.style.getPropertyValue("--profile-source-tooltip-x")).toBe("35px");
+    expect(sourceSegment.style.getPropertyValue("--profile-source-tooltip-x")).toBe("");
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();
     expect(topAppRow?.querySelector(".profile-top-app-icon img")).toHaveAttribute(

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -826,6 +826,22 @@ describe("renderer button parity", () => {
     ).not.toBeInTheDocument();
     expect(screen.getAllByText("Sparkle 45%")).toHaveLength(1);
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
+    expect(document.querySelector(".profile-start-panel-box")?.hasAttribute("title")).toBe(false);
+    const sourceSegment = document.querySelector(".profile-source-segment") as HTMLElement;
+    expect(sourceSegment).not.toBeNull();
+    vi.spyOn(sourceSegment, "getBoundingClientRect").mockReturnValue({
+      x: 10,
+      y: 0,
+      width: 120,
+      height: 8,
+      top: 0,
+      right: 130,
+      bottom: 8,
+      left: 10,
+      toJSON: () => ({})
+    });
+    fireEvent.pointerMove(sourceSegment, { clientX: 45 });
+    expect(sourceSegment.style.getPropertyValue("--profile-source-tooltip-x")).toBe("35px");
     const topAppRow = screen.getByText("Example").closest("li");
     expect(topAppRow).not.toBeNull();
     expect(topAppRow?.querySelector(".profile-top-app-icon img")).toHaveAttribute(
@@ -836,6 +852,7 @@ describe("renderer button parity", () => {
       ".profile-top-app-list:not(.profile-top-tool-list) li"
     );
     expect(topAppTiles).toHaveLength(3);
+    expect([...topAppTiles].every((tile) => !tile.hasAttribute("title"))).toBe(true);
     expect(
       [
         ...document.querySelectorAll(
@@ -852,6 +869,7 @@ describe("renderer button parity", () => {
     expect([...topAppTiles].some((tile) => tile.textContent?.includes("Fourth App"))).toBe(false);
     const topToolTiles = document.querySelectorAll(".profile-top-tool-list li");
     expect(topToolTiles).toHaveLength(2);
+    expect([...topToolTiles].every((tile) => !tile.hasAttribute("title"))).toBe(true);
     expect(screen.getByText("aws-vault")).toBeInTheDocument();
     expect(screen.getByText("1 update · CLI Cask")).toBeInTheDocument();
     expect(screen.getByText("ripgrep")).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1221,6 +1221,18 @@ describe("renderer button parity", () => {
     expect(screen.getAllByText("CLI Cask")).toHaveLength(2);
     expect(screen.getByText("Package Cask")).toBeInTheDocument();
     expect(screen.getByText("App Cask")).toBeInTheDocument();
+    expect(
+      screen.getByText("example-cli").closest("article")?.querySelector(".app-icon.brew.tool")
+    ).not.toBeNull();
+    expect(
+      screen.getByText("example-cli-cask").closest("article")?.querySelector(".app-icon.brew.tool")
+    ).not.toBeNull();
+    expect(
+      screen.getByText("Discover CLI").closest("article")?.querySelector(".app-icon.brew.tool")
+    ).not.toBeNull();
+    expect(
+      screen.getByText("example-package").closest("article")?.querySelector(".app-icon.brew.tool")
+    ).toBeNull();
   });
 
   it("keeps ignore enabled while a Homebrew cask is updating and disables uninstall", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1240,6 +1240,9 @@ describe("renderer button parity", () => {
     expect(
       screen.getByText("example-package").closest("article")?.querySelector(".app-icon.brew.tool")
     ).toBeNull();
+    expect(
+      screen.getByText("example-package").closest("article")?.querySelector(".app-icon.brew.cask")
+    ).not.toBeNull();
   });
 
   it("keeps ignore enabled while a Homebrew cask is updating and disables uninstall", () => {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2692,10 +2692,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
     <div className="profile-page">
       <div className="profile-stack">
         <section className="panel settings-panel profile-start-section">
-          <div
-            className="settings-panel-box profile-start-panel-box"
-            title={profile.startedUsing.title}
-          >
+          <div className="settings-panel-box profile-start-panel-box">
             <div className="profile-start-summary">
               <strong>
                 <span className="profile-start-value">{profile.startedUsing.relativeLabel}</span>
@@ -2732,6 +2729,8 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                     <span
                       className={`profile-source-segment ${profileSourceClass(source.channel)}`}
                       key={source.channel}
+                      onPointerMove={handleProfileSourceSegmentPointerMove}
+                      onPointerLeave={handleProfileSourceSegmentPointerLeave}
                       style={{ flexGrow: source.count }}
                     >
                       <span className="profile-source-tooltip" aria-hidden="true">
@@ -2770,12 +2769,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             {profile.topApps.length > 0 ? (
               <ol className="profile-top-app-list">
                 {profile.topApps.map((app) => (
-                  <li
-                    key={app.targetID}
-                    title={`${app.displayName}: #${app.rank} with ${app.count} update${
-                      app.count === 1 ? "" : "s"
-                    }`}
-                  >
+                  <li key={app.targetID}>
                     <span className={`profile-top-app-rank profile-top-app-rank-${app.rank}`}>
                       {app.rank}
                     </span>
@@ -2791,9 +2785,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                         app.displayName.slice(0, 1).toUpperCase()
                       )}
                     </span>
-                    <span className="profile-top-app-name" title={app.displayName}>
-                      {app.displayName}
-                    </span>
+                    <span className="profile-top-app-name">{app.displayName}</span>
                     <strong>
                       {app.count} update{app.count === 1 ? "" : "s"}
                     </strong>
@@ -2811,21 +2803,14 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
             {profile.topHomebrewItems.length > 0 ? (
               <ol className="profile-top-app-list profile-top-tool-list">
                 {profile.topHomebrewItems.map((item) => (
-                  <li
-                    key={item.targetID}
-                    title={`${item.displayName}: #${item.rank} with ${item.count} update${
-                      item.count === 1 ? "" : "s"
-                    }`}
-                  >
+                  <li key={item.targetID}>
                     <span className={`profile-top-app-rank profile-top-app-rank-${item.rank}`}>
                       {item.rank}
                     </span>
                     <span className="profile-top-app-icon profile-top-tool-icon" aria-hidden="true">
                       <Terminal size={29} strokeWidth={2.2} />
                     </span>
-                    <span className="profile-top-app-name" title={item.displayName}>
-                      {item.displayName}
-                    </span>
+                    <span className="profile-top-app-name">{item.displayName}</span>
                     <strong>
                       {item.count} update{item.count === 1 ? "" : "s"} · {item.kindLabel}
                     </strong>
@@ -2868,6 +2853,16 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
       </section>
     </div>
   );
+}
+
+function handleProfileSourceSegmentPointerMove(event: React.PointerEvent<HTMLSpanElement>) {
+  const bounds = event.currentTarget.getBoundingClientRect();
+  const x = Math.max(0, Math.min(bounds.width, event.clientX - bounds.left));
+  event.currentTarget.style.setProperty("--profile-source-tooltip-x", `${x}px`);
+}
+
+function handleProfileSourceSegmentPointerLeave(event: React.PointerEvent<HTMLSpanElement>) {
+  event.currentTarget.style.removeProperty("--profile-source-tooltip-x");
 }
 
 function ProfileMetric({

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -15,8 +15,8 @@ import {
   Download,
   Eye,
   EyeOff,
-  ExternalLink,
   FolderPlus,
+  Link2,
   Monitor,
   MoreHorizontal,
   Moon,
@@ -1597,7 +1597,7 @@ export function DiscoverRow({
             title="Open Homebrew page"
             aria-label="Open Homebrew page"
           >
-            <ExternalLink size={15} />
+            <Link2 size={15} />
           </button>
         )}
       </div>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2037,8 +2037,15 @@ function HomebrewItemIcon({
   const iconDataURL = item.iconDataURL ?? app?.iconDataURL;
   const isCaskItem = isCask(item.kind);
   const isCliLike = item.kind === "formula" || item.presentation === "cli";
-  const fallbackIcon = isCliLike ? <Terminal size={26} /> : <Package size={26} />;
-  const fallbackClassName = isCaskItem ? "app-icon brew cask" : "app-icon brew formula";
+  const fallbackIcon = isCliLike ? <Terminal size={25} strokeWidth={2.2} /> : <Package size={26} />;
+  const fallbackClassName = [
+    "app-icon",
+    "brew",
+    isCaskItem ? "cask" : "formula",
+    isCliLike ? "tool" : undefined
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   if (app) {
     return (

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2729,8 +2729,6 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                     <span
                       className={`profile-source-segment ${profileSourceClass(source.channel)}`}
                       key={source.channel}
-                      onPointerMove={handleProfileSourceSegmentPointerMove}
-                      onPointerLeave={handleProfileSourceSegmentPointerLeave}
                       style={{ flexGrow: source.count }}
                     >
                       <span className="profile-source-tooltip" aria-hidden="true">
@@ -2853,16 +2851,6 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
       </section>
     </div>
   );
-}
-
-function handleProfileSourceSegmentPointerMove(event: React.PointerEvent<HTMLSpanElement>) {
-  const bounds = event.currentTarget.getBoundingClientRect();
-  const x = Math.max(0, Math.min(bounds.width, event.clientX - bounds.left));
-  event.currentTarget.style.setProperty("--profile-source-tooltip-x", `${x}px`);
-}
-
-function handleProfileSourceSegmentPointerLeave(event: React.PointerEvent<HTMLSpanElement>) {
-  event.currentTarget.style.removeProperty("--profile-source-tooltip-x");
 }
 
 function ProfileMetric({

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1663,9 +1663,12 @@ button:disabled {
   padding: 5px 9px;
   border: 0.5px solid rgba(60, 60, 67, 0.08);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.58);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(255, 255, 255, 0.24)),
+    linear-gradient(135deg, rgba(214, 165, 31, 0.055), rgba(60, 60, 67, 0.018));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.58),
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    inset 0 -1px 0 rgba(60, 60, 67, 0.025),
     0 3px 10px rgba(0, 0, 0, 0.055);
   color: rgba(60, 60, 67, 0.58);
   font-size: 12px;
@@ -1680,9 +1683,12 @@ button:disabled {
 
 .profile-start-date:hover {
   border-color: rgba(60, 60, 67, 0.14);
-  background: rgba(255, 255, 255, 0.74);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.64), rgba(255, 255, 255, 0.32)),
+    linear-gradient(135deg, rgba(214, 165, 31, 0.075), rgba(60, 60, 67, 0.024));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.66),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    inset 0 -1px 0 rgba(60, 60, 67, 0.03),
     0 5px 14px rgba(0, 0, 0, 0.075);
   color: rgba(60, 60, 67, 0.68);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1788,7 +1788,7 @@ button:disabled {
 .profile-source-tooltip {
   position: absolute;
   bottom: calc(100% + 7px);
-  left: 50%;
+  left: var(--profile-source-tooltip-x, 50%);
   z-index: 20;
   width: max-content;
   max-width: 190px;
@@ -1810,11 +1810,6 @@ button:disabled {
     opacity 70ms ease,
     transform 70ms ease;
   white-space: normal;
-}
-
-.profile-source-chip:hover .profile-source-tooltip {
-  opacity: 1;
-  transform: translate(-50%, 0);
 }
 
 .profile-source-segment:first-child {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -734,8 +734,10 @@ button:disabled {
   justify-self: center;
   width: 48px;
   height: 48px;
-  background: #efeff4;
-  color: rgba(60, 60, 67, 0.7);
+  background:
+    linear-gradient(145deg, rgba(232, 154, 23, 0.1), rgba(60, 60, 67, 0.04)),
+    rgba(60, 60, 67, 0.035);
+  color: #9b650b;
 }
 
 .app-icon.brew.formula {
@@ -745,8 +747,7 @@ button:disabled {
 .app-icon.brew.tool {
   border: 0.5px solid rgba(60, 60, 67, 0.08);
   background:
-    linear-gradient(145deg, rgba(232, 154, 23, 0.18), rgba(60, 60, 67, 0.05)),
-    rgba(60, 60, 67, 0.04);
+    linear-gradient(145deg, rgba(232, 154, 23, 0.1), rgba(60, 60, 67, 0.05)), rgba(60, 60, 67, 0.04);
   color: #9b650b;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.72),
@@ -2431,8 +2432,10 @@ button:disabled {
   }
 
   .app-icon.brew {
-    background: #2c2c2e;
-    color: rgba(235, 235, 245, 0.74);
+    background:
+      linear-gradient(145deg, rgba(232, 154, 23, 0.04), rgba(235, 235, 245, 0.04)),
+      rgba(235, 235, 245, 0.045);
+    color: rgba(235, 235, 245, 0.48);
   }
 
   .app-icon.brew.formula {
@@ -2442,7 +2445,7 @@ button:disabled {
   .app-icon.brew.tool {
     border-color: rgba(235, 235, 245, 0.08);
     background:
-      linear-gradient(145deg, rgba(232, 154, 23, 0.07), rgba(235, 235, 245, 0.045)),
+      linear-gradient(145deg, rgba(232, 154, 23, 0.04), rgba(235, 235, 245, 0.045)),
       rgba(235, 235, 245, 0.045);
     color: rgba(235, 235, 245, 0.48);
     box-shadow:

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -705,6 +705,9 @@ button:disabled {
   font-size: 17px;
   font-weight: 700;
   overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.28),
+    0 5px 14px rgba(0, 0, 0, 0.09);
 }
 
 .clickable-app-icon {
@@ -745,6 +748,7 @@ button:disabled {
 .app-icon.app-icon-image {
   border-radius: 12px;
   background: transparent;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.11);
 }
 
 .app-icon img {
@@ -2287,6 +2291,13 @@ button:disabled {
 
   .app-icon {
     background: linear-gradient(180deg, #77777d, #3a3a3c);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 5px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  .app-icon.app-icon-image {
+    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.2);
   }
 
   .app-icon.brew {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -693,6 +693,7 @@ button:disabled {
 }
 
 .app-icon {
+  position: relative;
   display: grid;
   place-items: center;
   width: 50px;
@@ -708,6 +709,21 @@ button:disabled {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.28),
     0 5px 14px rgba(0, 0, 0, 0.09);
+  transition:
+    transform 110ms cubic-bezier(0.2, 0, 0.2, 1),
+    box-shadow 110ms cubic-bezier(0.2, 0, 0.2, 1);
+  will-change: transform;
+}
+
+.app-icon::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.06);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 110ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 
 .clickable-app-icon {
@@ -763,6 +779,31 @@ button:disabled {
 
 .app-icon.app-icon-image img {
   transform: scale(1.18);
+}
+
+@media (hover: hover) {
+  .app-icon:hover {
+    transform: translateY(-1px) scale(1.02);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.32),
+      0 8px 18px rgba(0, 0, 0, 0.13);
+  }
+
+  .app-icon:hover::after {
+    opacity: 1;
+  }
+
+  .app-icon.app-icon-image:hover {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.36),
+      0 8px 18px rgba(0, 0, 0, 0.15);
+  }
+
+  .app-icon.brew.tool:hover {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.78),
+      0 8px 18px rgba(0, 0, 0, 0.11);
+  }
 }
 
 .row-main {
@@ -2164,6 +2205,10 @@ button:disabled {
   }
 
   @media (hover: hover) {
+    .app-icon::after {
+      background: rgba(255, 255, 255, 0.02);
+    }
+
     .source-list button:not(.selected):hover,
     .sidebar-footer button:not(.selected):hover,
     .back-to-app-button:hover {
@@ -2304,6 +2349,26 @@ button:disabled {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 5px 14px rgba(0, 0, 0, 0.2);
+  }
+
+  @media (hover: hover) {
+    .app-icon:hover {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.1),
+        0 8px 18px rgba(0, 0, 0, 0.28);
+    }
+
+    .app-icon.app-icon-image:hover {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.1),
+        0 8px 18px rgba(0, 0, 0, 0.3);
+    }
+
+    .app-icon.brew.tool:hover {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.1),
+        0 8px 18px rgba(0, 0, 0, 0.26);
+    }
   }
 
   .app-icon.brew {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2516,6 +2516,10 @@ button:disabled {
     color: rgba(255, 255, 255, 0.86);
   }
 
+  .profile-start-value {
+    color: #d7d7dc;
+  }
+
   .profile-start-unit {
     color: rgba(235, 235, 245, 0.42);
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1664,6 +1664,9 @@ button:disabled {
   border: 0.5px solid rgba(60, 60, 67, 0.08);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.58);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.58),
+    0 3px 10px rgba(0, 0, 0, 0.055);
   color: rgba(60, 60, 67, 0.58);
   font-size: 12px;
   font-weight: 500;
@@ -1671,12 +1674,16 @@ button:disabled {
   transition:
     border-color 140ms ease,
     background 140ms ease,
+    box-shadow 140ms ease,
     color 140ms ease;
 }
 
 .profile-start-date:hover {
   border-color: rgba(60, 60, 67, 0.14);
   background: rgba(255, 255, 255, 0.74);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.66),
+    0 5px 14px rgba(0, 0, 0, 0.075);
   color: rgba(60, 60, 67, 0.68);
 }
 
@@ -2510,12 +2517,18 @@ button:disabled {
   .profile-start-date {
     border-color: rgba(235, 235, 245, 0.09);
     background: rgba(235, 235, 245, 0.075);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 3px 10px rgba(0, 0, 0, 0.18);
     color: rgba(235, 235, 245, 0.5);
   }
 
   .profile-start-date:hover {
     border-color: rgba(235, 235, 245, 0.15);
     background: rgba(235, 235, 245, 0.105);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 5px 14px rgba(0, 0, 0, 0.24);
     color: rgba(235, 235, 245, 0.62);
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1906,6 +1906,7 @@ button:disabled {
 }
 
 .profile-top-app-icon {
+  position: relative;
   display: grid;
   place-items: center;
   width: 62px;
@@ -1917,6 +1918,21 @@ button:disabled {
   color: white;
   font-size: 22px;
   font-weight: 700;
+  transition:
+    transform 110ms cubic-bezier(0.2, 0, 0.2, 1),
+    box-shadow 110ms cubic-bezier(0.2, 0, 0.2, 1);
+  will-change: transform;
+}
+
+.profile-top-app-icon::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.06);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 110ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 
 .profile-top-app-icon img {
@@ -1939,6 +1955,25 @@ button:disabled {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.72),
     0 5px 14px rgba(0, 0, 0, 0.07);
+}
+
+@media (hover: hover) {
+  .profile-top-app-list li:hover .profile-top-app-icon {
+    transform: translateY(-1px) scale(1.02);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.36),
+      0 8px 18px rgba(0, 0, 0, 0.15);
+  }
+
+  .profile-top-app-list li:hover .profile-top-app-icon::after {
+    opacity: 1;
+  }
+
+  .profile-top-app-list li:hover .profile-top-tool-icon {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.78),
+      0 8px 18px rgba(0, 0, 0, 0.11);
+  }
 }
 
 .profile-top-app-rank {
@@ -2529,6 +2564,24 @@ button:disabled {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 5px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  .profile-top-app-icon::after {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  @media (hover: hover) {
+    .profile-top-app-list li:hover .profile-top-app-icon {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.1),
+        0 8px 18px rgba(0, 0, 0, 0.3);
+    }
+
+    .profile-top-app-list li:hover .profile-top-tool-icon {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.1),
+        0 8px 18px rgba(0, 0, 0, 0.26);
+    }
   }
 
   .profile-top-app-rank {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1944,6 +1944,9 @@ button:disabled {
 
 .profile-top-app-icon.has-image {
   background: transparent;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.32),
+    0 5px 14px rgba(0, 0, 0, 0.11);
 }
 
 .profile-top-tool-icon {
@@ -2577,6 +2580,12 @@ button:disabled {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
       0 5px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  .profile-top-app-icon.has-image {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 5px 14px rgba(0, 0, 0, 0.2);
   }
 
   .profile-top-app-icon::after {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1120,13 +1120,20 @@ button:disabled {
   .primary-button,
   .danger-button,
   .destructive-text-button,
+  .app-icon,
+  .app-icon::after,
+  .profile-top-app-icon,
+  .profile-top-app-icon::after,
   .toolbar-search,
   .toolbar-search-field {
     transition: none;
   }
 
-  .toolbar-search-field {
+  .toolbar-search-field,
+  .app-icon,
+  .profile-top-app-icon {
     transform: none;
+    will-change: auto;
   }
 
   .item-card {
@@ -1142,6 +1149,9 @@ button:disabled {
   .primary-button:not(:disabled):hover,
   .danger-button:not(:disabled):hover,
   .destructive-text-button:not(:disabled):hover,
+  .app-icon:hover,
+  .profile-top-app-list li:hover .profile-top-app-icon,
+  .profile-top-app-list li:hover .profile-top-app-icon:hover,
   .toolbar-button:not(:disabled):active,
   .icon-button:not(:disabled):active,
   .secondary-icon-button:not(:disabled):active,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -746,9 +746,12 @@ button:disabled {
 }
 
 .app-icon.app-icon-image {
+  border: 0.5px solid rgba(60, 60, 67, 0.08);
   border-radius: 12px;
   background: transparent;
-  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.11);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.32),
+    0 5px 14px rgba(0, 0, 0, 0.11);
 }
 
 .app-icon img {
@@ -2297,7 +2300,10 @@ button:disabled {
   }
 
   .app-icon.app-icon-image {
-    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.2);
+    border-color: rgba(235, 235, 245, 0.08);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 5px 14px rgba(0, 0, 0, 0.2);
   }
 
   .app-icon.brew {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1629,7 +1629,7 @@ button:disabled {
 .profile-start-summary {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
+  align-items: center;
   gap: 5px;
   cursor: default;
   user-select: none;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -723,8 +723,23 @@ button:disabled {
   background: #e8eaee;
 }
 
+.app-icon.brew.tool {
+  border: 0.5px solid rgba(60, 60, 67, 0.08);
+  background:
+    linear-gradient(145deg, rgba(232, 154, 23, 0.18), rgba(60, 60, 67, 0.05)),
+    rgba(60, 60, 67, 0.04);
+  color: #9b650b;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 5px 14px rgba(0, 0, 0, 0.07);
+}
+
 .app-icon.brew svg {
   stroke-width: 1.8;
+}
+
+.app-icon.brew.tool svg {
+  stroke-width: 2.2;
 }
 
 .app-icon.app-icon-image {
@@ -2281,6 +2296,17 @@ button:disabled {
 
   .app-icon.brew.formula {
     background: #242427;
+  }
+
+  .app-icon.brew.tool {
+    border-color: rgba(235, 235, 245, 0.08);
+    background:
+      linear-gradient(145deg, rgba(232, 154, 23, 0.07), rgba(235, 235, 245, 0.045)),
+      rgba(235, 235, 245, 0.045);
+    color: rgba(235, 235, 245, 0.48);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 5px 14px rgba(0, 0, 0, 0.18);
   }
 
   .toolbar-button,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -692,10 +692,19 @@ button:disabled {
   gap: 5px;
 }
 
-.app-icon {
+.app-icon,
+.profile-top-app-icon {
   position: relative;
   display: grid;
   place-items: center;
+  overflow: hidden;
+  transition:
+    transform 110ms cubic-bezier(0.2, 0, 0.2, 1),
+    box-shadow 110ms cubic-bezier(0.2, 0, 0.2, 1);
+  will-change: transform;
+}
+
+.app-icon {
   width: 50px;
   height: 50px;
   padding: 0;
@@ -705,17 +714,13 @@ button:disabled {
   color: white;
   font-size: 17px;
   font-weight: 700;
-  overflow: hidden;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.28),
     0 5px 14px rgba(0, 0, 0, 0.09);
-  transition:
-    transform 110ms cubic-bezier(0.2, 0, 0.2, 1),
-    box-shadow 110ms cubic-bezier(0.2, 0, 0.2, 1);
-  will-change: transform;
 }
 
-.app-icon::after {
+.app-icon::after,
+.profile-top-app-icon::after {
   position: absolute;
   inset: 0;
   border-radius: inherit;
@@ -783,14 +788,19 @@ button:disabled {
 }
 
 @media (hover: hover) {
-  .app-icon:hover {
+  .app-icon:hover,
+  .profile-top-app-list li:hover .profile-top-app-icon {
     transform: translateY(-1px) scale(1.02);
+  }
+
+  .app-icon:hover {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.32),
       0 8px 18px rgba(0, 0, 0, 0.13);
   }
 
-  .app-icon:hover::after {
+  .app-icon:hover::after,
+  .profile-top-app-list li:hover .profile-top-app-icon::after {
     opacity: 1;
   }
 
@@ -1925,33 +1935,14 @@ button:disabled {
 }
 
 .profile-top-app-icon {
-  position: relative;
-  display: grid;
-  place-items: center;
   width: 62px;
   height: 62px;
   border-radius: 15px;
-  overflow: hidden;
   background: linear-gradient(180deg, #85858c, #595961);
   box-shadow: 0 5px 14px rgba(0, 0, 0, 0.11);
   color: white;
   font-size: 22px;
   font-weight: 700;
-  transition:
-    transform 110ms cubic-bezier(0.2, 0, 0.2, 1),
-    box-shadow 110ms cubic-bezier(0.2, 0, 0.2, 1);
-  will-change: transform;
-}
-
-.profile-top-app-icon::after {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: rgba(255, 255, 255, 0.06);
-  content: "";
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 110ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 
 .profile-top-app-icon img {
@@ -1981,14 +1972,9 @@ button:disabled {
 
 @media (hover: hover) {
   .profile-top-app-list li:hover .profile-top-app-icon {
-    transform: translateY(-1px) scale(1.02);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.36),
       0 8px 18px rgba(0, 0, 0, 0.15);
-  }
-
-  .profile-top-app-list li:hover .profile-top-app-icon::after {
-    opacity: 1;
   }
 
   .profile-top-app-list li:hover .profile-top-tool-icon {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1970,8 +1970,9 @@ button:disabled {
     0 5px 14px rgba(0, 0, 0, 0.07);
 }
 
-@media (hover: hover) {
+@media (hover: hover) and (prefers-reduced-motion: no-preference) {
   .profile-top-app-list li:hover .profile-top-app-icon {
+    transform: translateY(-1px) scale(1.02);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.36),
       0 8px 18px rgba(0, 0, 0, 0.15);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1974,6 +1974,19 @@ button:disabled {
       inset 0 1px 0 rgba(255, 255, 255, 0.78),
       0 8px 18px rgba(0, 0, 0, 0.11);
   }
+
+  .profile-top-app-list li:hover .profile-top-app-icon:hover {
+    transform: translateY(-2px) scale(1.04);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.4),
+      0 10px 22px rgba(0, 0, 0, 0.18);
+  }
+
+  .profile-top-app-list li:hover .profile-top-tool-icon:hover {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.82),
+      0 10px 22px rgba(0, 0, 0, 0.14);
+  }
 }
 
 .profile-top-app-rank {
@@ -2581,6 +2594,18 @@ button:disabled {
       box-shadow:
         inset 0 1px 0 rgba(255, 255, 255, 0.1),
         0 8px 18px rgba(0, 0, 0, 0.26);
+    }
+
+    .profile-top-app-list li:hover .profile-top-app-icon:hover {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        0 10px 22px rgba(0, 0, 0, 0.34);
+    }
+
+    .profile-top-app-list li:hover .profile-top-tool-icon:hover {
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        0 10px 22px rgba(0, 0, 0, 0.3);
     }
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1788,7 +1788,7 @@ button:disabled {
 .profile-source-tooltip {
   position: absolute;
   bottom: calc(100% + 7px);
-  left: var(--profile-source-tooltip-x, 50%);
+  left: 50%;
   z-index: 20;
   width: max-content;
   max-width: 190px;


### PR DESCRIPTION
## Summary
- Updates main-window Homebrew fallback icons with the same dimensional terminal treatment used in Profile stats, including aligned package/cask glyph colors and low-opacity gold backgrounds.
- Adds neutral depth, hover motion, and subtle overlays to app icons and Profile top app/tool icons.
- Polishes Profile stats visual details, including the date pill, top icon depth, native tooltip removal, centered Source mix tooltip behavior, and Discover link icon.

## Validation
- `npm run typecheck`
- `npm test -- --run ElectronTests/rendererButtons.test.tsx -t "profile stats"`
- `npm test -- --run ElectronTests/rendererButtons.test.tsx -t "shows presentation labels"`
