### PR TITLE
Reject local mDNS Sparkle feed hosts

### DIFF
--- a/ElectronTests/security.test.ts
+++ b/ElectronTests/security.test.ts
@@ -21,7 +21,12 @@ describe("security policy", () => {
 
   it("rejects local and private feed hosts", () => {
     expect(isAllowedFeedURL("https://localhost/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://localhost./feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://updates.local/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://updates.local./feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://local/feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://127.0.0.1/feed.xml")).toBe(false);
+    expect(isAllowedFeedURL("https://127.0.0.1./feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://10.0.0.4/feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://192.168.1.10/feed.xml")).toBe(false);
     expect(isAllowedFeedURL("https://[::1]/feed.xml")).toBe(false);

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -40,8 +40,13 @@ export function isAllowedFeedURL(raw: string | URL): boolean {
     return false;
   }
 
-  const host = url.hostname.toLowerCase().replace(/^\[/u, "").replace(/\]$/u, "");
-  if (host === "localhost" || host.endsWith(".localhost")) {
+  const host = normalizedFeedHost(url.hostname);
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "local" ||
+    host.endsWith(".local")
+  ) {
     return false;
   }
 
@@ -99,6 +104,11 @@ function safeURL(raw: string): URL | undefined {
   } catch {
     return undefined;
   }
+}
+
+function normalizedFeedHost(hostname: string): string {
+  const host = hostname.toLowerCase().replace(/^\[/u, "").replace(/\]$/u, "");
+  return host.endsWith(".") ? host.slice(0, -1) : host;
 }
 
 function isDisallowedIPv4(host: string): boolean {


### PR DESCRIPTION
## Summary
- Reject `local` and `.local` Sparkle feed hostnames in the shared feed URL policy.
- Normalize a trailing root dot before feed host policy checks so local host variants cannot bypass the guard.

Fixes #172

## Validation
- `npm test -- --run ElectronTests/security.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`