### PR TITLE
Allow current Homebrew formula index

### DIFF
--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -10,6 +10,7 @@ import { HomebrewFormulaClient } from "../src/main/homebrewFormulaClient";
 import { HomebrewInventoryParser } from "../src/main/homebrewInventoryClient";
 import { SelfUpdateClient } from "../src/main/selfUpdateClient";
 import { SparkleAppcastClient } from "../src/main/sparkleAppcastClient";
+import { byteLimits } from "../src/shared/security";
 import { version } from "../src/shared/version";
 
 const fixtures = path.join(process.cwd(), "ElectronTests", "Fixtures");
@@ -757,6 +758,40 @@ describe("ported clients", () => {
       )
     );
     expect(client.searchFormulae("rip", index, new Set()).at(0)?.token).toBe("ripgrep");
+  });
+
+  it("parses formula indexes above the cask index byte limit", () => {
+    const client = new HomebrewFormulaClient();
+    const payload = JSON.stringify([
+      {
+        name: "large-formula-index-entry",
+        versions: { stable: "1.2.3" },
+        homepage: "https://example.com/large-formula-index-entry",
+        desc: "x".repeat(byteLimits.homebrewCaskIndexMaxBytes)
+      }
+    ]);
+
+    expect(Buffer.byteLength(payload)).toBeGreaterThan(byteLimits.homebrewCaskIndexMaxBytes);
+
+    const index = client.parseIndex(Buffer.from(payload));
+
+    expect(index.byToken["large-formula-index-entry"]?.version.raw).toBe("1.2.3");
+    expect(client.searchFormulae("large formula", index, new Set()).at(0)?.token).toBe(
+      "large-formula-index-entry"
+    );
+  });
+
+  it("keeps cask indexes bounded by the cask byte limit", () => {
+    const client = new HomebrewCaskClient();
+    const payload = Buffer.alloc(byteLimits.homebrewCaskIndexMaxBytes + 1, " ");
+
+    const index = client.parseIndex(payload);
+
+    expect(index).toEqual({
+      byToken: {},
+      byBundleIdentifier: {},
+      byAppBundleName: {}
+    });
   });
 
   it("builds Homebrew inventory from installed and outdated output", () => {

--- a/src/main/homebrewCaskClient.ts
+++ b/src/main/homebrewCaskClient.ts
@@ -86,7 +86,7 @@ export class HomebrewCaskClient {
   }
 
   parseIndex(data: Buffer): HomebrewCaskIndex {
-    if (data.byteLength > byteLimits.homebrewIndexMaxBytes) {
+    if (data.byteLength > byteLimits.homebrewCaskIndexMaxBytes) {
       return emptyHomebrewCaskIndex;
     }
 

--- a/src/main/homebrewFormulaClient.ts
+++ b/src/main/homebrewFormulaClient.ts
@@ -26,7 +26,7 @@ export class HomebrewFormulaClient {
   }
 
   parseIndex(data: Buffer): HomebrewFormulaIndex {
-    if (data.byteLength > byteLimits.homebrewIndexMaxBytes) {
+    if (data.byteLength > byteLimits.homebrewFormulaIndexMaxBytes) {
       return emptyHomebrewFormulaIndex;
     }
     const raw = JSON.parse(data.toString("utf8")) as any[];

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -6,7 +6,8 @@ import { isIP } from "node:net";
 export const byteLimits = {
   appStoreLookupMaxBytes: 1 * 1024 * 1024,
   sparkleAppcastMaxBytes: 2 * 1024 * 1024,
-  homebrewIndexMaxBytes: 25 * 1024 * 1024
+  homebrewCaskIndexMaxBytes: 25 * 1024 * 1024,
+  homebrewFormulaIndexMaxBytes: 64 * 1024 * 1024
 };
 
 const homebrewTokenSegmentRegex = /^[a-z0-9][a-z0-9+._@-]{0,127}$/;


### PR DESCRIPTION
## Summary
- Splits Homebrew API byte limits so cask parsing keeps the existing 25 MiB bound while formula parsing has a larger bounded limit for the current public formula payload.
- Updates cask and formula clients to use their source-specific limits.
- Adds regression coverage for formula indexes above the cask cap and for cask indexes remaining bounded.

Fixes #168.

## Validation
- `npm test -- --run ElectronTests/clients.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`