### PR TITLE
Handle Homebrew outdated JSON shape drift

### DIFF
--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -819,6 +819,36 @@ describe("ported clients", () => {
     expect(result.items.find((item) => item.token === "ripgrep")?.isOutdated).toBe(false);
   });
 
+  it("flags non-array Homebrew formula outdated sections without dropping cask metadata", () => {
+    const result = new HomebrewInventoryParser().buildInventoryWithStatus(
+      "ripgrep 14.0.0\n",
+      "notion 4.0.0\n",
+      JSON.stringify({ formulae: { name: "ripgrep", current_version: "14.1.0" } }),
+      JSON.stringify({ casks: [{ token: "notion", current_version: "4.1.0" }] })
+    );
+
+    expect(result.outdatedDetectionSucceeded).toBe(false);
+    expect(result.outdatedDetectionSucceededByKind).toEqual({ formula: false, cask: true });
+    expect(result.warning).toBe("Homebrew outdated status could not be read reliably.");
+    expect(result.items.find((item) => item.token === "ripgrep")?.isOutdated).toBe(false);
+    expect(result.items.find((item) => item.token === "notion")?.isOutdated).toBe(true);
+  });
+
+  it("flags non-array Homebrew cask outdated sections without dropping formula metadata", () => {
+    const result = new HomebrewInventoryParser().buildInventoryWithStatus(
+      "ripgrep 14.0.0\n",
+      "notion 4.0.0\n",
+      JSON.stringify({ formulae: [{ name: "ripgrep", current_version: "14.1.0" }] }),
+      JSON.stringify({ casks: { token: "notion", current_version: "4.1.0" } })
+    );
+
+    expect(result.outdatedDetectionSucceeded).toBe(false);
+    expect(result.outdatedDetectionSucceededByKind).toEqual({ formula: true, cask: false });
+    expect(result.warning).toBe("Homebrew outdated status could not be read reliably.");
+    expect(result.items.find((item) => item.token === "ripgrep")?.isOutdated).toBe(true);
+    expect(result.items.find((item) => item.token === "notion")?.isOutdated).toBe(false);
+  });
+
   it("uses the highest comparable installed Homebrew version", () => {
     const inventory = new HomebrewInventoryParser().buildInventory(
       "ripgrep 14.0.2 14.1.0 13.9.0\n",

--- a/src/main/homebrewInventoryClient.ts
+++ b/src/main/homebrewInventoryClient.ts
@@ -90,8 +90,8 @@ export class HomebrewInventoryParser {
   ): HomebrewInventoryResult {
     const formulaInstalled = this.parseInstalledVersions(formulaVersionsOutput);
     const caskInstalled = this.parseInstalledVersions(caskVersionsOutput, "cask");
-    const formulaOutdated = this.parseOutdatedMetadata(formulaOutdatedJSON);
-    const caskOutdated = this.parseOutdatedMetadata(caskOutdatedJSON);
+    const formulaOutdated = this.parseOutdatedMetadata(formulaOutdatedJSON, "formula");
+    const caskOutdated = this.parseOutdatedMetadata(caskOutdatedJSON, "cask");
     const items = this.buildItems(
       formulaInstalled,
       caskInstalled,
@@ -194,7 +194,10 @@ export class HomebrewInventoryParser {
     return result;
   }
 
-  private parseOutdatedMetadata(raw: string): {
+  private parseOutdatedMetadata(
+    raw: string,
+    kindValue: HomebrewManagedItemKind
+  ): {
     metadata: Map<string, OutdatedMetadata>;
     valid: boolean;
   } {
@@ -209,8 +212,12 @@ export class HomebrewInventoryParser {
       return { metadata: result, valid: false };
     }
 
-    this.populateOutdatedMetadata(result, parsed?.formulae ?? [], "formula");
-    this.populateOutdatedMetadata(result, parsed?.casks ?? [], "cask");
+    const items = parsed?.[outdatedMetadataKey(kindValue)] ?? [];
+    if (!Array.isArray(items)) {
+      return { metadata: result, valid: false };
+    }
+
+    this.populateOutdatedMetadata(result, items, kindValue);
     return { metadata: result, valid: true };
   }
 
@@ -234,6 +241,10 @@ export class HomebrewInventoryParser {
 
 function key(kindValue: HomebrewManagedItemKind, token: string): string {
   return `${kindValue}:${token.toLowerCase()}`;
+}
+
+function outdatedMetadataKey(kindValue: HomebrewManagedItemKind): "formulae" | "casks" {
+  return kindValue === "formula" ? "formulae" : "casks";
 }
 
 function currentVersion(item: any, kindValue: HomebrewManagedItemKind): string {


### PR DESCRIPTION
## Summary
- Validate the expected `formulae` or `casks` section shape before parsing Homebrew outdated metadata.
- Treat non-array outdated sections as unreliable for that Homebrew kind without throwing or dropping valid metadata from the other kind.

Fixes #173

## Validation
- `npm test -- --run ElectronTests/clients.test.ts ElectronTests/homebrewInventoryClient.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`