### PR TITLE
Preserve app updates after transient lookup failures

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -23,7 +23,8 @@ import type {
   HomebrewCaskIndex,
   HomebrewManagedItem,
   PersistedSnapshot,
-  ProfileStats
+  ProfileStats,
+  UpdateRecord
 } from "../src/shared/domain";
 import { version } from "../src/shared/version";
 
@@ -718,6 +719,136 @@ describe("update store helpers", () => {
       source: "homebrew",
       remoteVersion: version("2.0.0"),
       homebrewToken: "precedence"
+    });
+  });
+
+  it("preserves previous App Store updates when App Store lookup transiently fails", async () => {
+    const installedApp = appRecord({
+      bundlePath: "/Applications/App Store Transient.app",
+      displayName: "App Store Transient",
+      bundleIdentifier: "com.example.app-store-transient",
+      sparkleFeedURL: "https://updates.example.com/app-store-transient.xml",
+      localVersion: version("1.0.0")
+    });
+    const previousUpdate: UpdateRecord = {
+      id: installedApp.id,
+      appID: installedApp.id,
+      source: "appStore",
+      supportLevel: "supported",
+      localVersion: version("1.0.0"),
+      remoteVersion: version("2.0.0"),
+      updateURL: "https://apps.apple.com/app/example",
+      appStoreItemID: 123,
+      checkedAt: "2026-05-20T12:00:00.000Z"
+    };
+    const sparkleLookup = vi.fn(async () => ({
+      type: "completed" as const,
+      value: {
+        remoteVersion: version("1.5.0"),
+        updateURL: "https://updates.example.com/download"
+      }
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [installedApp],
+        updates: [previousUpdate]
+      },
+      clients: {
+        scanner: { scanApplications: async () => [installedApp] },
+        appStore: { lookupOutcome: async () => ({ type: "transientFailure" as const }) },
+        sparkle: { lookupOutcome: sparkleLookup }
+      }
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().updates).toEqual([previousUpdate]);
+    expect(store.getSnapshot().recentlyUpdated).toEqual([]);
+    expect(sparkleLookup).not.toHaveBeenCalled();
+  });
+
+  it("preserves previous Sparkle build-only updates when Sparkle lookup transiently fails", async () => {
+    const installedApp = appRecord({
+      bundlePath: "/Applications/Sparkle Transient.app",
+      displayName: "Sparkle Transient",
+      bundleIdentifier: "com.example.sparkle-transient",
+      sparkleFeedURL: "https://updates.example.com/sparkle-transient.xml",
+      localVersion: version("1.0"),
+      bundleVersion: version("100")
+    });
+    const previousUpdate: UpdateRecord = {
+      id: installedApp.id,
+      appID: installedApp.id,
+      source: "sparkle",
+      supportLevel: "limited",
+      localVersion: version("1.0"),
+      remoteVersion: version("1.0"),
+      localBuildVersion: version("100"),
+      remoteBuildVersion: version("101"),
+      updateURL: "https://updates.example.com/download",
+      checkedAt: "2026-05-20T12:00:00.000Z"
+    };
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [installedApp],
+        updates: [previousUpdate]
+      },
+      clients: {
+        scanner: { scanApplications: async () => [installedApp] },
+        appStore: { lookupOutcome: async () => ({ type: "completed" as const }) },
+        sparkle: { lookupOutcome: async () => ({ type: "transientFailure" as const }) }
+      }
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().updates).toEqual([previousUpdate]);
+    expect(store.getSnapshot().recentlyUpdated).toEqual([]);
+  });
+
+  it("clears a previous app update after the installed version advances", async () => {
+    const previousApp = appRecord({
+      bundlePath: "/Applications/Advanced App.app",
+      displayName: "Advanced App",
+      bundleIdentifier: "com.example.advanced-app",
+      localVersion: version("1.0.0")
+    });
+    const refreshedApp = {
+      ...previousApp,
+      localVersion: version("2.0.0")
+    };
+    const previousUpdate: UpdateRecord = {
+      id: previousApp.id,
+      appID: previousApp.id,
+      source: "appStore",
+      supportLevel: "supported",
+      localVersion: version("1.0.0"),
+      remoteVersion: version("2.0.0"),
+      updateURL: "https://apps.apple.com/app/example",
+      checkedAt: "2026-05-20T12:00:00.000Z"
+    };
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [previousApp],
+        updates: [previousUpdate]
+      },
+      clients: {
+        scanner: { scanApplications: async () => [refreshedApp] },
+        appStore: { lookupOutcome: async () => ({ type: "transientFailure" as const }) }
+      }
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().updates).toEqual([]);
+    expect(store.getSnapshot().recentlyUpdated[0]).toMatchObject({
+      appID: previousApp.id,
+      source: "appStore",
+      fromVersion: version("1.0.0"),
+      toVersion: version("2.0.0")
     });
   });
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -70,6 +70,8 @@ type RefreshOptions = {
   allowHomebrewInventoryDuringActiveCommand?: boolean;
 };
 
