### PR TITLE
Fix prerelease version ordering

### DIFF
--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -243,6 +243,23 @@ describe("ported clients", () => {
     </item>
   </channel>
 </rss>`);
+    const stableOlderBuildWithNewerBetaRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-beta.3.zip"
+        sparkle:version="103"
+        sparkle:shortVersionString="1.0.0-beta.3" />
+    </item>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0.zip"
+        sparkle:version="100"
+        sparkle:shortVersionString="1.0.0" />
+    </item>
+  </channel>
+</rss>`);
     const betaRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
   <channel>
@@ -272,6 +289,17 @@ describe("ported clients", () => {
         version("102")
       )
     ).toBeUndefined();
+    expect(
+      new SparkleAppcastClient().parseAppcast(
+        stableOlderBuildWithNewerBetaRelease,
+        version("1.0.0-beta.2"),
+        version("102")
+      )
+    ).toMatchObject({
+      remoteVersion: version("1.0.0-beta.3"),
+      remoteBuildVersion: version("103"),
+      updateURL: "https://example.com/download/1.0.0-beta.3.zip"
+    });
     expect(new SparkleAppcastClient().parseAppcast(betaRelease, version("1.0.0"))).toBeUndefined();
   });
 

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -56,6 +56,40 @@ describe("ported clients", () => {
     expect(result?.appStoreItemID).toBe(987654321);
   });
 
+  it("uses stable App Store releases as updates over matching local prerelease builds", () => {
+    const client = new AppStoreLookupClient();
+    const stableRelease = Buffer.from(
+      JSON.stringify({
+        results: [
+          {
+            kind: "mac-software",
+            trackId: 123,
+            version: "1.0.0",
+            trackViewUrl: "https://apps.apple.com/app/example/id123"
+          }
+        ]
+      })
+    );
+    const betaRelease = Buffer.from(
+      JSON.stringify({
+        results: [
+          {
+            kind: "mac-software",
+            trackId: 123,
+            version: "1.0.0-beta.2",
+            trackViewUrl: "https://apps.apple.com/app/example/id123"
+          }
+        ]
+      })
+    );
+
+    expect(client.parseLookupResponse(stableRelease, version("1.0.0-beta.2"))).toMatchObject({
+      remoteVersion: version("1.0.0"),
+      appStoreItemID: 123
+    });
+    expect(client.parseLookupResponse(betaRelease, version("1.0.0"))).toBeUndefined();
+  });
+
   it("rejects iOS App Store records when installed app evidence is not enabled", () => {
     const data = Buffer.from(
       JSON.stringify({
@@ -174,6 +208,45 @@ describe("ported clients", () => {
     ).toBeUndefined();
   });
 
+  it("uses stable Sparkle releases as updates over matching local prerelease builds", () => {
+    const stableRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-beta.2.zip"
+        sparkle:version="102"
+        sparkle:shortVersionString="1.0.0-beta.2" />
+    </item>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0.zip"
+        sparkle:version="100"
+        sparkle:shortVersionString="1.0.0" />
+    </item>
+  </channel>
+</rss>`);
+    const betaRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-beta.2.zip"
+        sparkle:version="102"
+        sparkle:shortVersionString="1.0.0-beta.2" />
+    </item>
+  </channel>
+</rss>`);
+
+    expect(
+      new SparkleAppcastClient().parseAppcast(stableRelease, version("1.0.0-beta.2"))
+    ).toMatchObject({
+      remoteVersion: version("1.0.0"),
+      updateURL: "https://example.com/download/1.0.0.zip"
+    });
+    expect(new SparkleAppcastClient().parseAppcast(betaRelease, version("1.0.0"))).toBeUndefined();
+  });
+
   it("parses Homebrew cask schema drift fixtures", () => {
     const data = readFileSync(path.join(fixtures, "homebrew_cask_drift.json"));
     const index = new HomebrewCaskClient().parseIndex(data);
@@ -261,6 +334,52 @@ describe("ported clients", () => {
     ).toBe("pkg-backed-app");
     expect(
       client.lookupUpdate("com.example.pkgbacked", "Helper.app", version("1.0.0"), index)
+    ).toBeUndefined();
+  });
+
+  it("uses stable Homebrew cask versions as updates over matching local prerelease builds", () => {
+    const client = new HomebrewCaskClient();
+    const stableIndex = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "prerelease-app",
+            version: "1.0.0",
+            bundleIdentifier: "com.example.prerelease"
+          }
+        ])
+      )
+    );
+    const betaIndex = client.parseIndex(
+      Buffer.from(
+        JSON.stringify([
+          {
+            token: "prerelease-app",
+            version: "1.0.0-beta.2",
+            bundleIdentifier: "com.example.prerelease"
+          }
+        ])
+      )
+    );
+
+    expect(
+      client.lookupUpdate(
+        "com.example.prerelease",
+        "Prerelease App.app",
+        version("1.0.0-beta.2"),
+        stableIndex
+      )
+    ).toMatchObject({
+      remoteVersion: version("1.0.0"),
+      token: "prerelease-app"
+    });
+    expect(
+      client.lookupUpdate(
+        "com.example.prerelease",
+        "Prerelease App.app",
+        version("1.0.0"),
+        betaIndex
+      )
     ).toBeUndefined();
   });
 

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -303,6 +303,50 @@ describe("ported clients", () => {
     expect(new SparkleAppcastClient().parseAppcast(betaRelease, version("1.0.0"))).toBeUndefined();
   });
 
