### PR TITLE
Use versioned release build numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Prepare unsigned release artifacts
+        env:
+          BASELINE_RELEASE_BUILD: "1"
         run: scripts/prepare-unsigned-release.sh "${{ steps.version.outputs.version }}"
 
       - name: Upload unsigned release artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
           tag="${GITHUB_REF_NAME}"
           version="${tag#v}"
 
-          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
-            echo "Tag must look like v0.1.0"
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]?)[.](0|[1-9][0-9]?)$ ]]; then
+            echo "Tag must look like v0.1.0 with minor and patch below 100"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
           tag="${GITHUB_REF_NAME}"
           version="${tag#v}"
 
-          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
-            echo "Tag must look like v0.1.0 or v0.1.0-beta.1"
+          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Tag must look like v0.1.0"
             exit 1
           fi
 

--- a/ElectronTests/buildNumber.test.ts
+++ b/ElectronTests/buildNumber.test.ts
@@ -32,4 +32,10 @@ describe("build numbers", () => {
     expect(buildNumberForAppVersion("0.3.0-beta.1")).toBeUndefined();
     expect(buildNumberForAppVersion("0.3.0+build.1")).toBeUndefined();
   });
+
+  it("does not derive release build numbers for components outside packed slots", () => {
+    expect(buildNumberForAppVersion("0.3.100")).toBeUndefined();
+    expect(buildNumberForAppVersion("0.100.0")).toBeUndefined();
+    expect(buildNumberForAppVersion("0.03.0")).toBeUndefined();
+  });
 });

--- a/ElectronTests/buildNumber.test.ts
+++ b/ElectronTests/buildNumber.test.ts
@@ -27,4 +27,9 @@ describe("build numbers", () => {
     expect(buildNumberForAppVersion("1.1.0")).toBe("1010000");
     expect(buildNumberForAppVersion("3.0.0")).toBe("3000000");
   });
+
+  it("does not derive release build numbers for prerelease or build suffixes", () => {
+    expect(buildNumberForAppVersion("0.3.0-beta.1")).toBeUndefined();
+    expect(buildNumberForAppVersion("0.3.0+build.1")).toBeUndefined();
+  });
 });

--- a/ElectronTests/buildNumber.test.ts
+++ b/ElectronTests/buildNumber.test.ts
@@ -6,22 +6,25 @@ import { buildNumberForAppVersion, validBuildNumber } from "../src/shared/buildN
 
 describe("build numbers", () => {
   it("derives public release build numbers from app versions", () => {
-    expect(buildNumberForAppVersion("0.1.0")).toBe("100");
-    expect(buildNumberForAppVersion("0.2.0")).toBe("200");
-    expect(buildNumberForAppVersion("0.3.0")).toBe("300");
-    expect(buildNumberForAppVersion("0.3.1")).toBe("310");
-    expect(buildNumberForAppVersion("0.4.0")).toBe("400");
+    expect(buildNumberForAppVersion("0.1.0")).toBe("10000");
+    expect(buildNumberForAppVersion("0.2.0")).toBe("20000");
+    expect(buildNumberForAppVersion("0.3.0")).toBe("30000");
+    expect(buildNumberForAppVersion("0.3.1")).toBe("30100");
+    expect(buildNumberForAppVersion("0.4.0")).toBe("40000");
   });
 
   it("reserves one-off values between release builds for rebuilt artifacts", () => {
-    expect(buildNumberForAppVersion("0.3.0")).toBe("300");
-    expect(validBuildNumber("301")).toBe("301");
-    expect(buildNumberForAppVersion("0.3.1")).toBe("310");
+    expect(buildNumberForAppVersion("0.3.0")).toBe("30000");
+    expect(validBuildNumber("30001")).toBe("30001");
+    expect(buildNumberForAppVersion("0.3.1")).toBe("30100");
   });
 
   it("keeps pre-1.0 and post-1.0 build numbers monotonic", () => {
-    expect(buildNumberForAppVersion("1.0.0")).toBe("10000");
-    expect(buildNumberForAppVersion("1.0.1")).toBe("10010");
-    expect(buildNumberForAppVersion("1.1.0")).toBe("10100");
+    expect(buildNumberForAppVersion("0.3.10")).toBe("31000");
+    expect(buildNumberForAppVersion("0.4.0")).toBe("40000");
+    expect(buildNumberForAppVersion("1.0.0")).toBe("1000000");
+    expect(buildNumberForAppVersion("1.0.1")).toBe("1000100");
+    expect(buildNumberForAppVersion("1.1.0")).toBe("1010000");
+    expect(buildNumberForAppVersion("3.0.0")).toBe("3000000");
   });
 });

