### PR TITLE
Keep Update Brews clickable while Homebrew is busy

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1742,6 +1742,33 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Update Brews" })).toBeInTheDocument();
   });
 
+  it("shows updated aggregate state when every section Homebrew item is pending refresh", () => {
+    const second: HomebrewManagedItem = {
+      ...cask,
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula"
+    };
+
+    render(
+      <HomebrewSection
+        sectionID="outdated"
+        title="Outdated"
+        items={[cask, second]}
+        snapshot={snapshot({
+          homebrewItems: [cask, second],
+          homebrewUpdatedPendingRefreshItemIDs: [cask.id, second.id]
+        })}
+        empty="No updates."
+        showUpdateAll
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Update Brews" })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Updated" })).toHaveLength(3);
+  });
+
   it("keeps Homebrew update actions clickable while a Discover install is active", () => {
     const second: HomebrewManagedItem = {
       ...cask,
@@ -1828,6 +1855,41 @@ describe("renderer button parity", () => {
       "formula:fd",
       "formula:ripgrep"
     ]);
+  });
+
+  it("shows updated aggregate state in the combined updates section", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    };
+    const secondFormula: HomebrewManagedItem = {
+      id: "formula:fd",
+      token: "fd",
+      name: "fd",
+      kind: "formula",
+      installedVersion: version("9.0.0"),
+      latestVersion: version("10.0.0"),
+      isOutdated: true
+    };
+
+    render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          homebrewItems: [formula, secondFormula],
+          homebrewUpdatedPendingRefreshItemIDs: [formula.id, secondFormula.id]
+        })}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Update Brews" })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Updated" })).toHaveLength(3);
   });
 
   it("renders the Homebrew tab outdated section as a card grid", () => {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1742,7 +1742,7 @@ describe("renderer button parity", () => {
     expect(screen.getByRole("button", { name: "Update Brews" })).toBeInTheDocument();
   });
 
-  it("keeps individual Homebrew update actions clickable while a Discover install is active", () => {
+  it("keeps Homebrew update actions clickable while a Discover install is active", () => {
     const second: HomebrewManagedItem = {
       ...cask,
       id: "formula:ripgrep",
@@ -1765,10 +1765,10 @@ describe("renderer button parity", () => {
       />
     );
 
-    const batchButton = screen.getByRole("button", { name: "Updating" });
-    expect(batchButton).toBeDisabled();
+    const batchButton = screen.getByRole("button", { name: "Update Brews" });
+    expect(batchButton).toBeEnabled();
     fireEvent.click(batchButton);
-    expect(window.baseline.performHomebrewUpdateAll).not.toHaveBeenCalled();
+    expect(window.baseline.performHomebrewUpdateAll).toHaveBeenCalledWith([cask.id, second.id]);
 
     for (const updateButton of screen.getAllByRole("button", { name: "Update" })) {
       expect(updateButton).toBeEnabled();

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3294,6 +3294,92 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("queues visible Homebrew batch updates during an active Discover install", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    const formula = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const cask = homebrewItem({
+      id: "cask:raycast",
+      token: "raycast",
+      name: "Raycast",
+      kind: "cask",
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    });
+    const ignoredFormula = homebrewItem({
+      id: "formula:ignored",
+      token: "ignored",
+      name: "ignored",
+      kind: "formula",
+      latestVersion: version("1.0.0"),
+      isOutdated: true
+    });
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "install") {
+        return await new Promise((resolve) => {
+          resolveInstall = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        ignoredHomebrewItemIDs: [ignoredFormula.id],
+        homebrewItems: [formula, cask, ignoredFormula]
+      },
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [formula, cask, ignoredFormula],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
+      runBrewCommand
+    });
+
+    const install = store.installHomebrewItem(discoverItem);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
+
+    await store.performHomebrewUpdateAll([formula.id, cask.id, ignoredFormula.id]);
+
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual(
+      expect.arrayContaining([formula.id, cask.id])
+    );
+    expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(ignoredFormula.id);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["install", "fd"]]);
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+
+    await vi.waitFor(() => {
+      expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+        ["install", "fd"],
+        ["upgrade", "ripgrep"],
+        ["upgrade", "--cask", "--greedy", "raycast"]
+      ]);
+    });
+    expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual([]);
+  });
+
   it("queues burst-clicked individual Homebrew updates behind the active update", async () => {
     const formula = homebrewItem({
       id: "formula:ripgrep",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -416,14 +416,29 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       requireOutdated?: boolean;
     } = {}
   ): Promise<void> {
+    const queuedUpdate = this.queueHomebrewItemUpdate(item, options);
+    if (queuedUpdate) {
+      await queuedUpdate;
+    }
+  }
+
+  private queueHomebrewItemUpdate(
+    item: HomebrewManagedItem,
+    options: {
+      profileStatsEvent?: ProfileStatsEvent;
+      appUpdateAppID?: string;
+      requiredRemoteVersion?: VersionValue;
+      requireOutdated?: boolean;
+    } = {}
+  ): Promise<void> | undefined {
     if (!isValidHomebrewToken(item.token)) {
-      return;
+      return undefined;
     }
     if (
       this.state.homebrewUpdatingItemIDs.includes(item.id) ||
       this.homebrewUpdateQueue.some((entry) => entry.item.id === item.id)
     ) {
-      return;
+      return undefined;
     }
     this.clearHomebrewBatchFailureTimer(item.id);
     this.patch({
@@ -435,7 +450,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         [item.id]: HomebrewMaintenanceProgressStage.queued
       }
     });
-    await new Promise<void>((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       this.homebrewUpdateQueue.push({
         item,
         profileStatsEvent: options.profileStatsEvent,
@@ -617,37 +632,23 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
   }
 
   async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
-    if (this.state.homebrewUpdatingItemIDs.length > 0 || this.homebrewUpdateQueue.length > 0) {
+    const affected = this.homebrewBatchUpdateItems(itemIDs);
+    if (affected.length === 0) {
       return;
     }
+
+    if (this.isHomebrewCommandActive() || this.homebrewUpdateQueue.length > 0) {
+      this.queueHomebrewBatchUpdates(affected);
+      return;
+    }
+
     const releaseHomebrewCommandLock = this.reserveHomebrewCommandLock();
     if (!releaseHomebrewCommandLock) {
+      this.queueHomebrewBatchUpdates(affected);
       return;
     }
 
     try {
-      const requestedItemIDs = itemIDs ? new Set(itemIDs) : undefined;
-      const updatesByAppID = new Map(this.state.updates.map((update) => [update.appID, update]));
-      const appsRepresentedOutsideHomebrew = this.state.apps.filter(
-        (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
-      );
-      const ignoredApps = this.state.apps.filter((app) => this.state.ignoredIDs.includes(app.id));
-      const affected = this.state.homebrewItems.filter(
-        (item) =>
-          (!requestedItemIDs || requestedItemIDs.has(item.id)) &&
-          item.isOutdated &&
-          !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
-          isValidHomebrewToken(item.token) &&
-          !homebrewItemHasAppRepresentation(
-            item,
-            requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew,
-            updatesByAppID
-          )
-      );
-      if (affected.length === 0) {
-        return;
-      }
-
       const formulaTokens = affected
         .filter((item) => item.kind === "formula")
         .map((item) => item.token);
@@ -760,6 +761,37 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
     } finally {
       releaseHomebrewCommandLock();
+    }
+  }
+
+  private homebrewBatchUpdateItems(itemIDs?: string[]): HomebrewManagedItem[] {
+    const requestedItemIDs = itemIDs ? new Set(itemIDs) : undefined;
+    const updatesByAppID = new Map(this.state.updates.map((update) => [update.appID, update]));
+    const appsRepresentedOutsideHomebrew = this.state.apps.filter(
+      (app) => updatesByAppID.has(app.id) || this.state.ignoredIDs.includes(app.id)
+    );
+    const ignoredApps = this.state.apps.filter((app) => this.state.ignoredIDs.includes(app.id));
+    return this.state.homebrewItems.filter(
+      (item) =>
+        (!requestedItemIDs || requestedItemIDs.has(item.id)) &&
+        item.isOutdated &&
+        !this.state.ignoredHomebrewItemIDs.includes(item.id) &&
+        !this.state.homebrewUpdatedPendingRefreshItemIDs.includes(item.id) &&
+        isValidHomebrewToken(item.token) &&
+        !homebrewItemHasAppRepresentation(
+          item,
+          requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew,
+          updatesByAppID
+        )
+    );
+  }
+
+  private queueHomebrewBatchUpdates(items: HomebrewManagedItem[]): void {
+    for (const item of items) {
+      const queuedUpdate = this.queueHomebrewItemUpdate(item, { requireOutdated: true });
+      if (queuedUpdate) {
+        void queuedUpdate.catch(() => undefined);
+      }
     }
   }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1203,7 +1203,7 @@ function AllUpdatesSection({
         action={
           derived.allHomebrewOutdated.length > 1 ? (
             <UpdateActionButton
-              state={{ type: "ready" }}
+              state={homebrewBatchActionState(derived.allHomebrewOutdated, snapshot)}
               readyLabel="Update Brews"
               readyVariant="outline"
               onAction={() => performHomebrewUpdateAllForItems(derived.allHomebrewOutdated)}
@@ -2037,7 +2037,7 @@ export function HomebrewSection({
         action={
           showUpdateAll && items.length > 1 ? (
             <UpdateActionButton
-              state={{ type: "ready" }}
+              state={homebrewBatchActionState(items, snapshot)}
               readyLabel="Update Brews"
               readyVariant="outline"
               onAction={() => performHomebrewUpdateAllForItems(items)}
@@ -4011,6 +4011,16 @@ function combinedAvailableCount(derived: DerivedSections): number {
 
 function performHomebrewUpdateAllForItems(items: Pick<HomebrewManagedItem, "id">[]): void {
   void window.baseline.performHomebrewUpdateAll(items.map((item) => item.id));
+}
+
+function homebrewBatchActionState(
+  items: Pick<HomebrewManagedItem, "id">[],
+  snapshot: BaselineSnapshot
+): ActionState {
+  return items.length > 0 &&
+    items.every((item) => snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id))
+    ? { type: "done" }
+    : { type: "ready" };
 }
 
 function toggleCollapsedSection(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1181,7 +1181,6 @@ function AllUpdatesSection({
   snapshot: BaselineSnapshot;
   derived: DerivedSections;
 }) {
-  const homebrewCommandActive = isHomebrewCommandActive(snapshot);
   const items: RecentGridItem[] = [
     ...derived.availableApps.map((app) => ({
       type: "app" as const,
@@ -1204,18 +1203,9 @@ function AllUpdatesSection({
         action={
           derived.allHomebrewOutdated.length > 1 ? (
             <UpdateActionButton
-              state={
-                homebrewCommandActive
-                  ? { type: "updating" }
-                  : derived.allHomebrewOutdated.every((item) =>
-                        snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id)
-                      )
-                    ? { type: "done" }
-                    : { type: "ready" }
-              }
+              state={{ type: "ready" }}
               readyLabel="Update Brews"
               readyVariant="outline"
-              disabled={homebrewCommandActive}
               onAction={() => performHomebrewUpdateAllForItems(derived.allHomebrewOutdated)}
             />
           ) : undefined
@@ -2037,7 +2027,6 @@ export function HomebrewSection({
   cardLayout?: boolean;
 }) {
   const collapsed = collapsible && snapshot.collapsedHomebrewSectionIDs.includes(sectionID);
-  const homebrewCommandActive = isHomebrewCommandActive(snapshot);
   return (
     <section className="panel">
       <PanelTitle
@@ -2048,18 +2037,9 @@ export function HomebrewSection({
         action={
           showUpdateAll && items.length > 1 ? (
             <UpdateActionButton
-              state={
-                homebrewCommandActive
-                  ? { type: "updating" }
-                  : items.every((item) =>
-                        snapshot.homebrewUpdatedPendingRefreshItemIDs.includes(item.id)
-                      )
-                    ? { type: "done" }
-                    : { type: "ready" }
-              }
+              state={{ type: "ready" }}
               readyLabel="Update Brews"
               readyVariant="outline"
-              disabled={homebrewCommandActive}
               onAction={() => performHomebrewUpdateAllForItems(items)}
             />
           ) : undefined


### PR DESCRIPTION
## Summary
- Keeps the bulk `Update Brews` control rendered as a normal outline command button while Homebrew work is already active.
- Routes busy bulk-update clicks through the existing per-item Homebrew update queue so eligible visible items run after the active command finishes.
- Adds regression coverage for the busy bulk-click renderer state and queued batch execution path.

## Validation
- `npm test -- --run ElectronTests/updateStore.test.ts ElectronTests/rendererButtons.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`