+  it("requires newer Sparkle builds for matching-core prerelease promotions", () => {
+    const olderBuildRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-rc.1.zip"
+        sparkle:version="101"
+        sparkle:shortVersionString="1.0.0-rc.1" />
+    </item>
+  </channel>
+</rss>`);
+    const newerBuildRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-rc.1.zip"
+        sparkle:version="110"
+        sparkle:shortVersionString="1.0.0-rc.1" />
+    </item>
+  </channel>
+</rss>`);
+
+    expect(
+      new SparkleAppcastClient().parseAppcast(
+        olderBuildRelease,
+        version("1.0.0-beta.9"),
+        version("109")
+      )
+    ).toBeUndefined();
+    expect(
+      new SparkleAppcastClient().parseAppcast(
+        newerBuildRelease,
+        version("1.0.0-beta.9"),
+        version("109")
+      )
+    ).toMatchObject({
+      remoteVersion: version("1.0.0-rc.1"),
+      remoteBuildVersion: version("110"),
+      updateURL: "https://example.com/download/1.0.0-rc.1.zip"
+    });
+  });
+
   it("parses Homebrew cask schema drift fixtures", () => {
     const data = readFileSync(path.join(fixtures, "homebrew_cask_drift.json"));
     const index = new HomebrewCaskClient().parseIndex(data);

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -326,10 +326,27 @@ describe("ported clients", () => {
     </item>
   </channel>
 </rss>`);
+    const missingBuildRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-rc.1.zip"
+        sparkle:shortVersionString="1.0.0-rc.1" />
+    </item>
+  </channel>
+</rss>`);
 
     expect(
       new SparkleAppcastClient().parseAppcast(
         olderBuildRelease,
+        version("1.0.0-beta.9"),
+        version("109")
+      )
+    ).toBeUndefined();
+    expect(
+      new SparkleAppcastClient().parseAppcast(
+        missingBuildRelease,
         version("1.0.0-beta.9"),
         version("109")
       )

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -209,7 +209,7 @@ describe("ported clients", () => {
   });
 
   it("uses stable Sparkle releases as updates over matching local prerelease builds", () => {
-    const stableRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+    const stableOlderBuildRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
   <channel>
     <item>
@@ -222,6 +222,23 @@ describe("ported clients", () => {
       <enclosure
         url="https://example.com/download/1.0.0.zip"
         sparkle:version="100"
+        sparkle:shortVersionString="1.0.0" />
+    </item>
+  </channel>
+</rss>`);
+    const stableNewerBuildRelease = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0-beta.2.zip"
+        sparkle:version="102"
+        sparkle:shortVersionString="1.0.0-beta.2" />
+    </item>
+    <item>
+      <enclosure
+        url="https://example.com/download/1.0.0.zip"
+        sparkle:version="103"
         sparkle:shortVersionString="1.0.0" />
     </item>
   </channel>
@@ -239,11 +256,22 @@ describe("ported clients", () => {
 </rss>`);
 
     expect(
-      new SparkleAppcastClient().parseAppcast(stableRelease, version("1.0.0-beta.2"))
+      new SparkleAppcastClient().parseAppcast(
+        stableNewerBuildRelease,
+        version("1.0.0-beta.2"),
+        version("102")
+      )
     ).toMatchObject({
       remoteVersion: version("1.0.0"),
       updateURL: "https://example.com/download/1.0.0.zip"
     });
+    expect(
+      new SparkleAppcastClient().parseAppcast(
+        stableOlderBuildRelease,
+        version("1.0.0-beta.2"),
+        version("102")
+      )
+    ).toBeUndefined();
     expect(new SparkleAppcastClient().parseAppcast(betaRelease, version("1.0.0"))).toBeUndefined();
   });
 

--- a/ElectronTests/version.test.ts
+++ b/ElectronTests/version.test.ts
@@ -11,4 +11,13 @@ describe("version comparison", () => {
     expect(compareVersions(version("1.0"), version("1.0.0"))).toBe(0);
     expect(compareVersions(version(undefined), version(""))).toBe(0);
   });
+
+  it("orders prerelease suffixes before matching stable releases", () => {
+    expect(compareVersions(version("1.0.0"), version("1.0.0-beta.2"))).toBeGreaterThan(0);
+    expect(compareVersions(version("1.0.0-beta.2"), version("1.0.0"))).toBeLessThan(0);
+    expect(compareVersions(version("2.0"), version("2.0-rc.1"))).toBeGreaterThan(0);
+    expect(compareVersions(version("2.0-rc.1"), version("2.0"))).toBeLessThan(0);
+    expect(compareVersions(version("1.0.0-rc.1"), version("1.0.0-beta.9"))).toBeGreaterThan(0);
+    expect(compareVersions(version("1.0.0-beta.10"), version("1.0.0-beta.2"))).toBeGreaterThan(0);
+  });
 });

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -94,9 +94,10 @@ export class SparkleAppcastClient {
         parsedVersion: version(item.shortVersionString ?? item.buildVersion)
       }))
       .filter(({ parsedVersion }) => !isVersionEmpty(parsedVersion))
+      .filter((candidate) => isAppcastItemNewer(candidate, localVersion, localBuildVersion))
       .sort((lhs, rhs) => -1 * compareAppcastItems(lhs, rhs))[0];
 
-    if (!best || !isAppcastItemNewer(best, localVersion, localBuildVersion)) {
+    if (!best) {
       return undefined;
     }
 

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -136,7 +136,7 @@ function isAppcastItemNewer(
   const marketingVersionComparison = compareVersions(item.parsedVersion, localVersion);
   if (marketingVersionComparison > 0) {
     if (
-      isStableReleaseOverMatchingPrerelease(item.parsedVersion, localVersion) &&
+      isSameCorePrereleasePromotion(item.parsedVersion, localVersion) &&
       localBuildVersion &&
       !isVersionEmpty(localBuildVersion) &&
       !isVersionEmpty(item.buildVersion)
@@ -156,7 +156,7 @@ function isAppcastItemNewer(
   return isVersionGreater(item.buildVersion, localBuildVersion);
 }
 
-function isStableReleaseOverMatchingPrerelease(
+function isSameCorePrereleasePromotion(
   remoteVersion: VersionValue,
   localVersion: VersionValue
 ): boolean {
@@ -164,9 +164,11 @@ function isStableReleaseOverMatchingPrerelease(
   const localTokens = versionTokens(localVersion);
 
   return (
-    !prereleaseToken(remoteTokens) &&
-    prereleaseToken(localTokens) !== undefined &&
-    compareVersions(remoteVersion, releaseCoreVersion(localVersion, localTokens)) === 0
+    (prereleaseToken(remoteTokens) !== undefined || prereleaseToken(localTokens) !== undefined) &&
+    compareVersions(
+      releaseCoreVersion(remoteVersion, remoteTokens),
+      releaseCoreVersion(localVersion, localTokens)
+    ) === 0
   );
 }
 

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -27,6 +27,21 @@ const parser = new XMLParser({
   textNodeName: "#text"
 });
 
+const prereleaseLabels = new Set([
+  "dev",
+  "snapshot",
+  "nightly",
+  "canary",
+  "alpha",
+  "a",
+  "beta",
+  "b",
+  "pre",
+  "preview",
+  "rc",
+  "candidate"
+]);
+
 export class SparkleAppcastClient {
   async lookupOutcome(
     feedURL: string,
@@ -119,6 +134,14 @@ function isAppcastItemNewer(
 ): boolean {
   const marketingVersionComparison = compareVersions(item.parsedVersion, localVersion);
   if (marketingVersionComparison > 0) {
+    if (
+      isStableReleaseOverMatchingPrerelease(item.parsedVersion, localVersion) &&
+      localBuildVersion &&
+      !isVersionEmpty(localBuildVersion) &&
+      !isVersionEmpty(item.buildVersion)
+    ) {
+      return isVersionGreater(item.buildVersion, localBuildVersion);
+    }
     return true;
   }
   if (
@@ -130,6 +153,53 @@ function isAppcastItemNewer(
     return false;
   }
   return isVersionGreater(item.buildVersion, localBuildVersion);
+}
+
+function isStableReleaseOverMatchingPrerelease(
+  remoteVersion: VersionValue,
+  localVersion: VersionValue
+): boolean {
+  const remoteTokens = versionTokens(remoteVersion);
+  const localTokens = versionTokens(localVersion);
+
+  return (
+    !prereleaseToken(remoteTokens) &&
+    prereleaseToken(localTokens) !== undefined &&
+    compareVersions(remoteVersion, releaseCoreVersion(localVersion, localTokens)) === 0
+  );
+}
+
+type VersionToken = {
+  text: string;
+  index: number;
+  isNumeric: boolean;
+};
+
+function versionTokens(value: VersionValue): VersionToken[] {
+  return [
+    ...value.raw
+      .trim()
+      .toLowerCase()
+      .matchAll(/[a-z]+|\d+/giu)
+  ].map((match) => ({
+    text: match[0],
+    index: match.index ?? 0,
+    isNumeric: /^\d+$/u.test(match[0])
+  }));
+}
+
+function prereleaseToken(tokens: VersionToken[]): VersionToken | undefined {
+  return tokens.find((token, index) => {
+    if (token.isNumeric || !prereleaseLabels.has(token.text)) {
+      return false;
+    }
+    return tokens.slice(0, index).some((candidate) => candidate.isNumeric);
+  });
+}
+
+function releaseCoreVersion(value: VersionValue, tokens: VersionToken[]): VersionValue {
+  const marker = prereleaseToken(tokens);
+  return marker ? version(value.raw.slice(0, marker.index)) : value;
 }
 
 function normalizeItem(item: any): AppcastItem {

--- a/src/main/sparkleAppcastClient.ts
+++ b/src/main/sparkleAppcastClient.ts
@@ -138,10 +138,11 @@ function isAppcastItemNewer(
     if (
       isSameCorePrereleasePromotion(item.parsedVersion, localVersion) &&
       localBuildVersion &&
-      !isVersionEmpty(localBuildVersion) &&
-      !isVersionEmpty(item.buildVersion)
+      !isVersionEmpty(localBuildVersion)
     ) {
-      return isVersionGreater(item.buildVersion, localBuildVersion);
+      return (
+        !isVersionEmpty(item.buildVersion) && isVersionGreater(item.buildVersion, localBuildVersion)
+      );
     }
     return true;
   }

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -11,7 +11,30 @@ export function version(raw?: string | null): VersionValue {
   };
 }
 
-function components(value: VersionValue | string | null | undefined): number[] {
+type ParsedVersion = {
+  core: number[];
+  prerelease?: {
+    rank: number;
+    components: number[];
+  };
+};
+
+const prereleaseRanks: ReadonlyMap<string, number> = new Map([
+  ["dev", 0],
+  ["snapshot", 0],
+  ["nightly", 0],
+  ["canary", 0],
+  ["alpha", 1],
+  ["a", 1],
+  ["beta", 2],
+  ["b", 2],
+  ["pre", 3],
+  ["preview", 3],
+  ["rc", 4],
+  ["candidate", 4]
+] as const);
+
+function numericComponents(value: VersionValue | string | null | undefined): number[] {
   const raw = typeof value === "string" ? value : (value?.raw ?? "");
   const sanitized = raw.trim().replace(/[^0-9]+/g, ".");
   const parsed = sanitized
@@ -20,24 +43,90 @@ function components(value: VersionValue | string | null | undefined): number[] {
     .map((part) => Number.parseInt(part, 10))
     .filter((part) => Number.isFinite(part));
 
-  while (parsed.at(-1) === 0) {
-    parsed.pop();
-  }
-
-  return parsed;
+  return trimTrailingZeroes(parsed);
 }
 
-export function compareVersions(lhs: VersionValue | string, rhs: VersionValue | string): number {
-  const left = components(lhs);
-  const right = components(rhs);
-  const count = Math.max(left.length, right.length);
+function parseVersion(value: VersionValue | string | null | undefined): ParsedVersion {
+  const raw = typeof value === "string" ? value : (value?.raw ?? "");
+  const tokens = [
+    ...raw
+      .trim()
+      .toLowerCase()
+      .matchAll(/[a-z]+|\d+/giu)
+  ].map(([token]) => token);
+  const prereleaseIndex = tokens.findIndex((token, index) => {
+    if (!prereleaseRanks.has(token)) {
+      return false;
+    }
+    return tokens.slice(0, index).some((candidate) => /^\d+$/u.test(candidate));
+  });
+
+  if (prereleaseIndex < 0) {
+    return { core: numericComponents(value) };
+  }
+
+  return {
+    core: trimTrailingZeroes(
+      tokens
+        .slice(0, prereleaseIndex)
+        .filter((token) => /^\d+$/u.test(token))
+        .map((token) => Number.parseInt(token, 10))
+        .filter((part) => Number.isFinite(part))
+    ),
+    prerelease: {
+      rank: prereleaseRanks.get(tokens[prereleaseIndex] ?? "") ?? 0,
+      components: trimTrailingZeroes(
+        tokens
+          .slice(prereleaseIndex + 1)
+          .filter((token) => /^\d+$/u.test(token))
+          .map((token) => Number.parseInt(token, 10))
+          .filter((part) => Number.isFinite(part))
+      )
+    }
+  };
+}
+
+function trimTrailingZeroes(components: number[]): number[] {
+  const trimmed = [...components];
+  while (trimmed.at(-1) === 0) {
+    trimmed.pop();
+  }
+  return trimmed;
+}
+
+function compareComponents(lhs: number[], rhs: number[]): number {
+  const count = Math.max(lhs.length, rhs.length);
 
   for (let index = 0; index < count; index += 1) {
-    const leftValue = left[index] ?? 0;
-    const rightValue = right[index] ?? 0;
+    const leftValue = lhs[index] ?? 0;
+    const rightValue = rhs[index] ?? 0;
     if (leftValue !== rightValue) {
       return leftValue < rightValue ? -1 : 1;
     }
+  }
+
+  return 0;
+}
+
+export function compareVersions(lhs: VersionValue | string, rhs: VersionValue | string): number {
+  const left = parseVersion(lhs);
+  const right = parseVersion(rhs);
+  const coreComparison = compareComponents(left.core, right.core);
+  if (coreComparison !== 0) {
+    return coreComparison;
+  }
+
+  if (left.prerelease && !right.prerelease) {
+    return -1;
+  }
+  if (!left.prerelease && right.prerelease) {
+    return 1;
+  }
+  if (left.prerelease && right.prerelease) {
+    const rankComparison = left.prerelease.rank - right.prerelease.rank;
+    return (
+      rankComparison || compareComponents(left.prerelease.components, right.prerelease.components)
+    );
   }
 
   return 0;


### PR DESCRIPTION
## Summary
- Treat common prerelease suffixes such as alpha, beta, preview, and rc as lower precedence than the matching stable version while preserving numeric comparison and trailing-zero normalization.
- Keep App Store, Sparkle, and Homebrew cask update checks on the shared comparator so stable releases are surfaced over matching local prerelease builds and prerelease metadata is not offered over an installed stable build.
- Require Sparkle same-core prerelease promotions to prove a newer `sparkle:version` build when the local build is known, skipping candidates with missing or older build evidence while still allowing another eligible prerelease candidate to be selected.
- Add regression coverage for shared version comparison plus App Store, Sparkle, and Homebrew cask lookup behavior.

Fixes #160.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`
- `npm run build`