### PR TITLE
Align Homebrew cask upgrades with greedy detection

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2206,7 +2206,7 @@ describe("update store helpers", () => {
     await store.performAppUpdate(app.id);
 
     expect(runBrewCommand).toHaveBeenCalledWith(
-      ["upgrade", "--cask", "homebrew-managed"],
+      ["upgrade", "--cask", "--greedy", "homebrew-managed"],
       expect.any(Function)
     );
     expect(store.getSnapshot().profileStats.events).toEqual([
@@ -2261,7 +2261,7 @@ describe("update store helpers", () => {
     await store.performAppUpdate(app.id);
 
     expect(runBrewCommand).toHaveBeenCalledWith(
-      ["upgrade", "--cask", "homebrew-managed"],
+      ["upgrade", "--cask", "--greedy", "homebrew-managed"],
       expect.any(Function)
     );
   });
@@ -2390,7 +2390,7 @@ describe("update store helpers", () => {
     await linkedStore.performAppUpdate(app.id);
 
     expect(linkedBrewCommand).toHaveBeenCalledWith(
-      ["upgrade", "--cask", "sparkle-managed"],
+      ["upgrade", "--cask", "--greedy", "sparkle-managed"],
       expect.any(Function)
     );
   });
@@ -3290,7 +3290,7 @@ describe("update store helpers", () => {
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["install", "fd"],
       ["upgrade", "ripgrep"],
-      ["upgrade", "--cask", "raycast"]
+      ["upgrade", "--cask", "--greedy", "raycast"]
     ]);
   });
 
@@ -3369,7 +3369,7 @@ describe("update store helpers", () => {
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["upgrade", "ripgrep"],
       ["upgrade", "bat"],
-      ["upgrade", "--cask", "raycast"]
+      ["upgrade", "--cask", "--greedy", "raycast"]
     ]);
     expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual([]);
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toEqual([]);

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -455,7 +455,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   ): Promise<void> {
     const itemID = item.id;
     const command =
-      item.kind === "cask" ? ["upgrade", "--cask", item.token] : ["upgrade", item.token];
+      item.kind === "cask"
+        ? ["upgrade", "--cask", "--greedy", item.token]
+        : ["upgrade", item.token];
     const parser = new HomebrewMaintenanceOutputParser([item.token.toLowerCase()]);
     const result = await this.runBrewWithEvents(command, (event) => {
       this.applyHomebrewProgressEvent(
@@ -543,7 +545,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     );
     const sequence = [
       ...(formulaTokens.length > 0 ? [["upgrade", ...formulaTokens]] : []),
-      ...(caskTokens.length > 0 ? [["upgrade", "--cask", ...caskTokens]] : [])
+      ...(caskTokens.length > 0 ? [["upgrade", "--cask", "--greedy", ...caskTokens]] : [])
     ];
     const completedItemIDs = new Set<string>();
     let success = true;


### PR DESCRIPTION
Summary
- Adds `--greedy` to individual Homebrew cask upgrade commands so row-level app and cask updates match greedy outdated detection.
- Adds `--greedy` to queued Homebrew cask upgrade batches while leaving formula upgrade commands unchanged.
- Updates store tests to lock in greedy cask command construction for app-backed, linked Sparkle-backed, and queued cask paths.

Fixes #155.

Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`