+type AppLookupSource = Extract<UpdateRecord["source"], "appStore" | "sparkle">;
+
 type HomebrewUpdateQueueEntry = {
   item: HomebrewManagedItem;
   profileStatsEvent?: ProfileStatsEvent;
@@ -999,6 +1001,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       }
       this.latestHomebrewIndex = homebrewIndex;
       this.latestHomebrewFormulaIndex = homebrewFormulaIndex;
+      const previousUpdates = new Map(this.state.updates.map((update) => [update.appID, update]));
       const updates: UpdateRecord[] = [];
 
       for (const appRecord of apps) {
@@ -1027,6 +1030,17 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             });
             continue;
           }
+          if (outcome.type === "transientFailure") {
+            const previousUpdate = previousAppUpdateForTransientLookup(
+              previousUpdates,
+              appRecord,
+              "appStore"
+            );
+            if (previousUpdate) {
+              updates.push(previousUpdate);
+              continue;
+            }
+          }
         }
 
         if (appRecord.sparkleFeedURL) {
@@ -1051,6 +1065,17 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
               checkedAt: now
             });
             continue;
+          }
+          if (outcome.type === "transientFailure") {
+            const previousUpdate = previousAppUpdateForTransientLookup(
+              previousUpdates,
+              appRecord,
+              "sparkle"
+            );
+            if (previousUpdate) {
+              updates.push(previousUpdate);
+              continue;
+            }
           }
         }
 
@@ -1083,7 +1108,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       if (sequence !== this.refreshSequence) {
         return;
       }
-      const previousUpdates = new Map(this.state.updates.map((update) => [update.appID, update]));
       const previousHomebrewItems = this.state.homebrewItems;
       const reconciledHomebrewItems = reconcileHomebrewInventory(
         preservePreviousHomebrewOutdatedState(
@@ -1765,6 +1789,55 @@ function removeRecordKey<T>(record: Record<string, T>, key: string): Record<stri
   const next = { ...record };
   delete next[key];
   return next;
+}
+
+function previousAppUpdateForTransientLookup(
+  previousUpdates: Map<string, UpdateRecord>,
+  appRecord: AppRecord,
+  source: AppLookupSource
+): UpdateRecord | undefined {
+  const previousUpdate = previousUpdates.get(appRecord.id);
+  if (!previousUpdate || previousUpdate.source !== source) {
+    return undefined;
+  }
+  if (!canPreservePreviousAppUpdate(appRecord, previousUpdate)) {
+    return undefined;
+  }
+  return previousUpdate;
+}
+
+function canPreservePreviousAppUpdate(appRecord: AppRecord, previousUpdate: UpdateRecord): boolean {
+  if (previousUpdate.appID !== appRecord.id) {
+    return false;
+  }
+  if (compareVersions(previousUpdate.localVersion, appRecord.localVersion) !== 0) {
+    return false;
+  }
+  if (
+    previousUpdate.localBuildVersion &&
+    (!appRecord.bundleVersion ||
+      compareVersions(previousUpdate.localBuildVersion, appRecord.bundleVersion) !== 0)
+  ) {
+    return false;
+  }
+  return isAppUpdateNewerThanInstalledApp(previousUpdate, appRecord);
+}
+
+function isAppUpdateNewerThanInstalledApp(update: UpdateRecord, appRecord: AppRecord): boolean {
+  const versionComparison = compareVersions(update.remoteVersion, appRecord.localVersion);
+  if (versionComparison > 0) {
+    return true;
+  }
+  if (versionComparison < 0) {
+    return false;
+  }
+  if (!update.remoteBuildVersion || !update.localBuildVersion || !appRecord.bundleVersion) {
+    return false;
+  }
+  return (
+    compareVersions(update.localBuildVersion, appRecord.bundleVersion) === 0 &&
+    isVersionGreater(update.remoteBuildVersion, appRecord.bundleVersion)
+  );
 }
 
 function emptyHomebrewInventoryResult(): HomebrewInventoryResult {


### PR DESCRIPTION
## Summary
- Preserve previous App Store or Sparkle update records when the matching lookup returns a transient failure and the installed version/build still matches the prior record.
- Keep source precedence by carrying forward an existing App Store update instead of falling through to lower-precedence sources during transient App Store failures.
- Add regression coverage for App Store preservation, Sparkle build-only preservation, and clearing after the installed app advances.

Fixes #148

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm run test:electron` (4/5 passed locally; packaged-app case blocked because local packaging output was missing)