### PR TITLE
Move search to a sidebar palette

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -331,14 +331,15 @@ describe("renderer button parity", () => {
       />
     );
 
-    const discoverHeading = screen.getByText("Discover");
-    const homebrewHeading = screen.getByText("Homebrew Updates");
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    const discoverHeading = within(searchDialog).getByText("Discover");
+    const homebrewHeading = within(searchDialog).getByText("Homebrew Updates");
     expect(
       discoverHeading.compareDocumentPosition(homebrewHeading) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
-    expect(screen.queryByTitle("Collapse Discover")).not.toBeInTheDocument();
-    expect(screen.getByText("obsidian-cli")).toBeInTheDocument();
-    expect(screen.getByText("Obsidian")).toBeInTheDocument();
+    expect(within(searchDialog).queryByTitle("Collapse Discover")).not.toBeInTheDocument();
+    expect(within(searchDialog).getByText("obsidian-cli")).toBeInTheDocument();
+    expect(within(searchDialog).getByText("Obsidian")).toBeInTheDocument();
   });
 
   it("shows the main-window self-update shortcut only when self-update is available", () => {
@@ -379,6 +380,33 @@ describe("renderer button parity", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("opens the main-window search palette from keyboard shortcuts without selecting the query", () => {
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "apps",
+          searchText: "obsidian"
+        })}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: "k", metaKey: true });
+
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    const searchField = within(searchDialog).getByDisplayValue("obsidian") as HTMLInputElement;
+    expect(searchField).toHaveFocus();
+    expect(searchField.selectionStart).toBe(searchField.value.length);
+    expect(searchField.selectionEnd).toBe(searchField.value.length);
+    expect(screen.getByRole("heading", { level: 1, name: "Apps" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Apps" })).toBeInTheDocument();
+  });
+
   it("closes search mode on sidebar tab clicks without clearing the saved query", async () => {
     const formula: HomebrewManagedItem = {
       id: "formula:obsidian-cli",
@@ -414,24 +442,27 @@ describe("renderer button parity", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
 
-    expect(screen.getByText("Obsidian")).toBeInTheDocument();
-    expect(screen.getByText("obsidian-cli")).toBeInTheDocument();
-    expect(screen.queryByText("Example")).not.toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).getByText("Obsidian")).toBeInTheDocument();
+    expect(within(searchDialog).getByText("obsidian-cli")).toBeInTheDocument();
+    expect(within(searchDialog).queryByText("Example")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
 
     expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("apps");
     expect(window.baseline.setSearchText).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
     await waitFor(() => expect(screen.getByText("Example")).toBeInTheDocument());
     expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
     expect(screen.queryByText("obsidian-cli")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
 
-    expect(screen.getByDisplayValue("obsidian")).toBeInTheDocument();
-    expect(screen.getByText("Obsidian")).toBeInTheDocument();
-    expect(screen.getByText("obsidian-cli")).toBeInTheDocument();
+    const reopenedSearchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(reopenedSearchDialog).getByDisplayValue("obsidian")).toBeInTheDocument();
+    expect(within(reopenedSearchDialog).getByText("Obsidian")).toBeInTheDocument();
+    expect(within(reopenedSearchDialog).getByText("obsidian-cli")).toBeInTheDocument();
   });
 
   it("does not show discovery results after dismissing search into the Homebrew tab", () => {
@@ -466,8 +497,9 @@ describe("renderer button parity", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
 
-    expect(screen.getByText("Obsidian")).toBeInTheDocument();
-    expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).getByText("Obsidian")).toBeInTheDocument();
+    expect(within(searchDialog).queryByText("ripgrep")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Homebrew/ }));
 
@@ -480,6 +512,7 @@ describe("renderer button parity", () => {
       />
     );
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
     expect(screen.getByText("ripgrep")).toBeInTheDocument();
     expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
   });
@@ -506,7 +539,8 @@ describe("renderer button parity", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
-    expect(screen.getByText("Obsidian")).toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).getByText("Obsidian")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
 
     unmount();
