### PR TITLE
Refresh app inventory after scan directory changes

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -298,6 +298,88 @@ describe("update store helpers", () => {
     });
   });
 
+  it("refreshes app inventory after adding an additional scan directory", async () => {
+    let userData = "";
+    const scanState: { directory: string; app?: AppRecord } = { directory: "" };
+    const scannedDirectories: string[][] = [];
+    const store = await makeStore({
+      onUserData: (directory) => {
+        userData = directory;
+      },
+      clients: {
+        scanner: {
+          scanApplications: async (directories) => {
+            scannedDirectories.push(directories);
+            return scanState.app && directories.includes(scanState.directory)
+              ? [scanState.app]
+              : [];
+          }
+        }
+      }
+    });
+    scanState.directory = path.resolve(path.join(userData, "Extra Apps"));
+    const addedApp = appRecord({
+      bundlePath: path.join(scanState.directory, "Example.app"),
+      displayName: "Example",
+      localVersion: version("1.0.0")
+    });
+    scanState.app = addedApp;
+
+    await store.addDirectory(scanState.directory);
+
+    await vi.waitFor(() => {
+      expect(scannedDirectories).toContainEqual([
+        "/Applications",
+        path.join(os.homedir(), "Applications"),
+        scanState.directory
+      ]);
+      expect(store.getSnapshot().apps).toEqual([addedApp]);
+    });
+  });
+
+  it("refreshes app inventory after removing an additional scan directory", async () => {
+    let userData = "";
+    const scanState: { directory: string; app?: AppRecord } = { directory: "" };
+    const scannedDirectories: string[][] = [];
+    const store = await makeStore({
+      onUserData: (directory) => {
+        userData = directory;
+      },
+      clients: {
+        scanner: {
+          scanApplications: async (directories) => {
+            scannedDirectories.push(directories);
+            return scanState.app && directories.includes(scanState.directory)
+              ? [scanState.app]
+              : [];
+          }
+        }
+      }
+    });
+    scanState.directory = path.resolve(path.join(userData, "Extra Apps"));
+    const removableApp = appRecord({
+      bundlePath: path.join(scanState.directory, "Example.app"),
+      displayName: "Example",
+      localVersion: version("1.0.0")
+    });
+    scanState.app = removableApp;
+
+    await store.addDirectory(scanState.directory);
+    await vi.waitFor(() => {
+      expect(store.getSnapshot().apps).toEqual([removableApp]);
+    });
+
+    await store.removeDirectory(scanState.directory);
+
+    await vi.waitFor(() => {
+      expect(scannedDirectories.at(-1)).toEqual([
+        "/Applications",
+        path.join(os.homedir(), "Applications")
+      ]);
+      expect(store.getSnapshot().apps).toEqual([]);
+    });
+  });
+
   it("persists the started using date through store saves", async () => {
     let userData = "";
     const startedUsingAt = "2026-06-01T12:00:00.000Z";

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -297,19 +297,30 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
 
   async addDirectory(directory: string): Promise<void> {
     const resolved = path.resolve(directory);
-    const directories = [...new Set([...this.state.additionalDirectories, resolved])];
+    if (
+      this.state.additionalDirectories.some((candidate) => path.resolve(candidate) === resolved)
+    ) {
+      return;
+    }
+    const directories = [...this.state.additionalDirectories, resolved];
     this.patch({ additionalDirectories: directories });
     await this.persist();
+    await this.refresh(false);
   }
 
   async removeDirectory(directory: string): Promise<void> {
     const resolved = path.resolve(directory);
+    const directories = this.state.additionalDirectories.filter(
+      (candidate) => path.resolve(candidate) !== resolved
+    );
+    if (directories.length === this.state.additionalDirectories.length) {
+      return;
+    }
     this.patch({
-      additionalDirectories: this.state.additionalDirectories.filter(
-        (candidate) => path.resolve(candidate) !== resolved
-      )
+      additionalDirectories: directories
     });
     await this.persist();
+    await this.refresh(false);
   }
 
   async openApp(appID: string): Promise<void> {


### PR DESCRIPTION
Fixes #158

## Summary
- Trigger a full inventory refresh after scan directories are added or removed so the saved directory list and visible app snapshot stay in sync.
- Skip no-op duplicate add/remove directory mutations so unchanged settings do not start unnecessary refreshes.
- Add store-level regression coverage for discovering apps from a newly added directory and clearing apps after that directory is removed.

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run format