--- a/ElectronTests/buildNumber.test.ts
+++ b/ElectronTests/buildNumber.test.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { describe, expect, it } from "vitest";
+import { buildNumberForAppVersion, validBuildNumber } from "../src/shared/buildNumber";
+
+describe("build numbers", () => {
+  it("derives public release build numbers from app versions", () => {
+    expect(buildNumberForAppVersion("0.1.0")).toBe("100");
+    expect(buildNumberForAppVersion("0.2.0")).toBe("200");
+    expect(buildNumberForAppVersion("0.3.0")).toBe("300");
+    expect(buildNumberForAppVersion("0.3.1")).toBe("310");
+    expect(buildNumberForAppVersion("0.4.0")).toBe("400");
+  });
+
+  it("reserves one-off values between release builds for rebuilt artifacts", () => {
+    expect(buildNumberForAppVersion("0.3.0")).toBe("300");
+    expect(validBuildNumber("301")).toBe("301");
+    expect(buildNumberForAppVersion("0.3.1")).toBe("310");
+  });
+
+  it("keeps pre-1.0 and post-1.0 build numbers monotonic", () => {
+    expect(buildNumberForAppVersion("1.0.0")).toBe("10000");
+    expect(buildNumberForAppVersion("1.0.1")).toBe("10010");
+    expect(buildNumberForAppVersion("1.1.0")).toBe("10100");
+  });
+});

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -90,9 +90,18 @@ function releaseBuildNumber(): string {
 }
 
 function releaseVersionBuildNumber(): string | undefined {
-  return process.env.BASELINE_RELEASE_BUILD === "1"
-    ? buildNumberForAppVersion(packageJSON.version)
-    : undefined;
+  if (process.env.BASELINE_RELEASE_BUILD !== "1") {
+    return undefined;
+  }
+
+  const buildNumber = buildNumberForAppVersion(packageJSON.version);
+  if (!buildNumber) {
+    throw new Error(
+      `Cannot derive release build number from package version ${packageJSON.version}. ` +
+        "Use a stable x.y.z version with minor and patch components below 100."
+    );
+  }
+  return buildNumber;
 }
 
 function gitCommitCount(): string | undefined {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,8 +7,7 @@ import { MakerZIP } from "@electron-forge/maker-zip";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { execFileSync } from "node:child_process";
 import packageJSON from "./package.json";
-
-const buildNumberPattern = /^[0-9][0-9.]*$/u;
+import { buildNumberForAppVersion, validBuildNumber } from "./src/shared/buildNumber";
 
 function macOSMajorVersion(): number | undefined {
   if (process.platform !== "darwin") {
@@ -82,10 +81,18 @@ export default config;
 
 function releaseBuildNumber(): string {
   return (
-    validBuildNumber(process.env.BASELINE_BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER) ??
+    validBuildNumber(process.env.BASELINE_BUILD_NUMBER) ??
+    releaseVersionBuildNumber() ??
+    validBuildNumber(process.env.GITHUB_RUN_NUMBER) ??
     gitCommitCount() ??
     "1"
   );
+}
+
+function releaseVersionBuildNumber(): string | undefined {
+  return process.env.BASELINE_RELEASE_BUILD === "1"
+    ? buildNumberForAppVersion(packageJSON.version)
+    : undefined;
 }
 
 function gitCommitCount(): string | undefined {
@@ -99,9 +106,4 @@ function gitCommitCount(): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-function validBuildNumber(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && buildNumberPattern.test(trimmed) ? trimmed : undefined;
 }

--- a/scripts/check-release-assets.sh
+++ b/scripts/check-release-assets.sh
@@ -11,8 +11,8 @@ fi
 TAG="${1:-$(git describe --tags --abbrev=0)}"
 REPOSITORY="arshiaghaf/Baseline"
 
-if [[ ! "$TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
-  echo "Tag must look like v0.1.0 or v0.1.0-beta.1"
+if [[ ! "$TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "Tag must look like v0.1.0"
   exit 1
 fi
 

--- a/scripts/check-release-assets.sh
+++ b/scripts/check-release-assets.sh
@@ -11,8 +11,8 @@ fi
 TAG="${1:-$(git describe --tags --abbrev=0)}"
 REPOSITORY="arshiaghaf/Baseline"
 
-if [[ ! "$TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
-  echo "Tag must look like v0.1.0"
+if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]?)[.](0|[1-9][0-9]?)$ ]]; then
+  echo "Tag must look like v0.1.0 with minor and patch below 100"
   exit 1
 fi
 

--- a/scripts/create-unsigned-dmg.sh
+++ b/scripts/create-unsigned-dmg.sh
@@ -18,8 +18,8 @@ VOLUME_NAME="${APP_NAME} ${VERSION}"
 ARCH="$(uname -m)"
 PACKAGE_APP_PATH="$ROOT_DIR/out/${APP_NAME}-darwin-${ARCH}/${APP_NAME}.app"
 
-if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
-  echo "Version must look like 0.1.0"
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]?)[.](0|[1-9][0-9]?)$ ]]; then
+  echo "Version must look like 0.1.0 with minor and patch below 100"
   exit 1
 fi
 

--- a/scripts/create-unsigned-dmg.sh
+++ b/scripts/create-unsigned-dmg.sh
@@ -18,8 +18,8 @@ VOLUME_NAME="${APP_NAME} ${VERSION}"
 ARCH="$(uname -m)"
 PACKAGE_APP_PATH="$ROOT_DIR/out/${APP_NAME}-darwin-${ARCH}/${APP_NAME}.app"
 
-if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]?)[.](0|[1-9][0-9]?)$ ]]; then
-  echo "Version must look like 0.1.0 with minor and patch below 100"
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]?)[.](0|[1-9][0-9]?)(-preview)?$ ]]; then
+  echo "Version must look like 0.1.0 or 0.0.0-preview with minor and patch below 100"
   exit 1
 fi
 