@@ -555,9 +589,10 @@ describe("renderer button parity", () => {
     expect(within(allButton as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(within(appsButton as HTMLElement).getByText("1")).toBeInTheDocument();
     expect(within(homebrewButton as HTMLElement).getByText("1")).toBeInTheDocument();
-    expect(screen.getByText("Stable App")).toBeInTheDocument();
-    expect(screen.queryByText("Example")).not.toBeInTheDocument();
-    expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).getByText("Stable App")).toBeInTheDocument();
+    expect(within(searchDialog).queryByText("Example")).not.toBeInTheDocument();
+    expect(within(searchDialog).queryByText("ripgrep")).not.toBeInTheDocument();
   });
 
   it("hides sidebar update badges when counts are zero", () => {
@@ -1512,7 +1547,8 @@ describe("renderer button parity", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    fireEvent.click(within(searchDialog).getByRole("button", { name: "Install" }));
     const dialog = screen.getByRole("dialog", { name: "Install Raycast?" });
     fireEvent.click(within(dialog).getByRole("button", { name: "Install Raycast" }));
     expect(window.baseline.installHomebrewItem).toHaveBeenCalledWith(item);
@@ -1730,15 +1766,16 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.getByText("Example CLI")).toBeInTheDocument();
-    expect(screen.queryByText("App Updates")).not.toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).getByText("Example CLI")).toBeInTheDocument();
+    expect(within(searchDialog).queryByText("App Updates")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Update Brews" }));
+    const formulaRow = within(searchDialog).getByText("ripgrep-cli").closest("article");
+    expect(formulaRow).not.toBeNull();
+    fireEvent.click(within(formulaRow as HTMLElement).getByRole("button", { name: "Update" }));
 
-    expect(window.baseline.performHomebrewUpdateAll).toHaveBeenCalledWith([
-      searchCask.id,
-      formula.id
-    ]);
+    expect(window.baseline.performHomebrewUpdate).toHaveBeenCalledWith(formula.id);
+    expect(window.baseline.performHomebrewUpdateAll).not.toHaveBeenCalled();
   });
 
   it("hides ignored app-backed Homebrew casks from search results", () => {
@@ -1771,8 +1808,9 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.queryByText("Example CLI")).not.toBeInTheDocument();
-    expect(screen.getByText("ripgrep-cli")).toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).queryByText("Example CLI")).not.toBeInTheDocument();
+    expect(within(searchDialog).getByText("ripgrep-cli")).toBeInTheDocument();
   });
 
   it("moves installed apps and Homebrew into the Installed sidebar item", () => {
@@ -1905,11 +1943,14 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { level: 1, name: "Search" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 2, name: "Ignored" })).toBeInTheDocument();
-    expect(screen.getByText("ripgrep")).toBeInTheDocument();
-    expect(screen.queryByText("Example")).not.toBeInTheDocument();
-    expect(screen.queryByText("No matches found.")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Ignored" })).toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(
+      within(searchDialog).getByRole("heading", { level: 2, name: "Ignored Homebrew" })
+    ).toBeInTheDocument();
+    expect(within(searchDialog).getByText("ripgrep")).toBeInTheDocument();
+    expect(within(searchDialog).queryByText("Example")).not.toBeInTheDocument();
+    expect(within(searchDialog).queryByText("No matches found.")).not.toBeInTheDocument();
   });
 
   it("keeps app sections visible without Settings section controls", () => {
@@ -2331,7 +2372,7 @@ describe("renderer button parity", () => {
       version: version("1.0.0")
     };
 
-    const { container } = render(
+    render(
       <Dashboard
         compact={false}
         searchActive
@@ -2347,14 +2388,21 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.getByText("Notion Notes")).toBeInTheDocument();
-    expect(screen.getByText("notion-cli")).toBeInTheDocument();
-    expect(screen.getByText("Notion Calendar")).toBeInTheDocument();
-    expect(screen.queryByText("All your apps are up to date.")).not.toBeInTheDocument();
-    expect(screen.queryByText("All your Homebrew items are up to date.")).not.toBeInTheDocument();
-    expect(screen.getAllByRole("heading", { level: 2 })[0]).toHaveTextContent("Discover");
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(within(searchDialog).getByText("Notion Notes")).toBeInTheDocument();
+    expect(within(searchDialog).getByText("notion-cli")).toBeInTheDocument();
+    expect(within(searchDialog).getByText("Notion Calendar")).toBeInTheDocument();
+    expect(
+      within(searchDialog).queryByText("All your apps are up to date.")
+    ).not.toBeInTheDocument();
+    expect(
+      within(searchDialog).queryByText("All your Homebrew items are up to date.")
+    ).not.toBeInTheDocument();
+    expect(within(searchDialog).getAllByRole("heading", { level: 2 })[0]).toHaveTextContent(
+      "Discover"
+    );
 
-    const sections = Array.from(container.querySelectorAll("section.panel"));
+    const sections = Array.from(searchDialog.querySelectorAll(".search-palette-section"));
     const discoverSection = sections.find((section) =>
       within(section as HTMLElement).queryByRole("heading", { name: "Discover" })
     ) as HTMLElement | undefined;
@@ -2370,10 +2418,10 @@ describe("renderer button parity", () => {
     expect(installedHomebrewSection).toBeDefined();
     expect(discoverSection!.querySelector(".rows .row")).not.toBeNull();
     expect(discoverSection!.querySelector(".item-card")).toBeNull();
-    expect(installedAppsSection!.querySelector(".card-grid .item-card")).not.toBeNull();
-    expect(installedAppsSection!.querySelector(".rows .row")).toBeNull();
-    expect(installedHomebrewSection!.querySelector(".card-grid .item-card")).not.toBeNull();
-    expect(installedHomebrewSection!.querySelector(".rows .row")).toBeNull();
+    expect(installedAppsSection!.querySelector(".rows .row")).not.toBeNull();
+    expect(installedAppsSection!.querySelector(".item-card")).toBeNull();
+    expect(installedHomebrewSection!.querySelector(".rows .row")).not.toBeNull();
+    expect(installedHomebrewSection!.querySelector(".item-card")).toBeNull();
   });
 
   it("shows app-backed Homebrew updates in search when the app result does not match", () => {
@@ -2411,9 +2459,14 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.queryByRole("heading", { name: "App Updates" })).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Homebrew Updates" })).toBeInTheDocument();
-    expect(screen.getByText("Long Token Name")).toBeInTheDocument();
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    expect(
+      within(searchDialog).queryByRole("heading", { name: "App Updates" })
+    ).not.toBeInTheDocument();
+    expect(
+      within(searchDialog).getByRole("heading", { name: "Homebrew Updates" })
+    ).toBeInTheDocument();
+    expect(within(searchDialog).getByText("Long Token Name")).toBeInTheDocument();
   });
 
   it("search hides cask-backed apps from Installed Apps", () => {
@@ -2455,10 +2508,11 @@ describe("renderer button parity", () => {
       />
     );
 
-    const installedApps = screen
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    const installedApps = within(searchDialog)
       .getByRole("heading", { name: "Installed Apps" })
       .closest("section");
-    const installedHomebrew = screen
+    const installedHomebrew = within(searchDialog)
       .getByRole("heading", { name: "Installed Homebrew" })
       .closest("section");
     expect(installedApps).not.toBeNull();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -524,7 +524,7 @@ describe("renderer button parity", () => {
       fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
       const menu = screen.getByRole("menu");
       expect(menu).toHaveClass("row-action-menu-popover-floating");
-      expect(searchDialog).toContainElement(menu);
+      expect(searchDialog).not.toContainElement(menu);
       expect(menu).toHaveStyle({ visibility: "visible" });
       let ignoreMenuItem = screen.getByRole("menuitem", { name: "Ignore" });
       expect(ignoreMenuItem).toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -511,7 +511,6 @@ describe("renderer button parity", () => {
       render(
         <Dashboard
           compact={false}
-          searchActive
           onOpenSettings={() => undefined}
           snapshot={snapshot({
             selectedTab: "apps",
@@ -520,6 +519,7 @@ describe("renderer button parity", () => {
         />
       );
 
+      fireEvent.click(screen.getByRole("button", { name: "Search" }));
       const searchDialog = screen.getByRole("dialog", { name: "Search" });
       fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
       const menu = screen.getByRole("menu");

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -380,7 +380,7 @@ describe("renderer button parity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("opens the main-window search palette from keyboard shortcuts without selecting the query", () => {
+  it("opens the main-window search palette from keyboard shortcuts without selecting the query", async () => {
     render(
       <Dashboard
         compact={false}
@@ -395,6 +395,11 @@ describe("renderer button parity", () => {
     fireEvent.keyDown(document, { key: "k", ctrlKey: true });
     expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
 
+    const appSurface = document.querySelector(".app-content-surface") as HTMLElement & {
+      inert?: boolean;
+    };
+    const refreshButton = screen.getByRole("button", { name: "Refresh" });
+    refreshButton.focus();
     fireEvent.keyDown(document, { key: "k", metaKey: true });
 
     const searchDialog = screen.getByRole("dialog", { name: "Search" });
@@ -402,15 +407,24 @@ describe("renderer button parity", () => {
     expect(searchField).toHaveFocus();
     expect(searchField.selectionStart).toBe(searchField.value.length);
     expect(searchField.selectionEnd).toBe(searchField.value.length);
-    expect(screen.getByRole("heading", { level: 1, name: "Apps" })).toBeInTheDocument();
+    expect(appSurface).toHaveAttribute("aria-hidden", "true");
+    expect(appSurface.inert).toBe(true);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Apps", hidden: true })
+    ).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: "Escape" });
 
-    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument()
+    );
+    await waitFor(() => expect(refreshButton).toHaveFocus());
+    expect(appSurface).not.toHaveAttribute("aria-hidden");
+    expect(appSurface.inert).toBe(false);
     expect(screen.getByRole("heading", { level: 1, name: "Apps" })).toBeInTheDocument();
   });
 
-  it("closes search mode on sidebar tab clicks without clearing the saved query", async () => {
+  it("closes search mode on backdrop clicks without clearing the saved query", async () => {
     const formula: HomebrewManagedItem = {
       id: "formula:obsidian-cli",
       token: "obsidian-cli",
@@ -450,6 +464,7 @@ describe("renderer button parity", () => {
     expect(within(searchDialog).getByText("obsidian-cli")).toBeInTheDocument();
     expect(within(searchDialog).queryByText("Example")).not.toBeInTheDocument();
 
+    fireEvent.mouseDown(container.querySelector(".search-palette-backdrop") as HTMLElement);
     fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
 
     expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("apps");
@@ -467,7 +482,7 @@ describe("renderer button parity", () => {
     expect(within(reopenedSearchDialog).getByText("Obsidian")).toBeInTheDocument();
     expect(within(reopenedSearchDialog).getByText("obsidian-cli")).toBeInTheDocument();
 
-    fireEvent.mouseDown(container.querySelector(".sidebar") as HTMLElement);
+    fireEvent.mouseDown(container.querySelector(".search-palette-backdrop") as HTMLElement);
     expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
 
     const searchButton = screen.getByRole("button", { name: "Search" });
@@ -475,8 +490,7 @@ describe("renderer button parity", () => {
     fireEvent.click(searchButton);
     expect(screen.getByRole("dialog", { name: "Search" })).toBeInTheDocument();
 
-    fireEvent.mouseDown(searchButton);
-    fireEvent.click(searchButton);
+    fireEvent.mouseDown(container.querySelector(".search-palette-backdrop") as HTMLElement);
     expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
   });
 
@@ -516,6 +530,7 @@ describe("renderer button parity", () => {
     expect(within(searchDialog).getByText("Obsidian")).toBeInTheDocument();
     expect(within(searchDialog).queryByText("ripgrep")).not.toBeInTheDocument();
 
+    fireEvent.mouseDown(document.querySelector(".search-palette-backdrop") as HTMLElement);
     fireEvent.click(screen.getByRole("button", { name: /Homebrew/ }));
 
     expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("homebrew");
@@ -556,7 +571,7 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
     const searchDialog = screen.getByRole("dialog", { name: "Search" });
     expect(within(searchDialog).getByText("Obsidian")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
+    fireEvent.mouseDown(document.querySelector(".search-palette-backdrop") as HTMLElement);
 
     unmount();
     render(
@@ -597,9 +612,9 @@ describe("renderer button parity", () => {
       />
     );
 
-    const allButton = screen.getByRole("button", { name: /All/ });
-    const appsButton = screen.getByRole("button", { name: /Apps/ });
-    const homebrewButton = screen.getByRole("button", { name: /Homebrew/ });
+    const allButton = screen.getByRole("button", { name: /All/, hidden: true });
+    const appsButton = screen.getByRole("button", { name: /Apps/, hidden: true });
+    const homebrewButton = screen.getByRole("button", { name: /Homebrew/, hidden: true });
 
     expect(within(allButton as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(within(appsButton as HTMLElement).getByText("1")).toBeInTheDocument();
@@ -1935,7 +1950,9 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { level: 1, name: "Ignored" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Ignored", hidden: true })
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 2, name: /Ignored Apps and Homebrew/ })
     ).toBeInTheDocument();
@@ -1959,7 +1976,9 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { level: 1, name: "Ignored" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Ignored", hidden: true })
+    ).toBeInTheDocument();
     const searchDialog = screen.getByRole("dialog", { name: "Search" });
     expect(
       within(searchDialog).getByRole("heading", { level: 2, name: "Ignored Homebrew" })

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -392,6 +392,9 @@ describe("renderer button parity", () => {
       />
     );
 
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
+
     fireEvent.keyDown(document, { key: "k", metaKey: true });
 
     const searchDialog = screen.getByRole("dialog", { name: "Search" });

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -130,6 +130,32 @@ function toolbarButtonLabels(container: HTMLElement): Array<string | null> {
     .map((button) => button.getAttribute("aria-label") ?? button.getAttribute("title"));
 }
 
+function domRect({
+  top,
+  right,
+  bottom,
+  left
+}: {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}): DOMRect {
+  const width = right - left;
+  const height = bottom - top;
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    top,
+    right,
+    bottom,
+    left,
+    toJSON: () => ({})
+  } as DOMRect;
+}
+
 describe("renderer button parity", () => {
   beforeEach(() => {
     installBaselineMock();
@@ -465,28 +491,55 @@ describe("renderer button parity", () => {
   });
 
   it("closes search palette row action menus on outside clicks inside the dialog", () => {
-    render(
-      <Dashboard
-        compact={false}
-        searchActive
-        onOpenSettings={() => undefined}
-        snapshot={snapshot({
-          selectedTab: "apps",
-          searchText: "example"
-        })}
-      />
-    );
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("search-palette-results")) {
+          return domRect({ top: 140, right: 802, bottom: 220, left: 218 });
+        }
+        if (this.classList.contains("search-palette")) {
+          return domRect({ top: 80, right: 820, bottom: 360, left: 200 });
+        }
+        if (this.getAttribute("aria-label") === "Actions") {
+          return domRect({ top: 184, right: 792, bottom: 212, left: 764 });
+        }
+        return originalGetBoundingClientRect.call(this);
+      });
 
-    const searchDialog = screen.getByRole("dialog", { name: "Search" });
-    fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
-    expect(within(searchDialog).getByRole("menu")).toHaveClass("row-action-menu-popover-fixed");
-    expect(within(searchDialog).getByRole("menuitem", { name: "Ignore" })).toBeInTheDocument();
+    try {
+      render(
+        <Dashboard
+          compact={false}
+          searchActive
+          onOpenSettings={() => undefined}
+          snapshot={snapshot({
+            selectedTab: "apps",
+            searchText: "example"
+          })}
+        />
+      );
 
-    fireEvent.mouseDown(within(searchDialog).getByPlaceholderText("Search"));
+      const searchDialog = screen.getByRole("dialog", { name: "Search" });
+      fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("row-action-menu-popover-floating");
+      expect(searchDialog).toContainElement(menu);
+      expect(menu).toHaveStyle({ visibility: "visible" });
+      const ignoreMenuItem = screen.getByRole("menuitem", { name: "Ignore" });
+      expect(ignoreMenuItem).toBeInTheDocument();
 
-    expect(
-      within(searchDialog).queryByRole("menuitem", { name: "Ignore" })
-    ).not.toBeInTheDocument();
+      fireEvent.mouseDown(ignoreMenuItem);
+      fireEvent.click(ignoreMenuItem);
+      expect(window.baseline.toggleIgnoredApp).toHaveBeenCalledWith(app.id);
+
+      fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
+      fireEvent.mouseDown(within(searchDialog).getByPlaceholderText("Search"));
+
+      expect(screen.queryByRole("menuitem", { name: "Ignore" })).not.toBeInTheDocument();
+    } finally {
+      rectSpy.mockRestore();
+    }
   });
 
   it("closes search mode on backdrop clicks without clearing the saved query", async () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -425,6 +425,45 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Apps" })).toBeInTheDocument();
   });
 
+  it("skips non-tabbable status glyphs when trapping search palette focus", () => {
+    const item: HomebrewCaskDiscoveryItem = {
+      id: "formula:ray",
+      token: "ray",
+      displayName: "ray",
+      kind: "formula",
+      version: version("1.2.3")
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        searchActive
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "homebrew",
+          searchText: "ray",
+          apps: [],
+          updates: [],
+          homebrewItems: [],
+          homebrewDiscoverItems: [item],
+          homebrewDiscoverInstallingItemIDs: [item.id]
+        })}
+      />
+    );
+
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    const searchField = within(searchDialog).getByPlaceholderText("Search");
+    const clearButton = within(searchDialog).getByRole("button", { name: "Clear Search" });
+    const statusGlyph = within(searchDialog).getByRole("button", { name: "Updating" });
+    expect(statusGlyph).toHaveAttribute("tabindex", "-1");
+
+    clearButton.focus();
+    expect(clearButton).toHaveFocus();
+    fireEvent.keyDown(searchDialog, { key: "Tab" });
+
+    expect(searchField).toHaveFocus();
+  });
+
   it("closes search mode on backdrop clicks without clearing the saved query", async () => {
     const formula: HomebrewManagedItem = {
       id: "formula:obsidian-cli",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -526,9 +526,15 @@ describe("renderer button parity", () => {
       expect(menu).toHaveClass("row-action-menu-popover-floating");
       expect(searchDialog).toContainElement(menu);
       expect(menu).toHaveStyle({ visibility: "visible" });
-      const ignoreMenuItem = screen.getByRole("menuitem", { name: "Ignore" });
+      let ignoreMenuItem = screen.getByRole("menuitem", { name: "Ignore" });
       expect(ignoreMenuItem).toBeInTheDocument();
 
+      fireEvent.keyDown(ignoreMenuItem, { key: "Escape" });
+      expect(screen.queryByRole("menuitem", { name: "Ignore" })).not.toBeInTheDocument();
+      expect(screen.getByRole("dialog", { name: "Search" })).toBeInTheDocument();
+
+      fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
+      ignoreMenuItem = screen.getByRole("menuitem", { name: "Ignore" });
       fireEvent.mouseDown(ignoreMenuItem);
       fireEvent.click(ignoreMenuItem);
       expect(window.baseline.toggleIgnoredApp).toHaveBeenCalledWith(app.id);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -428,7 +428,7 @@ describe("renderer button parity", () => {
       version: version("1.6.0")
     };
 
-    render(
+    const { container } = render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}
@@ -466,6 +466,15 @@ describe("renderer button parity", () => {
     expect(within(reopenedSearchDialog).getByDisplayValue("obsidian")).toBeInTheDocument();
     expect(within(reopenedSearchDialog).getByText("Obsidian")).toBeInTheDocument();
     expect(within(reopenedSearchDialog).getByText("obsidian-cli")).toBeInTheDocument();
+
+    fireEvent.mouseDown(container.querySelector(".sidebar") as HTMLElement);
+    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(screen.getByRole("dialog", { name: "Search" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
   });
 
   it("does not show discovery results after dismissing search into the Homebrew tab", () => {
@@ -1081,7 +1090,7 @@ describe("renderer button parity", () => {
   });
 
   it("clears compact toolbar search and full-window sidebar search", () => {
-    const { rerender } = render(
+    const { unmount } = render(
       <Dashboard
         compact
         onOpenSettings={() => undefined}
@@ -1092,7 +1101,8 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Clear Search" }));
     expect(window.baseline.setSearchText).toHaveBeenCalledWith("");
 
-    rerender(
+    unmount();
+    render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ActionConfirmationContext,
+  App,
   AppRow,
   Dashboard,
   DiscoverRow,
@@ -2116,6 +2117,21 @@ describe("renderer button parity", () => {
     );
 
     await waitFor(() => expect(screen.getByPlaceholderText("Search")).toHaveFocus());
+  });
+
+  it("opens compact menu bar search when the production app loads a saved query", async () => {
+    vi.mocked(window.baseline.getSnapshot).mockResolvedValue(
+      snapshot({
+        searchText: "example"
+      })
+    );
+    window.location.hash = "/menubar";
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByPlaceholderText("Search")).toHaveFocus());
+    expect(screen.getByRole("button", { name: "Close Search" })).toBeInTheDocument();
+    expect(screen.getByText("Example")).toBeInTheDocument();
   });
 
   it("unifies app and Homebrew recently updated cards in the All tab without duplicating cask-backed apps", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -317,6 +317,7 @@ describe("renderer button parity", () => {
     render(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           selectedTab: "apps",
@@ -345,7 +346,7 @@ describe("renderer button parity", () => {
       <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={snapshot()} />
     );
 
-    expect(toolbarButtonLabels(container)).toEqual(["Search", "Refresh"]);
+    expect(toolbarButtonLabels(container)).toEqual(["Refresh"]);
 
     rerender(
       <Dashboard
@@ -363,11 +364,7 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(toolbarButtonLabels(container)).toEqual([
-      "New Baseline Update Available",
-      "Search",
-      "Refresh"
-    ]);
+    expect(toolbarButtonLabels(container)).toEqual(["New Baseline Update Available", "Refresh"]);
 
     fireEvent.click(screen.getByRole("button", { name: "New Baseline Update Available" }));
 
@@ -382,7 +379,7 @@ describe("renderer button parity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("closes search mode on sidebar tab clicks without clearing the saved query", () => {
+  it("closes search mode on sidebar tab clicks without clearing the saved query", async () => {
     const formula: HomebrewManagedItem = {
       id: "formula:obsidian-cli",
       token: "obsidian-cli",
@@ -415,6 +412,8 @@ describe("renderer button parity", () => {
       />
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
     expect(screen.getByText("obsidian-cli")).toBeInTheDocument();
     expect(screen.queryByText("Example")).not.toBeInTheDocument();
@@ -424,7 +423,7 @@ describe("renderer button parity", () => {
     expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("apps");
     expect(window.baseline.setSearchText).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
-    expect(screen.getByText("Example")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Example")).toBeInTheDocument());
     expect(screen.queryByText("Obsidian")).not.toBeInTheDocument();
     expect(screen.queryByText("obsidian-cli")).not.toBeInTheDocument();
 
@@ -465,6 +464,8 @@ describe("renderer button parity", () => {
       <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={searchSnapshot} />
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
 
@@ -499,34 +500,18 @@ describe("renderer button parity", () => {
       homebrewItems: [],
       homebrewDiscoverItems: [discoverItem]
     });
-    let searchOpen = true;
-    const setSearchOpen = vi.fn((open: boolean) => {
-      searchOpen = open;
-    });
 
     const { unmount } = render(
-      <Dashboard
-        compact={false}
-        onOpenSettings={() => undefined}
-        onToolbarSearchOpenChange={setSearchOpen}
-        toolbarSearchOpen={searchOpen}
-        snapshot={searchSnapshot}
-      />
+      <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={searchSnapshot} />
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
     expect(screen.getByText("Obsidian")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Apps/ }));
-    expect(setSearchOpen).toHaveBeenCalledWith(false);
 
     unmount();
     render(
-      <Dashboard
-        compact={false}
-        onOpenSettings={() => undefined}
-        onToolbarSearchOpenChange={setSearchOpen}
-        toolbarSearchOpen={searchOpen}
-        snapshot={searchSnapshot}
-      />
+      <Dashboard compact={false} onOpenSettings={() => undefined} snapshot={searchSnapshot} />
     );
 
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
@@ -550,9 +535,10 @@ describe("renderer button parity", () => {
       latestVersion: version("1.1.0"),
       isOutdated: true
     };
-    const { container } = render(
+    render(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           apps: [app, installedApp],
@@ -562,9 +548,9 @@ describe("renderer button parity", () => {
       />
     );
 
-    const [allButton, appsButton, homebrewButton] = Array.from(
-      container.querySelectorAll(".source-list button")
-    );
+    const allButton = screen.getByRole("button", { name: /All/ });
+    const appsButton = screen.getByRole("button", { name: /Apps/ });
+    const homebrewButton = screen.getByRole("button", { name: /Homebrew/ });
 
     expect(within(allButton as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(within(appsButton as HTMLElement).getByText("1")).toBeInTheDocument();
@@ -575,7 +561,7 @@ describe("renderer button parity", () => {
   });
 
   it("hides sidebar update badges when counts are zero", () => {
-    const { container } = render(
+    render(
       <Dashboard
         compact={false}
         onOpenSettings={() => undefined}
@@ -583,9 +569,9 @@ describe("renderer button parity", () => {
       />
     );
 
-    const [allButton, appsButton, homebrewButton] = Array.from(
-      container.querySelectorAll(".source-list button")
-    );
+    const allButton = screen.getByRole("button", { name: "All" });
+    const appsButton = screen.getByRole("button", { name: "Apps" });
+    const homebrewButton = screen.getByRole("button", { name: "Homebrew" });
 
     expect(within(allButton as HTMLElement).queryByText("0")).not.toBeInTheDocument();
     expect(within(appsButton as HTMLElement).queryByText("0")).not.toBeInTheDocument();
@@ -1056,7 +1042,7 @@ describe("renderer button parity", () => {
     expect(screen.getByPlaceholderText("Search")).toBeInTheDocument();
   });
 
-  it("clears toolbar search from compact and main layouts", () => {
+  it("clears compact toolbar search and full-window sidebar search", () => {
     const { rerender } = render(
       <Dashboard
         compact
@@ -1076,14 +1062,15 @@ describe("renderer button parity", () => {
       />
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
     fireEvent.click(screen.getByRole("button", { name: "Clear Search" }));
     expect(window.baseline.setSearchText).toHaveBeenCalledWith("");
   });
 
-  it("opens toolbar search and collapses it on outside click without clearing text", async () => {
+  it("opens compact toolbar search and collapses it on outside click without clearing text", async () => {
     render(
       <Dashboard
-        compact={false}
+        compact
         onOpenSettings={() => undefined}
         snapshot={snapshot({ searchText: "obsidian" })}
       />
@@ -1122,7 +1109,7 @@ describe("renderer button parity", () => {
   it("runs adjacent toolbar actions before collapsing open search", async () => {
     render(
       <Dashboard
-        compact={false}
+        compact
         onOpenSettings={() => undefined}
         snapshot={snapshot({ searchText: "raycast" })}
       />
@@ -1513,6 +1500,7 @@ describe("renderer button parity", () => {
     render(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           selectedTab: "homebrew",
@@ -1732,7 +1720,7 @@ describe("renderer button parity", () => {
     render(
       <Dashboard
         compact={false}
-        toolbarSearchOpen
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           searchText: "cli",
@@ -1772,7 +1760,7 @@ describe("renderer button parity", () => {
     render(
       <Dashboard
         compact={false}
-        toolbarSearchOpen
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           searchText: "cli",
@@ -1871,10 +1859,11 @@ describe("renderer button parity", () => {
       />
     );
 
+    const sourceLists = Array.from(container.querySelectorAll(".source-list"));
     expect(
-      Array.from(container.querySelectorAll(".secondary-source-list button")).map((button) =>
-        button.textContent?.trim()
-      )
+      within(sourceLists[2] as HTMLElement)
+        .getAllByRole("button")
+        .map((button) => button.textContent?.trim())
     ).toEqual(["Installed", "Ignored"]);
     fireEvent.click(screen.getByRole("button", { name: /Ignored/ }));
     expect(window.baseline.setSelectedTab).toHaveBeenCalledWith("ignored");
@@ -1894,7 +1883,7 @@ describe("renderer button parity", () => {
 
     expect(screen.getByRole("heading", { level: 1, name: "Ignored" })).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { level: 2, name: "Ignored Apps and Homebrew" })
+      screen.getByRole("heading", { level: 2, name: /Ignored Apps and Homebrew/ })
     ).toBeInTheDocument();
     expect(screen.getByText("Example")).toBeInTheDocument();
     expect(screen.getByText("ripgrep")).toBeInTheDocument();
@@ -1904,6 +1893,7 @@ describe("renderer button parity", () => {
     rerender(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           selectedTab: "ignored",
@@ -1915,7 +1905,8 @@ describe("renderer button parity", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { level: 1, name: "Ignored" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Search" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Ignored" })).toBeInTheDocument();
     expect(screen.getByText("ripgrep")).toBeInTheDocument();
     expect(screen.queryByText("Example")).not.toBeInTheDocument();
     expect(screen.queryByText("No matches found.")).not.toBeInTheDocument();
@@ -2343,6 +2334,7 @@ describe("renderer button parity", () => {
     const { container } = render(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           selectedTab: "apps",
@@ -2408,6 +2400,7 @@ describe("renderer button parity", () => {
     render(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           searchText: "long-token-name",
@@ -2449,6 +2442,7 @@ describe("renderer button parity", () => {
     render(
       <Dashboard
         compact={false}
+        searchActive
         onOpenSettings={() => undefined}
         snapshot={snapshot({
           selectedTab: "apps",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -464,6 +464,30 @@ describe("renderer button parity", () => {
     expect(searchField).toHaveFocus();
   });
 
+  it("closes search palette row action menus on outside clicks inside the dialog", () => {
+    render(
+      <Dashboard
+        compact={false}
+        searchActive
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          selectedTab: "apps",
+          searchText: "example"
+        })}
+      />
+    );
+
+    const searchDialog = screen.getByRole("dialog", { name: "Search" });
+    fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
+    expect(within(searchDialog).getByRole("menuitem", { name: "Ignore" })).toBeInTheDocument();
+
+    fireEvent.mouseDown(within(searchDialog).getByPlaceholderText("Search"));
+
+    expect(
+      within(searchDialog).queryByRole("menuitem", { name: "Ignore" })
+    ).not.toBeInTheDocument();
+  });
+
   it("closes search mode on backdrop clicks without clearing the saved query", async () => {
     const formula: HomebrewManagedItem = {
       id: "formula:obsidian-cli",

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -470,10 +470,13 @@ describe("renderer button parity", () => {
     fireEvent.mouseDown(container.querySelector(".sidebar") as HTMLElement);
     expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    fireEvent.mouseDown(searchButton);
+    fireEvent.click(searchButton);
     expect(screen.getByRole("dialog", { name: "Search" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    fireEvent.mouseDown(searchButton);
+    fireEvent.click(searchButton);
     expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument();
   });
 

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -479,6 +479,7 @@ describe("renderer button parity", () => {
 
     const searchDialog = screen.getByRole("dialog", { name: "Search" });
     fireEvent.click(within(searchDialog).getByRole("button", { name: "Actions" }));
+    expect(within(searchDialog).getByRole("menu")).toHaveClass("row-action-menu-popover-fixed");
     expect(within(searchDialog).getByRole("menuitem", { name: "Ignore" })).toBeInTheDocument();
 
     fireEvent.mouseDown(within(searchDialog).getByPlaceholderText("Search"));

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -89,9 +89,18 @@ test("launches the Electron shell and renders the dashboard", async () => {
   const page = await app.firstWindow();
   await expect(page).toHaveTitle("Baseline");
   await expect(page.locator("h1")).toContainText("All");
+  await expect(page.getByRole("button", { name: "Search", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "All", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Apps", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Homebrew", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(page.locator("h1")).toContainText("Search");
+  const searchField = page.getByPlaceholder("Search");
+  await expect(searchField).toBeVisible();
+  await searchField.fill("missing-app");
+  await expect(page.getByText("No matches found.")).toBeVisible();
+  await page.getByRole("button", { name: "All", exact: true }).click();
+  await expect(page.locator("h1")).toContainText("All");
   await expect.poll(() => page.evaluate(() => typeof window.baseline)).toBe("object");
   await expect(
     page.evaluate(() => typeof (window as Window & { require?: unknown }).require)

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -94,12 +94,15 @@ test("launches the Electron shell and renders the dashboard", async () => {
   await expect(page.getByRole("button", { name: "Apps", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Homebrew", exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Search", exact: true }).click();
-  await expect(page.locator("h1")).toContainText("Search");
-  const searchField = page.getByPlaceholder("Search");
+  await expect(page.locator("h1")).toContainText("All");
+  const searchDialog = page.getByRole("dialog", { name: "Search" });
+  await expect(searchDialog).toBeVisible();
+  const searchField = searchDialog.getByPlaceholder("Search");
   await expect(searchField).toBeVisible();
   await searchField.fill("missing-app");
-  await expect(page.getByText("No matches found.")).toBeVisible();
-  await page.getByRole("button", { name: "All", exact: true }).click();
+  await expect(searchDialog.getByText("No matches found.")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(searchDialog).not.toBeVisible();
   await expect(page.locator("h1")).toContainText("All");
   await expect.poll(() => page.evaluate(() => typeof window.baseline)).toBe("object");
   await expect(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -195,6 +195,30 @@ export function Dashboard({
   const sidebarDerived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
   const compactShellRef = useRef<HTMLElement>(null);
+  const appContentRef = useRef<HTMLDivElement>(null);
+  const searchButtonRef = useRef<HTMLButtonElement>(null);
+  const searchPaletteReturnFocusRef = useRef<HTMLElement | null>(null);
+  const shouldRestoreSearchPaletteFocusRef = useRef(false);
+
+  const openSearchPalette = () => {
+    const activeElement = document.activeElement;
+    searchPaletteReturnFocusRef.current =
+      activeElement instanceof HTMLElement && activeElement !== document.body
+        ? activeElement
+        : searchButtonRef.current;
+    setSearchActive(true);
+  };
+  const closeSearchPalette = () => {
+    shouldRestoreSearchPaletteFocusRef.current = true;
+    setSearchActive(false);
+  };
+  const toggleSearchPalette = () => {
+    if (searchActive) {
+      closeSearchPalette();
+      return;
+    }
+    openSearchPalette();
+  };
 
   useEffect(() => {
     if (!compact || controlledSearchActive !== undefined) {
@@ -224,13 +248,43 @@ export function Dashboard({
       const key = event.key.toLowerCase();
       if (event.metaKey && (key === "f" || key === "k")) {
         event.preventDefault();
+        if (!searchActive) {
+          const activeElement = document.activeElement;
+          searchPaletteReturnFocusRef.current =
+            activeElement instanceof HTMLElement && activeElement !== document.body
+              ? activeElement
+              : searchButtonRef.current;
+        }
         setSearchActive(true);
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [compact]);
+  }, [compact, searchActive]);
+
+  useEffect(() => {
+    const appContent = appContentRef.current;
+    if (!appContent || compact) {
+      return undefined;
+    }
+
+    setElementInert(appContent, searchActive);
+    return () => setElementInert(appContent, false);
+  }, [compact, searchActive]);
+
+  useEffect(() => {
+    if (compact || searchActive || !shouldRestoreSearchPaletteFocusRef.current) {
+      return;
+    }
+
+    shouldRestoreSearchPaletteFocusRef.current = false;
+    const focusTarget = searchPaletteReturnFocusRef.current ?? searchButtonRef.current;
+    searchPaletteReturnFocusRef.current = null;
+    if (focusTarget?.isConnected) {
+      focusTarget.focus();
+    }
+  }, [compact, searchActive]);
 
   const confirmAction = () => {
     if (!actionConfirmation) {
@@ -243,6 +297,10 @@ export function Dashboard({
       return;
     }
     void window.baseline.uninstallHomebrewItem(confirmation.item.id);
+  };
+  const requestActionConfirmation = (confirmation: ActionConfirmation) => {
+    setSearchActive(false);
+    setActionConfirmation(confirmation);
   };
 
   let shell: React.ReactNode;
@@ -310,9 +368,10 @@ export function Dashboard({
           snapshot={snapshot}
           derived={sidebarDerived}
           route="main"
+          searchButtonRef={searchButtonRef}
           onSelectSearch={() => {
             window.location.hash = "/main";
-            setSearchActive(!searchActive);
+            toggleSearchPalette();
           }}
           onDismissSearch={() => setSearchActive(false)}
           onNavigate={() => setSearchActive(false)}
@@ -367,18 +426,20 @@ export function Dashboard({
   }
 
   return (
-    <ActionConfirmationContext.Provider value={setActionConfirmation}>
+    <ActionConfirmationContext.Provider value={requestActionConfirmation}>
       <div
         className={actionConfirmation ? "action-surface action-surface-disabled" : "action-surface"}
         aria-hidden={actionConfirmation ? true : undefined}
       >
-        {shell}
-        {!compact && searchActive && (
-          <SearchPalette
-            snapshot={snapshot}
-            derived={searchDerived}
-            onClose={() => setSearchActive(false)}
-          />
+        <div
+          ref={appContentRef}
+          className="app-content-surface"
+          aria-hidden={!compact && searchActive ? true : undefined}
+        >
+          {shell}
+        </div>
+        {!compact && searchActive && !actionConfirmation && (
+          <SearchPalette snapshot={snapshot} derived={searchDerived} onClose={closeSearchPalette} />
         )}
       </div>
       {actionConfirmation && (
@@ -433,10 +494,59 @@ function compactPopoverControlFocusTarget(
   return focusTarget;
 }
 
+function setElementInert(element: HTMLElement, inert: boolean): void {
+  (element as HTMLElement & { inert: boolean }).inert = inert;
+}
+
+const focusableSelector = [
+  "a[href]",
+  "button:not(:disabled)",
+  "input:not(:disabled)",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
+  "[tabindex]:not([tabindex='-1'])"
+].join(",");
+
+function focusableElementsIn(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+    (element) => !element.closest("[aria-hidden='true']")
+  );
+}
+
+function trapFocusWithin(event: KeyboardEvent, container: HTMLElement | null): void {
+  if (!container) {
+    return;
+  }
+
+  const focusableElements = focusableElementsIn(container);
+  if (focusableElements.length === 0) {
+    event.preventDefault();
+    container.focus();
+    return;
+  }
+
+  const firstElement = focusableElements[0]!;
+  const lastElement = focusableElements[focusableElements.length - 1]!;
+  const activeElement = document.activeElement;
+  if (event.shiftKey) {
+    if (activeElement === firstElement || !container.contains(activeElement)) {
+      event.preventDefault();
+      lastElement.focus();
+    }
+    return;
+  }
+
+  if (activeElement === lastElement || !container.contains(activeElement)) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+}
+
 function Sidebar({
   snapshot,
   derived,
   route,
+  searchButtonRef,
   onSelectSearch,
   onDismissSearch,
   onNavigate
@@ -444,6 +554,7 @@ function Sidebar({
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
   route: "main" | "settings";
+  searchButtonRef?: React.RefObject<HTMLButtonElement | null>;
   onSelectSearch?: () => void;
   onDismissSearch?: () => void;
   onNavigate?: () => void;
@@ -464,7 +575,7 @@ function Sidebar({
   return (
     <aside className="sidebar" onMouseDownCapture={dismissSearchFromSidebarMouseDown}>
       <nav className="source-list">
-        <button data-search-toggle="true" onClick={onSelectSearch}>
+        <button data-search-toggle="true" onClick={onSelectSearch} ref={searchButtonRef}>
           <Search size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Search</span>
         </button>
@@ -669,21 +780,37 @@ function SearchPalette({
   derived: DerivedSections;
   onClose: () => void;
 }) {
+  const dialogRef = useRef<HTMLElement>(null);
+  const handleDialogKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key === "Tab") {
+      trapFocusWithin(event.nativeEvent, dialogRef.current);
+    }
+  };
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         onClose();
+        return;
+      }
+      if (event.key === "Tab") {
+        trapFocusWithin(event, dialogRef.current);
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [onClose]);
 
   return (
     <div className="search-palette-layer">
-      <div className="search-palette-backdrop" />
+      <div className="search-palette-backdrop" aria-hidden="true" onMouseDown={() => onClose()} />
       <div
         className="search-palette-workspace"
         onMouseDown={(event) => {
@@ -693,10 +820,13 @@ function SearchPalette({
         }}
       >
         <section
+          ref={dialogRef}
           className="search-palette"
           role="dialog"
           aria-modal="true"
           aria-label="Search"
+          tabIndex={-1}
+          onKeyDownCapture={handleDialogKeyDown}
           onMouseDown={(event) => event.stopPropagation()}
         >
           <SearchField snapshot={snapshot} autoFocus />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -655,7 +655,7 @@ function SearchTab({
   derived: DerivedSections;
 }) {
   return (
-    <div className="stack search-tab">
+    <div className="stack">
       <SearchField snapshot={snapshot} autoFocus />
       {snapshot.searchText.trim() ? <SearchResults snapshot={snapshot} derived={derived} /> : null}
     </div>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -312,8 +312,9 @@ export function Dashboard({
           route="main"
           onSelectSearch={() => {
             window.location.hash = "/main";
-            setSearchActive(true);
+            setSearchActive(!searchActive);
           }}
+          onDismissSearch={() => setSearchActive(false)}
           onNavigate={() => setSearchActive(false)}
         />
         <section className="workspace">
@@ -437,12 +438,14 @@ function Sidebar({
   derived,
   route,
   onSelectSearch,
+  onDismissSearch,
   onNavigate
 }: {
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
   route: "main" | "settings";
   onSelectSearch?: () => void;
+  onDismissSearch?: () => void;
   onNavigate?: () => void;
 }) {
   const selectTab = (tab: MenuTab) => {
@@ -452,7 +455,7 @@ function Sidebar({
   };
 
   return (
-    <aside className="sidebar">
+    <aside className="sidebar" onMouseDownCapture={onDismissSearch}>
       <nav className="source-list">
         <button onClick={onSelectSearch}>
           <Search size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -672,30 +675,31 @@ function SearchPalette({
   }, [onClose]);
 
   return (
-    <div
-      className="search-palette-backdrop"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) {
-          onClose();
-        }
-      }}
-    >
-      <section
-        className="search-palette"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Search"
-        onMouseDown={(event) => event.stopPropagation()}
+    <div className="search-palette-layer">
+      <div className="search-palette-backdrop" />
+      <div
+        className="search-palette-workspace"
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget) {
+            onClose();
+          }
+        }}
       >
-        <SearchField snapshot={snapshot} autoFocus />
-        {snapshot.searchText.trim() ? (
-          <SearchPaletteResults snapshot={snapshot} derived={derived} />
-        ) : (
-          <p className="search-palette-empty">
-            Search apps, Homebrew, installed, and ignored items.
-          </p>
-        )}
-      </section>
+        <section
+          className="search-palette"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Search"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <SearchField snapshot={snapshot} autoFocus />
+          {snapshot.searchText.trim() ? (
+            <SearchPaletteResults snapshot={snapshot} derived={derived} />
+          ) : (
+            <p className="search-palette-empty">Search Homebrew for apps, packages, and tools.</p>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2741,9 +2741,7 @@ function RowMoreActionButton({
       >
         {uninstalling ? <UninstallActionGlyph /> : <MoreHorizontal size={15} />}
       </button>
-      {popoverPlacement === "floating" && popover
-        ? createPortal(popover, floatingRowActionMenuPortalTarget(menuRef.current))
-        : popover}
+      {popoverPlacement === "floating" && popover ? createPortal(popover, document.body) : popover}
     </div>
   );
 }
@@ -2768,10 +2766,6 @@ function floatingRowActionMenuStyle(
     top: position?.top ?? 0,
     visibility: position ? "visible" : "hidden"
   };
-}
-
-function floatingRowActionMenuPortalTarget(menu: HTMLElement | null): HTMLElement {
-  return menu?.closest<HTMLElement>(".search-palette") ?? document.body;
 }
 
 function rowActionMenuEstimatedHeight(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
 // SPDX-License-Identifier: GPL-3.0-only
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   AlertTriangle,
@@ -76,6 +76,10 @@ type RowUpdateMenuAction = {
   state: ActionState;
   disabled?: boolean;
   onAction: () => void;
+};
+type RowActionMenuPosition = {
+  left: number;
+  top: number;
 };
 type SettingsSectionID = "general" | "profile" | "appearance" | "diagnostics";
 
@@ -2540,7 +2544,11 @@ function RowMoreActionButton({
 }) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [fixedPopoverPosition, setFixedPopoverPosition] = useState<RowActionMenuPosition>();
   const ignoreLabel = isIgnored ? "Unignore" : "Ignore";
+  const useFixedPopover = open && Boolean(menuRef.current?.closest(".search-palette"));
 
   useEffect(() => {
     if (!open) {
@@ -2566,6 +2574,50 @@ function RowMoreActionButton({
     };
   }, [open]);
 
+  useLayoutEffect(() => {
+    if (!open || !useFixedPopover) {
+      setFixedPopoverPosition(undefined);
+      return undefined;
+    }
+
+    const updatePopoverPosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+
+      const triggerRect = trigger.getBoundingClientRect();
+      const popoverRect = popoverRef.current?.getBoundingClientRect();
+      const popoverWidth = popoverRect?.width || 142;
+      const popoverHeight =
+        popoverRect?.height || rowActionMenuEstimatedHeight(updateAction, canUninstall);
+      const viewportPadding = 8;
+      const gap = 6;
+      const maxLeft = Math.max(viewportPadding, window.innerWidth - popoverWidth - viewportPadding);
+      const left = Math.min(Math.max(viewportPadding, triggerRect.right - popoverWidth), maxLeft);
+      const belowTop = triggerRect.bottom + gap;
+      const aboveTop = triggerRect.top - popoverHeight - gap;
+      const hasRoomBelow = belowTop + popoverHeight + viewportPadding <= window.innerHeight;
+      const top =
+        hasRoomBelow || aboveTop < viewportPadding
+          ? Math.min(belowTop, window.innerHeight - popoverHeight - viewportPadding)
+          : Math.max(viewportPadding, aboveTop);
+
+      setFixedPopoverPosition({
+        left,
+        top: Math.max(viewportPadding, top)
+      });
+    };
+
+    updatePopoverPosition();
+    window.addEventListener("resize", updatePopoverPosition);
+    window.addEventListener("scroll", updatePopoverPosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePopoverPosition);
+      window.removeEventListener("scroll", updatePopoverPosition, true);
+    };
+  }, [canUninstall, open, updateAction, useFixedPopover]);
+
   const invokeIgnore = () => {
     setOpen(false);
     onToggleIgnore();
@@ -2588,6 +2640,7 @@ function RowMoreActionButton({
   return (
     <div className="row-action-menu" ref={menuRef}>
       <button
+        ref={triggerRef}
         className="secondary-icon-button"
         disabled={disabled}
         onClick={() => setOpen((isOpen) => !isOpen)}
@@ -2599,7 +2652,16 @@ function RowMoreActionButton({
         {uninstalling ? <UninstallActionGlyph /> : <MoreHorizontal size={15} />}
       </button>
       {open && (
-        <div className="row-action-menu-popover" role="menu">
+        <div
+          ref={popoverRef}
+          className={
+            useFixedPopover
+              ? "row-action-menu-popover row-action-menu-popover-fixed"
+              : "row-action-menu-popover"
+          }
+          role="menu"
+          style={fixedRowActionMenuStyle(useFixedPopover, fixedPopoverPosition)}
+        >
           {updateAction && (
             <button
               onClick={invokeUpdate}
@@ -2647,6 +2709,29 @@ function RowMoreActionButton({
       )}
     </div>
   );
+}
+
+function rowActionMenuEstimatedHeight(
+  updateAction: RowUpdateMenuAction | undefined,
+  canUninstall: boolean
+): number {
+  const itemCount = 1 + (updateAction ? 1 : 0) + (canUninstall ? 1 : 0);
+  return itemCount * 28 + 10;
+}
+
+function fixedRowActionMenuStyle(
+  useFixedPopover: boolean,
+  position: RowActionMenuPosition | undefined
+): React.CSSProperties | undefined {
+  if (!useFixedPopover) {
+    return undefined;
+  }
+
+  return {
+    left: position?.left ?? 0,
+    top: position?.top ?? 0,
+    visibility: position ? "visible" : "hidden"
+  };
 }
 
 function ProgressRing({ value }: { value: number }) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -880,8 +880,14 @@ function SearchPalette({
   );
 }
 
+const searchPaletteFloatingRowMenuSelector =
+  "[data-search-palette-floating-row-menu='true'][role='menu']";
+
 function hasOpenNestedMenu(container: HTMLElement | null): boolean {
-  return Boolean(container?.querySelector("[role='menu']"));
+  return Boolean(
+    container?.querySelector("[role='menu']") ||
+    document.querySelector(searchPaletteFloatingRowMenuSelector)
+  );
 }
 
 function SearchField({
@@ -2672,10 +2678,14 @@ function RowMoreActionButton({
     setOpen(false);
     onUninstall();
   };
+  const isSearchPaletteRowMenu = Boolean(menuRef.current?.closest(".search-palette"));
   const popover = open ? (
     <div
       ref={popoverRef}
       className={rowActionMenuPopoverClassName(popoverPlacement)}
+      data-search-palette-floating-row-menu={
+        isSearchPaletteRowMenu && popoverPlacement === "floating" ? "true" : undefined
+      }
       role="menu"
       style={
         popoverPlacement === "floating"

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -817,6 +817,9 @@ function SearchPalette({
   const dialogRef = useRef<HTMLElement>(null);
   const handleDialogKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Escape") {
+      if (hasOpenNestedMenu(dialogRef.current)) {
+        return;
+      }
       event.preventDefault();
       onClose();
       return;
@@ -829,6 +832,9 @@ function SearchPalette({
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        if (hasOpenNestedMenu(dialogRef.current)) {
+          return;
+        }
         event.preventDefault();
         onClose();
         return;
@@ -872,6 +878,10 @@ function SearchPalette({
       </div>
     </div>
   );
+}
+
+function hasOpenNestedMenu(container: HTMLElement | null): boolean {
+  return Boolean(container?.querySelector("[role='menu']"));
 }
 
 function SearchField({

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -453,11 +453,18 @@ function Sidebar({
     window.location.hash = "/main";
     void window.baseline.setSelectedTab(tab);
   };
+  const dismissSearchFromSidebarMouseDown = (event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target;
+    if (target instanceof Element && target.closest("[data-search-toggle='true']")) {
+      return;
+    }
+    onDismissSearch?.();
+  };
 
   return (
-    <aside className="sidebar" onMouseDownCapture={onDismissSearch}>
+    <aside className="sidebar" onMouseDownCapture={dismissSearchFromSidebarMouseDown}>
       <nav className="source-list">
-        <button onClick={onSelectSearch}>
+        <button data-search-toggle="true" onClick={onSelectSearch}>
           <Search size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Search</span>
         </button>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
 import {
   AlertTriangle,
@@ -77,7 +78,8 @@ type RowUpdateMenuAction = {
   disabled?: boolean;
   onAction: () => void;
 };
-type RowActionMenuPosition = {
+type RowActionMenuPlacement = "below" | "above" | "floating";
+type RowActionMenuFloatingPosition = {
   left: number;
   top: number;
 };
@@ -2546,9 +2548,10 @@ function RowMoreActionButton({
   const menuRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [fixedPopoverPosition, setFixedPopoverPosition] = useState<RowActionMenuPosition>();
+  const [popoverPlacement, setPopoverPlacement] = useState<RowActionMenuPlacement>("below");
+  const [floatingPopoverPosition, setFloatingPopoverPosition] =
+    useState<RowActionMenuFloatingPosition>();
   const ignoreLabel = isIgnored ? "Unignore" : "Ignore";
-  const useFixedPopover = open && Boolean(menuRef.current?.closest(".search-palette"));
 
   useEffect(() => {
     if (!open) {
@@ -2556,7 +2559,8 @@ function RowMoreActionButton({
     }
 
     const closeOnOutsideClick = (event: MouseEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (!menuRef.current?.contains(target) && !popoverRef.current?.contains(target)) {
         setOpen(false);
       }
     };
@@ -2575,48 +2579,70 @@ function RowMoreActionButton({
   }, [open]);
 
   useLayoutEffect(() => {
-    if (!open || !useFixedPopover) {
-      setFixedPopoverPosition(undefined);
+    if (!open) {
+      setPopoverPlacement("below");
+      setFloatingPopoverPosition(undefined);
       return undefined;
     }
 
-    const updatePopoverPosition = () => {
+    const updatePopoverPlacement = () => {
       const trigger = triggerRef.current;
-      if (!trigger) {
+      const clippingContainer =
+        menuRef.current?.closest(".search-palette-results") ??
+        menuRef.current?.closest(".search-palette");
+      if (!trigger || !(clippingContainer instanceof HTMLElement)) {
+        setPopoverPlacement("below");
+        setFloatingPopoverPosition(undefined);
         return;
       }
 
       const triggerRect = trigger.getBoundingClientRect();
+      const clippingRect = clippingContainer.getBoundingClientRect();
       const popoverRect = popoverRef.current?.getBoundingClientRect();
-      const popoverWidth = popoverRect?.width || 142;
+      const popoverWidth = popoverRect?.width || rowActionMenuEstimatedWidth;
       const popoverHeight =
         popoverRect?.height || rowActionMenuEstimatedHeight(updateAction, canUninstall);
       const viewportPadding = 8;
       const gap = 6;
-      const maxLeft = Math.max(viewportPadding, window.innerWidth - popoverWidth - viewportPadding);
-      const left = Math.min(Math.max(viewportPadding, triggerRect.right - popoverWidth), maxLeft);
-      const belowTop = triggerRect.bottom + gap;
-      const aboveTop = triggerRect.top - popoverHeight - gap;
-      const hasRoomBelow = belowTop + popoverHeight + viewportPadding <= window.innerHeight;
-      const top =
-        hasRoomBelow || aboveTop < viewportPadding
-          ? Math.min(belowTop, window.innerHeight - popoverHeight - viewportPadding)
-          : Math.max(viewportPadding, aboveTop);
+      const availableBelow = clippingRect.bottom - triggerRect.bottom - gap - viewportPadding;
+      const availableAbove = triggerRect.top - clippingRect.top - gap - viewportPadding;
 
-      setFixedPopoverPosition({
-        left,
-        top: Math.max(viewportPadding, top)
+      if (availableBelow >= popoverHeight) {
+        setPopoverPlacement("below");
+        setFloatingPopoverPosition(undefined);
+        return;
+      }
+
+      if (availableAbove >= popoverHeight) {
+        setPopoverPlacement("above");
+        setFloatingPopoverPosition(undefined);
+        return;
+      }
+
+      const preferredTop =
+        availableBelow >= availableAbove
+          ? triggerRect.bottom + gap
+          : triggerRect.top - popoverHeight - gap;
+      const maxTop = Math.max(
+        viewportPadding,
+        window.innerHeight - popoverHeight - viewportPadding
+      );
+      const maxLeft = Math.max(viewportPadding, window.innerWidth - popoverWidth - viewportPadding);
+      setPopoverPlacement("floating");
+      setFloatingPopoverPosition({
+        left: Math.min(Math.max(viewportPadding, triggerRect.right - popoverWidth), maxLeft),
+        top: Math.min(Math.max(viewportPadding, preferredTop), maxTop)
       });
     };
 
-    updatePopoverPosition();
-    window.addEventListener("resize", updatePopoverPosition);
-    window.addEventListener("scroll", updatePopoverPosition, true);
+    updatePopoverPlacement();
+    window.addEventListener("resize", updatePopoverPlacement);
+    window.addEventListener("scroll", updatePopoverPlacement, true);
     return () => {
-      window.removeEventListener("resize", updatePopoverPosition);
-      window.removeEventListener("scroll", updatePopoverPosition, true);
+      window.removeEventListener("resize", updatePopoverPlacement);
+      window.removeEventListener("scroll", updatePopoverPlacement, true);
     };
-  }, [canUninstall, open, updateAction, useFixedPopover]);
+  }, [canUninstall, open, updateAction]);
 
   const invokeIgnore = () => {
     setOpen(false);
@@ -2636,6 +2662,60 @@ function RowMoreActionButton({
     setOpen(false);
     onUninstall();
   };
+  const popover = open ? (
+    <div
+      ref={popoverRef}
+      className={rowActionMenuPopoverClassName(popoverPlacement)}
+      role="menu"
+      style={
+        popoverPlacement === "floating"
+          ? floatingRowActionMenuStyle(floatingPopoverPosition)
+          : undefined
+      }
+    >
+      {updateAction && (
+        <button
+          onClick={invokeUpdate}
+          role="menuitem"
+          disabled={updateAction.disabled || updateAction.state.type !== "ready"}
+        >
+          {updateAction.state.type === "ready" ? (
+            <Download size={14} />
+          ) : updateAction.state.type === "queued" ? (
+            <ClockArrowDown size={14} />
+          ) : updateAction.state.type === "updating" ? (
+            updateAction.state.progress === undefined ? (
+              <RefreshCcw className="spin" size={14} />
+            ) : (
+              <ProgressRing value={updateAction.state.progress} />
+            )
+          ) : updateAction.state.type === "done" ? (
+            <Check className="done-glyph" size={14} strokeWidth={3} />
+          ) : (
+            <span className="failure-glyph">!</span>
+          )}
+          <span>
+            {updateAction.state.type === "ready" ? "Update" : actionStateLabel(updateAction.state)}
+          </span>
+        </button>
+      )}
+      <button onClick={invokeIgnore} role="menuitem" disabled={disabled}>
+        {isIgnored ? <EyeOff size={14} /> : <Eye size={14} />}
+        <span>{ignoreLabel}</span>
+      </button>
+      {canUninstall && (
+        <button
+          className="danger-menu-item"
+          onClick={invokeUninstall}
+          role="menuitem"
+          disabled={uninstallDisabled}
+        >
+          {uninstalling ? <UninstallActionGlyph /> : <Trash2 size={14} />}
+          <span>{uninstallLabel}</span>
+        </button>
+      )}
+    </div>
+  ) : null;
 
   return (
     <div className="row-action-menu" ref={menuRef}>
@@ -2651,64 +2731,37 @@ function RowMoreActionButton({
       >
         {uninstalling ? <UninstallActionGlyph /> : <MoreHorizontal size={15} />}
       </button>
-      {open && (
-        <div
-          ref={popoverRef}
-          className={
-            useFixedPopover
-              ? "row-action-menu-popover row-action-menu-popover-fixed"
-              : "row-action-menu-popover"
-          }
-          role="menu"
-          style={fixedRowActionMenuStyle(useFixedPopover, fixedPopoverPosition)}
-        >
-          {updateAction && (
-            <button
-              onClick={invokeUpdate}
-              role="menuitem"
-              disabled={updateAction.disabled || updateAction.state.type !== "ready"}
-            >
-              {updateAction.state.type === "ready" ? (
-                <Download size={14} />
-              ) : updateAction.state.type === "queued" ? (
-                <ClockArrowDown size={14} />
-              ) : updateAction.state.type === "updating" ? (
-                updateAction.state.progress === undefined ? (
-                  <RefreshCcw className="spin" size={14} />
-                ) : (
-                  <ProgressRing value={updateAction.state.progress} />
-                )
-              ) : updateAction.state.type === "done" ? (
-                <Check className="done-glyph" size={14} strokeWidth={3} />
-              ) : (
-                <span className="failure-glyph">!</span>
-              )}
-              <span>
-                {updateAction.state.type === "ready"
-                  ? "Update"
-                  : actionStateLabel(updateAction.state)}
-              </span>
-            </button>
-          )}
-          <button onClick={invokeIgnore} role="menuitem" disabled={disabled}>
-            {isIgnored ? <EyeOff size={14} /> : <Eye size={14} />}
-            <span>{ignoreLabel}</span>
-          </button>
-          {canUninstall && (
-            <button
-              className="danger-menu-item"
-              onClick={invokeUninstall}
-              role="menuitem"
-              disabled={uninstallDisabled}
-            >
-              {uninstalling ? <UninstallActionGlyph /> : <Trash2 size={14} />}
-              <span>{uninstallLabel}</span>
-            </button>
-          )}
-        </div>
-      )}
+      {popoverPlacement === "floating" && popover
+        ? createPortal(popover, floatingRowActionMenuPortalTarget(menuRef.current))
+        : popover}
     </div>
   );
+}
+
+const rowActionMenuEstimatedWidth = 142;
+
+function rowActionMenuPopoverClassName(placement: RowActionMenuPlacement): string {
+  if (placement === "above") {
+    return "row-action-menu-popover row-action-menu-popover-above";
+  }
+  if (placement === "floating") {
+    return "row-action-menu-popover row-action-menu-popover-floating";
+  }
+  return "row-action-menu-popover";
+}
+
+function floatingRowActionMenuStyle(
+  position: RowActionMenuFloatingPosition | undefined
+): React.CSSProperties {
+  return {
+    left: position?.left ?? 0,
+    top: position?.top ?? 0,
+    visibility: position ? "visible" : "hidden"
+  };
+}
+
+function floatingRowActionMenuPortalTarget(menu: HTMLElement | null): HTMLElement {
+  return menu?.closest<HTMLElement>(".search-palette") ?? document.body;
 }
 
 function rowActionMenuEstimatedHeight(
@@ -2717,21 +2770,6 @@ function rowActionMenuEstimatedHeight(
 ): number {
   const itemCount = 1 + (updateAction ? 1 : 0) + (canUninstall ? 1 : 0);
   return itemCount * 28 + 10;
-}
-
-function fixedRowActionMenuStyle(
-  useFixedPopover: boolean,
-  position: RowActionMenuPosition | undefined
-): React.CSSProperties | undefined {
-  if (!useFixedPopover) {
-    return undefined;
-  }
-
-  return {
-    left: position?.left ?? 0,
-    top: position?.top ?? 0,
-    visibility: position ? "visible" : "hidden"
-  };
 }
 
 function ProgressRing({ value }: { value: number }) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -127,21 +127,12 @@ const initialSnapshot: BaselineSnapshot = {
 function App() {
   const [snapshot, setSnapshot] = useState<BaselineSnapshot>(initialSnapshot);
   const [route, setRoute] = useState<Route>(currentRoute());
-  const [toolbarSearchOpen, setToolbarSearchOpen] = useState(false);
-  const previousSearchTextRef = useRef(initialSnapshot.searchText);
+  const [searchActive, setSearchActive] = useState(false);
 
   useEffect(() => {
     void window.baseline.getSnapshot().then(setSnapshot);
     return window.baseline.onSnapshotChanged(setSnapshot);
   }, []);
-
-  useEffect(() => {
-    const previousSearchText = previousSearchTextRef.current;
-    previousSearchTextRef.current = snapshot.searchText;
-    if (!previousSearchText.trim() && snapshot.searchText.trim()) {
-      setToolbarSearchOpen(true);
-    }
-  }, [snapshot.searchText]);
 
   useEffect(() => {
     const onHashChange = () => setRoute(currentRoute());
@@ -157,10 +148,10 @@ function App() {
     <Dashboard
       snapshot={snapshot}
       compact={route === "menubar"}
-      toolbarSearchOpen={toolbarSearchOpen}
-      onToolbarSearchOpenChange={setToolbarSearchOpen}
+      searchActive={searchActive}
+      onSearchActiveChange={setSearchActive}
       onOpenSettings={() => {
-        setToolbarSearchOpen(false);
+        setSearchActive(false);
         void window.baseline.showSettings();
       }}
     />
@@ -170,55 +161,55 @@ function App() {
 export function Dashboard({
   snapshot,
   compact,
-  toolbarSearchOpen: controlledToolbarSearchOpen,
-  onToolbarSearchOpenChange,
+  searchActive: controlledSearchActive,
+  onSearchActiveChange,
   onOpenSettings
 }: {
   snapshot: BaselineSnapshot;
   compact: boolean;
-  toolbarSearchOpen?: boolean;
-  onToolbarSearchOpenChange?: (open: boolean) => void;
+  searchActive?: boolean;
+  onSearchActiveChange?: (active: boolean) => void;
   onOpenSettings: () => void;
 }) {
   const selectedTab = snapshot.selectedTab;
-  const [uncontrolledToolbarSearchOpen, setUncontrolledToolbarSearchOpen] = useState(
-    Boolean(snapshot.searchText)
+  const [uncontrolledSearchActive, setUncontrolledSearchActive] = useState(
+    compact && Boolean(snapshot.searchText)
   );
-  const toolbarSearchOpen = controlledToolbarSearchOpen ?? uncontrolledToolbarSearchOpen;
-  const setToolbarSearchOpen = (open: boolean) => {
-    if (onToolbarSearchOpenChange) {
-      onToolbarSearchOpenChange(open);
+  const searchActive = controlledSearchActive ?? uncontrolledSearchActive;
+  const setSearchActive = (active: boolean) => {
+    if (onSearchActiveChange) {
+      onSearchActiveChange(active);
       return;
     }
-    setUncontrolledToolbarSearchOpen(open);
+    setUncontrolledSearchActive(active);
   };
   const previousSearchTextRef = useRef(snapshot.searchText);
   const derived = useMemo(
-    () => deriveSections(toolbarSearchOpen ? snapshot : { ...snapshot, searchText: "" }),
-    [snapshot, toolbarSearchOpen]
+    () => deriveSections(searchActive ? snapshot : { ...snapshot, searchText: "" }),
+    [snapshot, searchActive]
   );
   const sidebarDerived = useMemo(() => deriveSections({ ...snapshot, searchText: "" }), [snapshot]);
   const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmation>();
   const compactShellRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
-    if (controlledToolbarSearchOpen !== undefined) {
+    if (!compact || controlledSearchActive !== undefined) {
       return;
     }
     const previousSearchText = previousSearchTextRef.current;
     previousSearchTextRef.current = snapshot.searchText;
     if (!previousSearchText.trim() && snapshot.searchText.trim()) {
-      setToolbarSearchOpen(true);
+      setSearchActive(true);
     }
-  }, [controlledToolbarSearchOpen, snapshot.searchText]);
+  }, [compact, controlledSearchActive, snapshot.searchText]);
 
   useEffect(() => {
-    if (!compact || toolbarSearchOpen) {
+    if (!compact || searchActive) {
       return;
     }
 
     clearCompactPopoverControlFocus(document.activeElement, compactShellRef.current);
-  }, [compact, toolbarSearchOpen]);
+  }, [compact, searchActive]);
 
   const confirmAction = () => {
     if (!actionConfirmation) {
@@ -252,10 +243,10 @@ export function Dashboard({
           </div>
           <div className="topbar-actions">
             <ToolbarSearch
-              open={toolbarSearchOpen}
+              open={searchActive}
               snapshot={snapshot}
-              onToggle={() => setToolbarSearchOpen(!toolbarSearchOpen)}
-              onClose={() => setToolbarSearchOpen(false)}
+              onToggle={() => setSearchActive(!searchActive)}
+              onClose={() => setSearchActive(false)}
               toolbarButtonTabIndex={-1}
             />
             <button
@@ -285,20 +276,25 @@ export function Dashboard({
             snapshot={snapshot}
             derived={derived}
             compact={compact}
-            searchActive={toolbarSearchOpen}
+            searchActive={searchActive}
           />
         </section>
       </main>
     );
   } else {
-    const title = selectedTabTitle(selectedTab);
+    const title = searchActive ? "Search" : selectedTabTitle(selectedTab);
     shell = (
       <main className="app-shell">
         <Sidebar
           snapshot={snapshot}
           derived={sidebarDerived}
           route="main"
-          onNavigate={() => setToolbarSearchOpen(false)}
+          searchActive={searchActive}
+          onSelectSearch={() => {
+            window.location.hash = "/main";
+            setSearchActive(true);
+          }}
+          onNavigate={() => setSearchActive(false)}
         />
         <section className="workspace">
           <header className="topbar">
@@ -309,12 +305,6 @@ export function Dashboard({
               {snapshot.selfUpdate?.available && snapshot.selfUpdate.releaseURL ? (
                 <SelfUpdateToolbarButton releaseURL={snapshot.selfUpdate.releaseURL} />
               ) : null}
-              <ToolbarSearch
-                open={toolbarSearchOpen}
-                snapshot={snapshot}
-                onToggle={() => setToolbarSearchOpen(!toolbarSearchOpen)}
-                onClose={() => setToolbarSearchOpen(false)}
-              />
               <button
                 className="toolbar-button refresh-button"
                 onClick={() => void window.baseline.refresh(false)}
@@ -347,7 +337,7 @@ export function Dashboard({
               snapshot={snapshot}
               derived={derived}
               compact={compact}
-              searchActive={toolbarSearchOpen}
+              searchActive={searchActive}
             />
           </section>
         </section>
@@ -419,11 +409,15 @@ function Sidebar({
   snapshot,
   derived,
   route,
+  searchActive = false,
+  onSelectSearch,
   onNavigate
 }: {
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
   route: "main" | "settings";
+  searchActive?: boolean;
+  onSelectSearch?: () => void;
   onNavigate?: () => void;
 }) {
   const selectTab = (tab: MenuTab) => {
@@ -436,7 +430,18 @@ function Sidebar({
     <aside className="sidebar">
       <nav className="source-list">
         <button
-          className={route === "main" && snapshot.selectedTab === "all" ? "selected" : ""}
+          className={route === "main" && searchActive ? "selected" : ""}
+          onClick={onSelectSearch}
+        >
+          <Search size={16} strokeWidth={sidebarIconStrokeWidth} />
+          <span>Search</span>
+        </button>
+      </nav>
+      <nav className="source-list">
+        <button
+          className={
+            route === "main" && !searchActive && snapshot.selectedTab === "all" ? "selected" : ""
+          }
           onClick={() => selectTab("all")}
         >
           <Server size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -444,7 +449,9 @@ function Sidebar({
           <SidebarBadge count={combinedAvailableCount(derived)} />
         </button>
         <button
-          className={route === "main" && snapshot.selectedTab === "apps" ? "selected" : ""}
+          className={
+            route === "main" && !searchActive && snapshot.selectedTab === "apps" ? "selected" : ""
+          }
           onClick={() => selectTab("apps")}
         >
           <AppWindowMac size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -452,7 +459,11 @@ function Sidebar({
           <SidebarBadge count={derived.availableApps.length} />
         </button>
         <button
-          className={route === "main" && snapshot.selectedTab === "homebrew" ? "selected" : ""}
+          className={
+            route === "main" && !searchActive && snapshot.selectedTab === "homebrew"
+              ? "selected"
+              : ""
+          }
           onClick={() => selectTab("homebrew")}
         >
           <Beer size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -460,16 +471,24 @@ function Sidebar({
           <SidebarBadge count={derived.allHomebrewOutdated.length} />
         </button>
       </nav>
-      <nav className="source-list secondary-source-list">
+      <nav className="source-list">
         <button
-          className={route === "main" && snapshot.selectedTab === "installed" ? "selected" : ""}
+          className={
+            route === "main" && !searchActive && snapshot.selectedTab === "installed"
+              ? "selected"
+              : ""
+          }
           onClick={() => selectTab("installed")}
         >
           <CheckCircle2 size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Installed</span>
         </button>
         <button
-          className={route === "main" && snapshot.selectedTab === "ignored" ? "selected" : ""}
+          className={
+            route === "main" && !searchActive && snapshot.selectedTab === "ignored"
+              ? "selected"
+              : ""
+          }
           onClick={() => selectTab("ignored")}
         >
           <EyeOff size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -604,6 +623,9 @@ function SelectedTabContent({
   compact: boolean;
   searchActive: boolean;
 }) {
+  if (!compact && searchActive) {
+    return <SearchTab snapshot={snapshot} derived={derived} />;
+  }
   if (searchActive && snapshot.searchText.trim()) {
     return <SearchResults snapshot={snapshot} derived={derived} />;
   }
@@ -623,6 +645,67 @@ function SelectedTabContent({
     return <HomebrewTab snapshot={snapshot} derived={derived} />;
   }
   return <InstalledTab snapshot={snapshot} derived={derived} compact={compact} />;
+}
+
+function SearchTab({
+  snapshot,
+  derived
+}: {
+  snapshot: BaselineSnapshot;
+  derived: DerivedSections;
+}) {
+  return (
+    <div className="stack search-tab">
+      <SearchField snapshot={snapshot} autoFocus />
+      {snapshot.searchText.trim() ? <SearchResults snapshot={snapshot} derived={derived} /> : null}
+    </div>
+  );
+}
+
+function SearchField({
+  snapshot,
+  autoFocus = false
+}: {
+  snapshot: BaselineSnapshot;
+  autoFocus?: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!autoFocus) {
+      return;
+    }
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [autoFocus]);
+
+  const clearSearch = () => {
+    void window.baseline.setSearchText("");
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="search-box search-page-field">
+      <Search size={15} strokeWidth={toolbarIconStrokeWidth} />
+      <input
+        ref={inputRef}
+        value={snapshot.searchText}
+        onChange={(event) => void window.baseline.setSearchText(event.currentTarget.value)}
+        placeholder="Search"
+      />
+      {snapshot.searchText ? (
+        <button
+          className="search-clear-button"
+          onClick={clearSearch}
+          onMouseDown={(event) => event.preventDefault()}
+          title="Clear Search"
+          aria-label="Clear Search"
+        >
+          <X size={12} />
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 function SearchResults({

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -185,6 +185,10 @@ export function Dashboard({
   };
   const previousSearchTextRef = useRef(snapshot.searchText);
   const derived = useMemo(
+    () => deriveSections(compact && searchActive ? snapshot : { ...snapshot, searchText: "" }),
+    [snapshot, compact, searchActive]
+  );
+  const searchDerived = useMemo(
     () => deriveSections(searchActive ? snapshot : { ...snapshot, searchText: "" }),
     [snapshot, searchActive]
   );
@@ -210,6 +214,23 @@ export function Dashboard({
 
     clearCompactPopoverControlFocus(document.activeElement, compactShellRef.current);
   }, [compact, searchActive]);
+
+  useEffect(() => {
+    if (compact) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if ((event.metaKey || event.ctrlKey) && (key === "f" || key === "k")) {
+        event.preventDefault();
+        setSearchActive(true);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [compact]);
 
   const confirmAction = () => {
     if (!actionConfirmation) {
@@ -282,14 +303,13 @@ export function Dashboard({
       </main>
     );
   } else {
-    const title = searchActive ? "Search" : selectedTabTitle(selectedTab);
+    const title = selectedTabTitle(selectedTab);
     shell = (
       <main className="app-shell">
         <Sidebar
           snapshot={snapshot}
           derived={sidebarDerived}
           route="main"
-          searchActive={searchActive}
           onSelectSearch={() => {
             window.location.hash = "/main";
             setSearchActive(true);
@@ -352,6 +372,13 @@ export function Dashboard({
         aria-hidden={actionConfirmation ? true : undefined}
       >
         {shell}
+        {!compact && searchActive && (
+          <SearchPalette
+            snapshot={snapshot}
+            derived={searchDerived}
+            onClose={() => setSearchActive(false)}
+          />
+        )}
       </div>
       {actionConfirmation && (
         <ActionConfirmationOverlay
@@ -409,14 +436,12 @@ function Sidebar({
   snapshot,
   derived,
   route,
-  searchActive = false,
   onSelectSearch,
   onNavigate
 }: {
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
   route: "main" | "settings";
-  searchActive?: boolean;
   onSelectSearch?: () => void;
   onNavigate?: () => void;
 }) {
@@ -429,19 +454,14 @@ function Sidebar({
   return (
     <aside className="sidebar">
       <nav className="source-list">
-        <button
-          className={route === "main" && searchActive ? "selected" : ""}
-          onClick={onSelectSearch}
-        >
+        <button onClick={onSelectSearch}>
           <Search size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Search</span>
         </button>
       </nav>
       <nav className="source-list">
         <button
-          className={
-            route === "main" && !searchActive && snapshot.selectedTab === "all" ? "selected" : ""
-          }
+          className={route === "main" && snapshot.selectedTab === "all" ? "selected" : ""}
           onClick={() => selectTab("all")}
         >
           <Server size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -449,9 +469,7 @@ function Sidebar({
           <SidebarBadge count={combinedAvailableCount(derived)} />
         </button>
         <button
-          className={
-            route === "main" && !searchActive && snapshot.selectedTab === "apps" ? "selected" : ""
-          }
+          className={route === "main" && snapshot.selectedTab === "apps" ? "selected" : ""}
           onClick={() => selectTab("apps")}
         >
           <AppWindowMac size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -459,11 +477,7 @@ function Sidebar({
           <SidebarBadge count={derived.availableApps.length} />
         </button>
         <button
-          className={
-            route === "main" && !searchActive && snapshot.selectedTab === "homebrew"
-              ? "selected"
-              : ""
-          }
+          className={route === "main" && snapshot.selectedTab === "homebrew" ? "selected" : ""}
           onClick={() => selectTab("homebrew")}
         >
           <Beer size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -473,22 +487,14 @@ function Sidebar({
       </nav>
       <nav className="source-list">
         <button
-          className={
-            route === "main" && !searchActive && snapshot.selectedTab === "installed"
-              ? "selected"
-              : ""
-          }
+          className={route === "main" && snapshot.selectedTab === "installed" ? "selected" : ""}
           onClick={() => selectTab("installed")}
         >
           <CheckCircle2 size={16} strokeWidth={sidebarIconStrokeWidth} />
           <span>Installed</span>
         </button>
         <button
-          className={
-            route === "main" && !searchActive && snapshot.selectedTab === "ignored"
-              ? "selected"
-              : ""
-          }
+          className={route === "main" && snapshot.selectedTab === "ignored" ? "selected" : ""}
           onClick={() => selectTab("ignored")}
         >
           <EyeOff size={16} strokeWidth={sidebarIconStrokeWidth} />
@@ -623,10 +629,7 @@ function SelectedTabContent({
   compact: boolean;
   searchActive: boolean;
 }) {
-  if (!compact && searchActive) {
-    return <SearchTab snapshot={snapshot} derived={derived} />;
-  }
-  if (searchActive && snapshot.searchText.trim()) {
+  if (compact && searchActive && snapshot.searchText.trim()) {
     return <SearchResults snapshot={snapshot} derived={derived} />;
   }
   if (!compact && snapshot.selectedTab === "ignored") {
@@ -647,17 +650,52 @@ function SelectedTabContent({
   return <InstalledTab snapshot={snapshot} derived={derived} compact={compact} />;
 }
 
-function SearchTab({
+function SearchPalette({
   snapshot,
-  derived
+  derived,
+  onClose
 }: {
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
+  onClose: () => void;
 }) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
   return (
-    <div className="stack">
-      <SearchField snapshot={snapshot} autoFocus />
-      {snapshot.searchText.trim() ? <SearchResults snapshot={snapshot} derived={derived} /> : null}
+    <div
+      className="search-palette-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <section
+        className="search-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <SearchField snapshot={snapshot} autoFocus />
+        {snapshot.searchText.trim() ? (
+          <SearchPaletteResults snapshot={snapshot} derived={derived} />
+        ) : (
+          <p className="search-palette-empty">
+            Search apps, Homebrew, installed, and ignored items.
+          </p>
+        )}
+      </section>
     </div>
   );
 }
@@ -675,8 +713,13 @@ function SearchField({
     if (!autoFocus) {
       return;
     }
-    inputRef.current?.focus();
-    inputRef.current?.select();
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus();
+    const caretPosition = input.value.length;
+    input.setSelectionRange(caretPosition, caretPosition);
   }, [autoFocus]);
 
   const clearSearch = () => {
@@ -685,7 +728,7 @@ function SearchField({
   };
 
   return (
-    <div className="search-box search-page-field">
+    <div className="search-box search-palette-field">
       <Search size={15} strokeWidth={toolbarIconStrokeWidth} />
       <input
         ref={inputRef}
@@ -705,6 +748,93 @@ function SearchField({
         </button>
       ) : null}
     </div>
+  );
+}
+
+function SearchPaletteResults({
+  snapshot,
+  derived
+}: {
+  snapshot: BaselineSnapshot;
+  derived: DerivedSections;
+}) {
+  const searchInstalledApps = derived.installedApps.filter(
+    (app) => !uninstallableHomebrewItemForApp(app, snapshot)
+  );
+  const hasResults =
+    snapshot.homebrewDiscoverItems.length > 0 ||
+    derived.availableApps.length > 0 ||
+    derived.allHomebrewOutdated.length > 0 ||
+    searchInstalledApps.length > 0 ||
+    derived.homebrewInstalled.length > 0 ||
+    derived.ignoredApps.length > 0 ||
+    derived.homebrewIgnored.length > 0;
+
+  if (!hasResults) {
+    return <p className="search-palette-empty">No matches found.</p>;
+  }
+
+  return (
+    <div className="search-palette-results">
+      {snapshot.homebrewDiscoverItems.length > 0 && (
+        <SearchPaletteSection title="Discover">
+          {snapshot.homebrewDiscoverItems.map((item) => (
+            <DiscoverRow key={item.id} item={item} snapshot={snapshot} />
+          ))}
+        </SearchPaletteSection>
+      )}
+      {derived.availableApps.length > 0 && (
+        <SearchPaletteSection title="App Updates">
+          {derived.availableApps.map((app) => (
+            <AppRow key={app.id} app={app} snapshot={snapshot} recentlyUpdated={false} />
+          ))}
+        </SearchPaletteSection>
+      )}
+      {derived.allHomebrewOutdated.length > 0 && (
+        <SearchPaletteSection title="Homebrew Updates">
+          {derived.allHomebrewOutdated.map((item) => (
+            <HomebrewRow key={item.id} item={item} snapshot={snapshot} />
+          ))}
+        </SearchPaletteSection>
+      )}
+      {searchInstalledApps.length > 0 && (
+        <SearchPaletteSection title="Installed Apps">
+          {searchInstalledApps.map((app) => (
+            <AppRow key={app.id} app={app} snapshot={snapshot} recentlyUpdated={false} />
+          ))}
+        </SearchPaletteSection>
+      )}
+      {derived.homebrewInstalled.length > 0 && (
+        <SearchPaletteSection title="Installed Homebrew">
+          {derived.homebrewInstalled.map((item) => (
+            <HomebrewRow key={item.id} item={item} snapshot={snapshot} />
+          ))}
+        </SearchPaletteSection>
+      )}
+      {derived.ignoredApps.length > 0 && (
+        <SearchPaletteSection title="Ignored Apps">
+          {derived.ignoredApps.map((app) => (
+            <AppRow key={app.id} app={app} snapshot={snapshot} recentlyUpdated={false} />
+          ))}
+        </SearchPaletteSection>
+      )}
+      {derived.homebrewIgnored.length > 0 && (
+        <SearchPaletteSection title="Ignored Homebrew">
+          {derived.homebrewIgnored.map((item) => (
+            <HomebrewRow key={item.id} item={item} snapshot={snapshot} />
+          ))}
+        </SearchPaletteSection>
+      )}
+    </div>
+  );
+}
+
+function SearchPaletteSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="search-palette-section">
+      <h2>{title}</h2>
+      <div className="rows">{children}</div>
+    </section>
   );
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -124,15 +124,24 @@ const initialSnapshot: BaselineSnapshot = {
   defaultScanDirectories: []
 };
 
-function App() {
+export function App() {
   const [snapshot, setSnapshot] = useState<BaselineSnapshot>(initialSnapshot);
   const [route, setRoute] = useState<Route>(currentRoute());
   const [searchActive, setSearchActive] = useState(false);
+  const previousSearchTextRef = useRef(initialSnapshot.searchText);
 
   useEffect(() => {
     void window.baseline.getSnapshot().then(setSnapshot);
     return window.baseline.onSnapshotChanged(setSnapshot);
   }, []);
+
+  useEffect(() => {
+    const previousSearchText = previousSearchTextRef.current;
+    previousSearchTextRef.current = snapshot.searchText;
+    if (route === "menubar" && !previousSearchText.trim() && snapshot.searchText.trim()) {
+      setSearchActive(true);
+    }
+  }, [route, snapshot.searchText]);
 
   useEffect(() => {
     const onHashChange = () => setRoute(currentRoute());

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -855,7 +855,6 @@ function SearchPalette({
           aria-label="Search"
           tabIndex={-1}
           onKeyDownCapture={handleDialogKeyDown}
-          onMouseDown={(event) => event.stopPropagation()}
         >
           <SearchField snapshot={snapshot} autoFocus />
           {snapshot.searchText.trim() ? (

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -508,18 +508,37 @@ function setElementInert(element: HTMLElement, inert: boolean): void {
 }
 
 const focusableSelector = [
-  "a[href]",
-  "button:not(:disabled)",
-  "input:not(:disabled)",
-  "select:not(:disabled)",
-  "textarea:not(:disabled)",
+  "a[href]:not([tabindex='-1'])",
+  "button:not(:disabled):not([tabindex='-1'])",
+  "input:not(:disabled):not([tabindex='-1'])",
+  "select:not(:disabled):not([tabindex='-1'])",
+  "textarea:not(:disabled):not([tabindex='-1'])",
   "[tabindex]:not([tabindex='-1'])"
 ].join(",");
 
 function focusableElementsIn(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).filter(
-    (element) => !element.closest("[aria-hidden='true']")
-  );
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector))
+    .filter(
+      (element) =>
+        !element.closest("[aria-hidden='true']") &&
+        element.getAttribute("tabindex") !== "-1" &&
+        element.tabIndex >= 0
+    )
+    .sort(compareDocumentOrder);
+}
+
+function compareDocumentOrder(lhs: HTMLElement, rhs: HTMLElement): number {
+  if (lhs === rhs) {
+    return 0;
+  }
+  const position = lhs.compareDocumentPosition(rhs);
+  if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+    return -1;
+  }
+  if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+    return 1;
+  }
+  return 0;
 }
 
 function trapFocusWithin(event: KeyboardEvent, container: HTMLElement | null): void {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -222,7 +222,7 @@ export function Dashboard({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const key = event.key.toLowerCase();
-      if ((event.metaKey || event.ctrlKey) && (key === "f" || key === "k")) {
+      if (event.metaKey && (key === "f" || key === "k")) {
         event.preventDefault();
         setSearchActive(true);
       }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1146,6 +1146,12 @@ button:disabled {
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
 }
 
+.row-action-menu-popover-fixed {
+  position: fixed;
+  right: auto;
+  z-index: 45;
+}
+
 .row:has(.row-action-menu-popover),
 .item-card:has(.row-action-menu-popover) {
   position: relative;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8,6 +8,8 @@
 @tailwind utilities;
 
 :root {
+  --sidebar-width: 196px;
+
   color: #0d0d0d;
   background: transparent;
   font-family:
@@ -41,7 +43,6 @@ button:disabled {
 }
 
 .app-shell {
-  --sidebar-width: 196px;
   --sidebar-background: rgba(255, 255, 255, 0.5);
   --scrollbar-thumb: rgba(60, 60, 60, 0.07);
   --scrollbar-thumb-hover: rgba(60, 60, 60, 0.16);
@@ -384,26 +385,6 @@ button:disabled {
   color: rgba(60, 60, 67, 0.78);
 }
 
-.command-row {
-  display: grid;
-  grid-template-columns: minmax(230px, 1fr) auto;
-  gap: 10px;
-  padding: 10px 60px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-  background: rgba(255, 255, 255, 0.88);
-}
-
-.command-row.search-only {
-  grid-template-columns: minmax(230px, 520px);
-}
-
-.compact .command-row {
-  grid-template-columns: 1fr;
-  padding: 0 0 10px;
-  border-bottom: 0;
-  background: transparent;
-}
-
 .search-box {
   position: relative;
   display: flex;
@@ -428,8 +409,37 @@ button:disabled {
   font-size: 13px;
 }
 
-.search-page-field {
-  width: min(420px, 100%);
+.search-palette-backdrop {
+  position: fixed;
+  inset: 0 0 0 var(--sidebar-width);
+  z-index: 40;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 92px 48px 32px;
+  background: rgba(255, 255, 255, 0.45);
+  -webkit-app-region: no-drag;
+}
+
+.search-palette {
+  display: grid;
+  gap: 16px;
+  width: min(720px, 100%);
+  max-height: calc(100vh - 130px);
+  padding: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(60, 60, 67, 0.09);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.98);
+  -webkit-backdrop-filter: blur(22px) saturate(1.15);
+  backdrop-filter: blur(22px) saturate(1.15);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.05),
+    0 18px 50px rgba(0, 0, 0, 0.14);
+}
+
+.search-palette-field {
+  width: 100%;
   height: 42px;
   gap: 10px;
   padding: 0 42px 0 14px;
@@ -446,7 +456,7 @@ button:disabled {
     background 150ms ease;
 }
 
-.search-page-field::after {
+.search-palette-field::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -466,7 +476,7 @@ button:disabled {
   mask-composite: exclude;
 }
 
-.search-page-field:focus-within {
+.search-palette-field:focus-within {
   border-color: rgba(60, 60, 67, 0.16);
   background: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(248, 248, 248, 0.98)), #ffffff;
   box-shadow:
@@ -474,16 +484,16 @@ button:disabled {
     0 7px 18px rgba(0, 0, 0, 0.05);
 }
 
-.search-page-field svg {
+.search-palette-field svg {
   flex: 0 0 auto;
   color: rgba(60, 60, 67, 0.48);
 }
 
-.search-page-field:focus-within svg {
+.search-palette-field:focus-within svg {
   color: rgba(60, 60, 67, 0.58);
 }
 
-.search-page-field input {
+.search-palette-field input {
   height: 100%;
   color: #1c1c1e;
   font-size: 15px;
@@ -495,7 +505,7 @@ button:disabled {
   right: 6px;
 }
 
-.search-page-field .search-clear-button {
+.search-palette-field .search-clear-button {
   top: 11px;
   right: 12px;
   background: rgba(60, 60, 67, 0.08);
@@ -506,10 +516,100 @@ button:disabled {
 }
 
 @media (hover: hover) {
-  .search-page-field .search-clear-button:hover {
+  .search-palette-field .search-clear-button:hover {
     background: rgba(60, 60, 67, 0.13);
     color: #1c1c1e;
   }
+}
+
+.search-palette-empty {
+  margin: 0;
+  padding: 4px 2px 2px;
+  color: rgba(60, 60, 67, 0.58);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.search-palette-results {
+  display: grid;
+  gap: 14px;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.search-palette-section {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.search-palette-section h2 {
+  margin: 0;
+  padding: 0 2px;
+  color: rgba(60, 60, 67, 0.58);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.search-palette .rows {
+  gap: 2px;
+}
+
+.search-palette .row {
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  gap: 10px;
+  min-height: 52px;
+  padding: 7px 8px;
+  border-top: 0;
+  border-radius: 12px;
+}
+
+.search-palette .row:hover {
+  background: rgba(60, 60, 67, 0.055);
+}
+
+.search-palette .app-icon,
+.search-palette .app-icon img {
+  width: 38px;
+  height: 38px;
+}
+
+.search-palette .app-icon {
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.search-palette .app-icon.brew {
+  width: 38px;
+  height: 38px;
+}
+
+.search-palette .app-icon.brew svg {
+  width: 22px;
+  height: 22px;
+}
+
+.search-palette .row-main {
+  gap: 3px;
+}
+
+.search-palette .row-title strong {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.search-palette .row-title span {
+  font-size: 11px;
+}
+
+.search-palette .row-main p {
+  margin-top: 0;
+  font-size: 12px;
+}
+
+.search-palette .row-actions {
+  gap: 5px;
 }
 
 .content {
@@ -2383,8 +2483,7 @@ button:disabled {
     background: #191919;
   }
 
-  .topbar,
-  .command-row {
+  .topbar {
     border-color: rgba(255, 255, 255, 0.1);
     background: rgba(25, 25, 25, 0.88);
   }
@@ -2422,7 +2521,19 @@ button:disabled {
     color: rgba(235, 235, 245, 0.58);
   }
 
-  .search-page-field {
+  .search-palette-backdrop {
+    background: rgba(0, 0, 0, 0.24);
+  }
+
+  .search-palette {
+    border-color: rgba(235, 235, 245, 0.09);
+    background: rgba(36, 36, 38, 0.98);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.28),
+      0 22px 58px rgba(0, 0, 0, 0.42);
+  }
+
+  .search-palette-field {
     border-color: rgba(235, 235, 245, 0.1);
     background:
       linear-gradient(180deg, rgba(255, 255, 255, 0.095), rgba(255, 255, 255, 0.055)),
@@ -2433,13 +2544,13 @@ button:disabled {
     color: rgba(235, 235, 245, 0.56);
   }
 
-  .search-page-field::after {
+  .search-palette-field::after {
     background:
       radial-gradient(140% 140% at 0% 0%, rgba(255, 255, 255, 0.12), transparent 58%),
       radial-gradient(140% 140% at 100% 100%, rgba(255, 255, 255, 0.055), transparent 60%);
   }
 
-  .search-page-field:focus-within {
+  .search-palette-field:focus-within {
     border-color: rgba(235, 235, 245, 0.2);
     background:
       linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.07)),
@@ -2449,11 +2560,11 @@ button:disabled {
       0 10px 24px rgba(0, 0, 0, 0.24);
   }
 
-  .search-page-field svg {
+  .search-palette-field svg {
     color: rgba(235, 235, 245, 0.44);
   }
 
-  .search-page-field:focus-within svg {
+  .search-palette-field:focus-within svg {
     color: rgba(235, 235, 245, 0.58);
   }
 
@@ -2483,16 +2594,25 @@ button:disabled {
     color: rgba(235, 235, 245, 0.5);
   }
 
-  .search-page-field .search-clear-button {
+  .search-palette-field .search-clear-button {
     background: rgba(235, 235, 245, 0.08);
     color: rgba(235, 235, 245, 0.52);
   }
 
   @media (hover: hover) {
-    .search-page-field .search-clear-button:hover {
+    .search-palette-field .search-clear-button:hover {
       background: rgba(235, 235, 245, 0.13);
       color: #fcfcfc;
     }
+  }
+
+  .search-palette-empty,
+  .search-palette-section h2 {
+    color: rgba(235, 235, 245, 0.5);
+  }
+
+  .search-palette .row:hover {
+    background: rgba(235, 235, 245, 0.08);
   }
 
   .panel-title h2 {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -58,6 +58,11 @@ button:disabled {
   background: var(--sidebar-background);
 }
 
+.app-content-surface {
+  width: 100vw;
+  height: 100vh;
+}
+
 .app-shell,
 .app-shell * {
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
@@ -413,7 +418,7 @@ button:disabled {
   position: fixed;
   inset: 0;
   z-index: 40;
-  pointer-events: none;
+  pointer-events: auto;
   -webkit-app-region: no-drag;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -434,7 +434,7 @@ button:disabled {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 92px 48px 32px;
+  padding: 78px 48px 32px;
   pointer-events: auto;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -9,6 +9,7 @@
 
 :root {
   --sidebar-width: 196px;
+  --update-accent-rgb: 1, 105, 204;
 
   color: #0d0d0d;
   background: transparent;
@@ -47,7 +48,6 @@ button:disabled {
   --scrollbar-thumb: rgba(60, 60, 60, 0.07);
   --scrollbar-thumb-hover: rgba(60, 60, 60, 0.16);
   --scrollbar-track: transparent;
-  --update-accent-rgb: 1, 105, 204;
 
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
@@ -409,16 +409,28 @@ button:disabled {
   font-size: 13px;
 }
 
-.search-palette-backdrop {
+.search-palette-layer {
   position: fixed;
-  inset: 0 0 0 var(--sidebar-width);
+  inset: 0;
   z-index: 40;
+  pointer-events: none;
+  -webkit-app-region: no-drag;
+}
+
+.search-palette-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.search-palette-workspace {
+  position: absolute;
+  inset: 0 0 0 var(--sidebar-width);
   display: flex;
   align-items: flex-start;
   justify-content: center;
   padding: 92px 48px 32px;
-  background: rgba(255, 255, 255, 0.45);
-  -webkit-app-region: no-drag;
+  pointer-events: auto;
 }
 
 .search-palette {
@@ -2522,7 +2534,7 @@ button:disabled {
   }
 
   .search-palette-backdrop {
-    background: rgba(0, 0, 0, 0.24);
+    background: rgba(0, 0, 0, 0.42);
   }
 
   .search-palette {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -429,13 +429,87 @@ button:disabled {
 }
 
 .search-page-field {
-  width: min(520px, 100%);
-  padding-right: 30px;
+  width: min(420px, 100%);
+  height: 42px;
+  gap: 10px;
+  padding: 0 42px 0 14px;
+  border-color: rgba(67, 67, 67, 0.06);
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(246, 246, 246, 0.96)), #ffffff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 5px 14px rgba(0, 0, 0, 0.035);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background 150ms ease;
+}
+
+.search-page-field::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background:
+    radial-gradient(140% 140% at 0% 0%, rgba(255, 255, 255, 0.88), transparent 56%),
+    radial-gradient(140% 140% at 100% 100%, rgba(255, 255, 255, 0.5), transparent 58%);
+  pointer-events: none;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+
+.search-page-field:focus-within {
+  border-color: rgba(60, 60, 67, 0.16);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(248, 248, 248, 0.98)), #ffffff;
+  box-shadow:
+    0 0 0 3px rgba(60, 60, 67, 0.045),
+    0 7px 18px rgba(0, 0, 0, 0.05);
+}
+
+.search-page-field svg {
+  flex: 0 0 auto;
+  color: rgba(60, 60, 67, 0.48);
+}
+
+.search-page-field:focus-within svg {
+  color: rgba(60, 60, 67, 0.58);
+}
+
+.search-page-field input {
+  height: 100%;
+  color: #1c1c1e;
+  font-size: 15px;
+  font-weight: 400;
 }
 
 .search-box .search-clear-button {
   top: 5px;
   right: 6px;
+}
+
+.search-page-field .search-clear-button {
+  top: 11px;
+  right: 12px;
+  background: rgba(60, 60, 67, 0.08);
+  color: rgba(60, 60, 67, 0.52);
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+}
+
+@media (hover: hover) {
+  .search-page-field .search-clear-button:hover {
+    background: rgba(60, 60, 67, 0.13);
+    color: #1c1c1e;
+  }
 }
 
 .content {
@@ -2348,6 +2422,41 @@ button:disabled {
     color: rgba(235, 235, 245, 0.58);
   }
 
+  .search-page-field {
+    border-color: rgba(235, 235, 245, 0.1);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.095), rgba(255, 255, 255, 0.055)),
+      rgba(255, 255, 255, 0.04);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.055),
+      0 8px 22px rgba(0, 0, 0, 0.2);
+    color: rgba(235, 235, 245, 0.56);
+  }
+
+  .search-page-field::after {
+    background:
+      radial-gradient(140% 140% at 0% 0%, rgba(255, 255, 255, 0.12), transparent 58%),
+      radial-gradient(140% 140% at 100% 100%, rgba(255, 255, 255, 0.055), transparent 60%);
+  }
+
+  .search-page-field:focus-within {
+    border-color: rgba(235, 235, 245, 0.2);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.07)),
+      rgba(255, 255, 255, 0.05);
+    box-shadow:
+      0 0 0 3px rgba(235, 235, 245, 0.055),
+      0 10px 24px rgba(0, 0, 0, 0.24);
+  }
+
+  .search-page-field svg {
+    color: rgba(235, 235, 245, 0.44);
+  }
+
+  .search-page-field:focus-within svg {
+    color: rgba(235, 235, 245, 0.58);
+  }
+
   .toolbar-search input {
     border-color: rgba(235, 235, 245, 0.18);
     background: rgba(255, 255, 255, 0.08);
@@ -2372,6 +2481,18 @@ button:disabled {
 
   .search-clear-button {
     color: rgba(235, 235, 245, 0.5);
+  }
+
+  .search-page-field .search-clear-button {
+    background: rgba(235, 235, 245, 0.08);
+    color: rgba(235, 235, 245, 0.52);
+  }
+
+  @media (hover: hover) {
+    .search-page-field .search-clear-button:hover {
+      background: rgba(235, 235, 245, 0.13);
+      color: #fcfcfc;
+    }
   }
 
   .panel-title h2 {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1146,10 +1146,15 @@ button:disabled {
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
 }
 
-.row-action-menu-popover-fixed {
+.row-action-menu-popover-above {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+
+.row-action-menu-popover-floating {
   position: fixed;
   right: auto;
-  z-index: 45;
+  z-index: 60;
 }
 
 .row:has(.row-action-menu-popover),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -113,6 +113,14 @@ button:disabled {
   max-width: var(--sidebar-width);
   padding: 49px 10px 12px;
   background: transparent;
+  -webkit-app-region: no-drag;
+}
+
+.sidebar::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 49px;
   -webkit-app-region: drag;
 }
 
@@ -122,7 +130,7 @@ button:disabled {
   -webkit-app-region: no-drag;
 }
 
-.secondary-source-list {
+.source-list + .source-list {
   margin-top: 20px;
 }
 
@@ -142,6 +150,19 @@ button:disabled {
   font-weight: 300;
   text-align: left;
   transition: none;
+  -webkit-app-region: no-drag;
+}
+
+.source-list button *,
+.sidebar-footer button * {
+  -webkit-app-region: no-drag;
+}
+
+.source-list button > svg,
+.source-list button > span,
+.sidebar-footer button > svg,
+.sidebar-footer button > span {
+  pointer-events: none;
 }
 
 .source-list button.selected,
@@ -384,6 +405,7 @@ button:disabled {
 }
 
 .search-box {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -404,6 +426,16 @@ button:disabled {
   background: transparent;
   color: #0d0d0d;
   font-size: 13px;
+}
+
+.search-page-field {
+  width: min(520px, 100%);
+  padding-right: 30px;
+}
+
+.search-box .search-clear-button {
+  top: 5px;
+  right: 6px;
 }
 
 .content {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2539,7 +2539,7 @@ button:disabled {
   }
 
   .search-palette-backdrop {
-    background: rgba(0, 0, 0, 0.42);
+    background: rgba(0, 0, 0, 0.58);
   }
 
   .search-palette {


### PR DESCRIPTION
## Summary
- Move main-window sidebar Search from a dedicated page into a command-palette-style overlay that opens over the current tab while preserving the selected sidebar context.
- Keep compact menu bar search on the existing inline behavior while main-window Search supports sidebar open, Cmd+F, Cmd+K, Escape close, backdrop/sidebar dismissal, modal focus trapping, focus restoration, and a focused field without selected text.
- Present search matches as compact action rows across Discover, app updates, Homebrew updates, installed, and ignored sections; keep row action menus visible and dismissible when palette results are clipped.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/electron-smoke.spec.ts -g "launches the Electron shell and renders the dashboard|persists preferences across Electron relaunches|reuses the main window without duplicate setup|reopens settings after renderer-side back navigation"`