### PR TITLE
Reject IPv6 link-local Sparkle feeds

### DIFF
--- a/ElectronTests/security.test.ts
+++ b/ElectronTests/security.test.ts
@@ -38,6 +38,12 @@ describe("security policy", () => {
     expect(isAllowedFeedURL("https://[::a00:4]/feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://[64:ff9b::127.0.0.1]/feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://[64:ff9b::7f00:1]/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://[fe80::1]/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://[fe90::1]/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://[fea0::1]/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://[febf::1]/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://[fc00::1]/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://[fdff::1]/feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://[2001:4860:4860::8888]/feed.xml")).toBe(true);
     expect(isAllowedFeedURL("https://[::ffff:0:808:808]/feed.xml")).toBe(true);
     expect(isAllowedFeedURL("https://updates.example.com/appcast.xml")).toBe(true);

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -119,26 +119,23 @@ function isDisallowedIPv4(host: string): boolean {
 
 function isDisallowedIPv6(host: string): boolean {
   const normalized = host.toLowerCase();
-  const embeddedIPv4 = embeddedIPv4Address(normalized);
+  const groups = ipv6Groups(normalized);
+  const embeddedIPv4 = groups ? embeddedIPv4Address(groups) : undefined;
   if (embeddedIPv4) {
     return isDisallowedIPv4(embeddedIPv4);
   }
+  const firstGroup = groups?.[0];
 
   return (
     normalized === "::" ||
     normalized === "::1" ||
-    normalized.startsWith("fe80:") ||
-    normalized.startsWith("fc") ||
-    normalized.startsWith("fd")
+    (firstGroup !== undefined &&
+      ((firstGroup >= 0xfe80 && firstGroup <= 0xfebf) ||
+        (firstGroup >= 0xfc00 && firstGroup <= 0xfdff)))
   );
 }
 
-function embeddedIPv4Address(host: string): string | undefined {
-  const groups = ipv6Groups(host);
-  if (!groups) {
-    return undefined;
-  }
-
+function embeddedIPv4Address(groups: number[]): string | undefined {
   const isIPv4Mapped = groups.slice(0, 5).every((group) => group === 0) && groups[5] === 0xffff;
   const isIPv4Translated =
     groups.slice(0, 4).every((group) => group === 0) && groups[4] === 0xffff && groups[5] === 0;


### PR DESCRIPTION
## Summary
- Parses IPv6 feed hosts into hextets before applying local-address policy.
- Rejects the full `fe80::/10` link-local range while preserving unique-local and embedded IPv4 protections.
- Adds regression coverage for `fe90::`, `fea0::`, and `febf::` Sparkle feed hosts alongside existing public IPv6 allow coverage.

Fixes #169.

## Validation
- `npm test -- --run ElectronTests/security.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`