--- a/scripts/create-unsigned-dmg.sh
+++ b/scripts/create-unsigned-dmg.sh
@@ -18,8 +18,8 @@ VOLUME_NAME="${APP_NAME} ${VERSION}"
 ARCH="$(uname -m)"
 PACKAGE_APP_PATH="$ROOT_DIR/out/${APP_NAME}-darwin-${ARCH}/${APP_NAME}.app"
 
-if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
-  echo "Version must look like 0.1.0 or 0.1.0-beta.1"
+if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "Version must look like 0.1.0"
   exit 1
 fi
 

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -18,8 +18,8 @@ CHANGELOG_SECTION_PATH="$(mktemp)"
 
 trap 'rm -f "$CHANGELOG_SECTION_PATH"' EXIT
 
-if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
-  echo "Version must look like 0.1.0"
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]?)[.](0|[1-9][0-9]?)$ ]]; then
+  echo "Version must look like 0.1.0 with minor and patch below 100"
   exit 1
 fi
 

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -118,7 +118,7 @@ if (releaseNoteLines.length === 0) {
 fs.writeFileSync(outputPath, `${releaseNoteLines.join("\n")}\n`);
 NODE
 
-scripts/create-unsigned-dmg.sh "$VERSION"
+BASELINE_RELEASE_BUILD=1 scripts/create-unsigned-dmg.sh "$VERSION"
 
 if [[ ! -f "$DMG_PATH" ]]; then
   echo "Expected DMG was not created at $DMG_PATH"

--- a/scripts/prepare-unsigned-release.sh
+++ b/scripts/prepare-unsigned-release.sh
@@ -18,8 +18,8 @@ CHANGELOG_SECTION_PATH="$(mktemp)"
 
 trap 'rm -f "$CHANGELOG_SECTION_PATH"' EXIT
 
-if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
-  echo "Version must look like 0.1.0 or 0.1.0-beta.1"
+if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "Version must look like 0.1.0"
   exit 1
 fi
 

--- a/src/main/appMetadata.ts
+++ b/src/main/appMetadata.ts
@@ -5,8 +5,7 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 import type { App } from "electron";
 import { formatAppDisplayVersion, type AppMetadata } from "../shared/appMetadata";
-
-const buildNumberPattern = /^[0-9][0-9.]*$/u;
+import { validBuildNumber } from "../shared/buildNumber";
 
 export function appMetadata(app: App): AppMetadata {
   const version = app.getVersion();
@@ -56,9 +55,4 @@ function runBuildNumberCommand(command: string, args: string[], cwd?: string): s
   } catch {
     return undefined;
   }
-}
-
-function validBuildNumber(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && buildNumberPattern.test(trimmed) ? trimmed : undefined;
 }

