### PR TITLE
Bump tar override for GHSA-vmf3-w455-68vh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9268,9 +9268,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",
-    "tar": "^7.5.15",
+    "tar": "^7.5.16",
     "tmp": "^0.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bump the npm `tar` override to `^7.5.16`, the first patched release for GHSA-vmf3-w455-68vh / CVE-2026-53655.
- Refresh the lockfile so Electron Forge's transitive dev tooling resolves the patched `tar` package.

## Validation
- `npm ls tar --all`
- `npm audit`
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`
- `npm run build` (exited 0; no packaged app output was produced locally under Node 26.3.0)
- `npm run test:electron` (4/5 passed locally; packaged-app case could not run because no packaged app output existed)