--- a/src/shared/buildNumber.ts
+++ b/src/shared/buildNumber.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+const buildNumberPattern = /^[0-9][0-9.]*$/u;
+const appVersionPattern = /^(\d+)\.(\d+)\.(\d+)(?:[-+][A-Za-z0-9._-]+)?$/u;
+
+export function validBuildNumber(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && buildNumberPattern.test(trimmed) ? trimmed : undefined;
+}
+
+export function buildNumberForAppVersion(value: string): string | undefined {
+  const match = appVersionPattern.exec(value.trim());
+  if (!match) {
+    return undefined;
+  }
+
+  const major = Number.parseInt(match[1] ?? "", 10);
+  const minor = Number.parseInt(match[2] ?? "", 10);
+  const patch = Number.parseInt(match[3] ?? "", 10);
+  if (![major, minor, patch].every(Number.isSafeInteger)) {
+    return undefined;
+  }
+
+  const buildNumber =
+    major > 0 ? major * 10000 + minor * 100 + patch * 10 : minor * 100 + patch * 10;
+  return buildNumber > 0 ? String(buildNumber) : undefined;
+}

--- a/src/shared/buildNumber.ts
+++ b/src/shared/buildNumber.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const buildNumberPattern = /^[0-9][0-9.]*$/u;
-const appVersionPattern = /^(\d+)\.(\d+)\.(\d+)(?:[-+][A-Za-z0-9._-]+)?$/u;
+const appVersionPattern = /^(\d+)\.(\d+)\.(\d+)$/u;
 
 export function validBuildNumber(value: string | undefined): string | undefined {
   const trimmed = value?.trim();

--- a/src/shared/buildNumber.ts
+++ b/src/shared/buildNumber.ts
@@ -22,7 +22,6 @@ export function buildNumberForAppVersion(value: string): string | undefined {
     return undefined;
   }
 
-  const buildNumber =
-    major > 0 ? major * 10000 + minor * 100 + patch * 10 : minor * 100 + patch * 10;
+  const buildNumber = major * 1_000_000 + minor * 10_000 + patch * 100;
   return buildNumber > 0 ? String(buildNumber) : undefined;
 }

--- a/src/shared/buildNumber.ts
+++ b/src/shared/buildNumber.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const buildNumberPattern = /^[0-9][0-9.]*$/u;
-const appVersionPattern = /^(\d+)\.(\d+)\.(\d+)$/u;
+const appVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d?)\.(0|[1-9]\d?)$/u;
 
 export function validBuildNumber(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -23,5 +23,5 @@ export function buildNumberForAppVersion(value: string): string | undefined {
   }
 
   const buildNumber = major * 1_000_000 + minor * 10_000 + patch * 100;
-  return buildNumber > 0 ? String(buildNumber) : undefined;
+  return buildNumber > 0 && Number.isSafeInteger(buildNumber) ? String(buildNumber) : undefined;
 }


### PR DESCRIPTION
## Summary
- Add a shared build-number helper that derives public release build numbers from stable app versions, such as `0.3.0 -> 30000` and `0.3.1 -> 30100`.
- Make the release workflow opt into version-derived build numbers with `BASELINE_RELEASE_BUILD=1`, while preserving explicit `BASELINE_BUILD_NUMBER` for one-off rebuilt artifacts.
- Keep internal/dev build fallbacks intact through `GITHUB_RUN_NUMBER` and local git commit count, and require stable `x.y.z` versions for release artifact scripts.

## Validation
- `npm test -- --run ElectronTests/buildNumber.test.ts`
- `bash -n scripts/check-release-assets.sh scripts/create-unsigned-dmg.sh scripts/prepare-unsigned-release.sh`
- `npm run typecheck`
- `npm run lint`
