### PR TITLE
Gate App Store software fallback to Safari extensions

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -386,6 +386,66 @@ describe("bundle scanner", () => {
     });
   });
 
+  it("marks native Safari web extension apps", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    const appPath = path.join(root, "Content Blocker.app");
+    await writeAppPlist(appPath, {
+      displayName: "Content Blocker",
+      bundleIdentifier: "com.example.content-blocker",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>CFBundleSupportedPlatforms</key>",
+        "  <array>",
+        "    <string>MacOSX</string>",
+        "  </array>",
+        "  <key>LSMinimumSystemVersion</key>",
+        "  <string>13.5</string>"
+      ].join("\n")
+    });
+    await writeExtensionPlist(
+      path.join(appPath, "Contents", "PlugIns", "Content Blocker Extension.appex"),
+      "com.apple.Safari.web-extension"
+    );
+    await mkdir(path.join(appPath, "Contents", "_MASReceipt"), { recursive: true });
+    await writeFile(path.join(appPath, "Contents", "_MASReceipt", "receipt"), "receipt");
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundlePath: appPath,
+      bundleIdentifier: "com.example.content-blocker",
+      sourceHint: "appStore",
+      isIOSAppOnMac: false,
+      hasAppStoreEvidence: true,
+      hasSafariWebExtension: true
+    });
+  });
+
+  it("does not mark other app extensions as Safari web extension apps", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    const appPath = path.join(root, "Native Service App.app");
+    await writeAppPlist(appPath, {
+      displayName: "Native Service App",
+      bundleIdentifier: "com.example.native-service",
+      version: "1.0.0"
+    });
+    await writeExtensionPlist(
+      path.join(appPath, "Contents", "PlugIns", "Service Extension.appex"),
+      "com.example.native-service-extension"
+    );
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundleIdentifier: "com.example.native-service",
+      hasSafariWebExtension: false
+    });
+  });
+
   it("scans App Store wrapper bundles for iOS-on-Mac apps", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
     tempDirs.push(root);
@@ -635,4 +695,28 @@ async function writeWrappedIOSAppPlist(
 `
     );
   }
+}
+
+async function writeExtensionPlist(
+  appExtensionPath: string,
+  extensionPoint: string
+): Promise<void> {
+  await mkdir(path.join(appExtensionPath, "Contents"), { recursive: true });
+  await writeFile(
+    path.join(appExtensionPath, "Contents", "Info.plist"),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.extension</string>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>${extensionPoint}</string>
+  </dict>
+</dict>
+</plist>
+`
+  );
 }

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -215,6 +215,30 @@ describe("ported clients", () => {
     }
   });
 
+  it("keeps Mac App Store lookup requests filtered when Mac-capable software fallback is enabled", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ resultCount: 0, results: [] }), { status: 200 })
+      );
+
+    try {
+      await new AppStoreLookupClient().lookupOutcome(
+        "com.example.safari-extension",
+        version("1.0"),
+        {
+          includeMacCapableAppStoreSoftware: true
+        }
+      );
+
+      const requestedURL = new URL(fetchMock.mock.calls[0]?.[0] as string);
+      expect(requestedURL.searchParams.get("bundleId")).toBe("com.example.safari-extension");
+      expect(requestedURL.searchParams.get("entity")).toBe("macSoftware");
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("omits the entity filter when iOS App Store software lookup is enabled", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/ElectronTests/clients.test.ts
+++ b/ElectronTests/clients.test.ts
@@ -109,6 +109,61 @@ describe("ported clients", () => {
     expect(new AppStoreLookupClient().parseLookupResponse(data, version("1.0"))).toBeUndefined();
   });
 
+  it("accepts Mac-capable App Store software records only when fallback is enabled", () => {
+    const data = Buffer.from(
+      JSON.stringify({
+        resultCount: 1,
+        results: [
+          {
+            kind: "software",
+            bundleId: "com.example.mac-capable",
+            supportedDevices: ["MacDesktop-MacDesktop", "iPhone15-iPhone15"],
+            trackId: 123,
+            version: "2.0",
+            trackViewUrl: "https://apps.apple.com/app/example/id123"
+          }
+        ]
+      })
+    );
+
+    expect(
+      new AppStoreLookupClient().parseLookupResponse(data, version("1.0"), {
+        bundleIdentifier: "com.example.mac-capable"
+      })
+    ).toBeUndefined();
+
+    const result = new AppStoreLookupClient().parseLookupResponse(data, version("1.0"), {
+      bundleIdentifier: "com.example.mac-capable",
+      includeMacCapableAppStoreSoftware: true
+    });
+
+    expect(result?.remoteVersion.raw).toBe("2.0");
+    expect(result?.appStoreItemID).toBe(123);
+  });
+
+  it("rejects iOS-only App Store software records on Mac lookup paths", () => {
+    const data = Buffer.from(
+      JSON.stringify({
+        resultCount: 1,
+        results: [
+          {
+            kind: "software",
+            bundleId: "com.example.ios-only",
+            supportedDevices: ["iPhone15-iPhone15", "iPadAir11M3-iPadAir11M3"],
+            trackId: 123,
+            version: "2.0"
+          }
+        ]
+      })
+    );
+
+    expect(
+      new AppStoreLookupClient().parseLookupResponse(data, version("1.0"), {
+        bundleIdentifier: "com.example.ios-only"
+      })
+    ).toBeUndefined();
+  });
+
   it("prefers matching iOS App Store records for installed iOS-on-Mac apps", () => {
     const data = Buffer.from(
       JSON.stringify({

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1041,11 +1041,24 @@ describe("update store helpers", () => {
       sourceHint: "appStore",
       localVersion: version("1.0.0")
     });
+    const safariExtensionApp = appRecord({
+      bundlePath: "/Applications/Safari Extension App.app",
+      displayName: "Safari Extension App",
+      bundleIdentifier: "com.example.safari-extension-app",
+      sourceHint: "appStore",
+      localVersion: version("1.0.0"),
+      hasSafariWebExtension: true
+    });
     const lookupOutcome = vi.fn(async () => ({ type: "completed" as const }));
     const store = await makeStore({
       clients: {
         scanner: {
-          scanApplications: async () => [iOSAppOnMac, sideloadedIOSAppOnMac, nativeMacApp]
+          scanApplications: async () => [
+            iOSAppOnMac,
+            sideloadedIOSAppOnMac,
+            nativeMacApp,
+            safariExtensionApp
+          ]
         },
         appStore: { lookupOutcome }
       }
@@ -1057,19 +1070,25 @@ describe("update store helpers", () => {
       1,
       iOSAppOnMac.bundleIdentifier,
       iOSAppOnMac.localVersion,
-      { includeIOSAppStoreSoftware: true }
+      { includeIOSAppStoreSoftware: true, includeMacCapableAppStoreSoftware: false }
     );
     expect(lookupOutcome).toHaveBeenNthCalledWith(
       2,
       sideloadedIOSAppOnMac.bundleIdentifier,
       sideloadedIOSAppOnMac.localVersion,
-      { includeIOSAppStoreSoftware: false }
+      { includeIOSAppStoreSoftware: false, includeMacCapableAppStoreSoftware: false }
     );
     expect(lookupOutcome).toHaveBeenNthCalledWith(
       3,
       nativeMacApp.bundleIdentifier,
       nativeMacApp.localVersion,
-      { includeIOSAppStoreSoftware: false }
+      { includeIOSAppStoreSoftware: false, includeMacCapableAppStoreSoftware: false }
+    );
+    expect(lookupOutcome).toHaveBeenNthCalledWith(
+      4,
+      safariExtensionApp.bundleIdentifier,
+      safariExtensionApp.localVersion,
+      { includeIOSAppStoreSoftware: false, includeMacCapableAppStoreSoftware: true }
     );
   });
 

--- a/src/main/appStoreLookupClient.ts
+++ b/src/main/appStoreLookupClient.ts
@@ -13,12 +13,14 @@ type LookupEntry = {
   trackId?: number;
   releaseNotes?: string;
   currentVersionReleaseDate?: string;
+  supportedDevices?: string[];
 };
 
 export type LookupOutcome<T> = { type: "completed"; value?: T } | { type: "transientFailure" };
 
 type LookupOptions = {
   includeIOSAppStoreSoftware?: boolean;
+  includeMacCapableAppStoreSoftware?: boolean;
 };
 
 export class AppStoreLookupClient {
@@ -66,6 +68,9 @@ export class AppStoreLookupClient {
         ? results.find((entry) => isIOSAppStoreSoftware(entry, options.bundleIdentifier))
         : undefined) ??
       results.find((entry) => entry.kind === "mac-software") ??
+      (options.includeMacCapableAppStoreSoftware
+        ? results.find((entry) => isMacCapableAppStoreSoftware(entry, options.bundleIdentifier))
+        : undefined) ??
       (results.length === 1 && !results[0]?.kind ? results[0] : undefined);
     if (!selected) {
       return undefined;
@@ -89,5 +94,16 @@ export class AppStoreLookupClient {
 function isIOSAppStoreSoftware(entry: LookupEntry, bundleIdentifier: string | undefined): boolean {
   return (
     entry.kind === "software" && entry.bundleId?.toLowerCase() === bundleIdentifier?.toLowerCase()
+  );
+}
+
+function isMacCapableAppStoreSoftware(
+  entry: LookupEntry,
+  bundleIdentifier: string | undefined
+): boolean {
+  return (
+    entry.kind === "software" &&
+    entry.bundleId?.toLowerCase() === bundleIdentifier?.toLowerCase() &&
+    entry.supportedDevices?.some((device) => device.startsWith("MacDesktop-")) === true
   );
 }

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -18,6 +18,7 @@ type AppBundleInfo = {
   info: InfoPlist;
   isIOSAppOnMac: boolean;
   hasAppStoreEvidence: boolean;
+  hasSafariWebExtension: boolean;
   iconResourcesPath: string;
 };
 type IconLoadResult = { dataURL?: string };
@@ -96,7 +97,8 @@ export class BundleScannerClient {
     if (!bundleInfo) {
       return undefined;
     }
-    const { info, isIOSAppOnMac, hasAppStoreEvidence, iconResourcesPath } = bundleInfo;
+    const { info, isIOSAppOnMac, hasAppStoreEvidence, hasSafariWebExtension, iconResourcesPath } =
+      bundleInfo;
     if (isWebAppBundle(info)) {
       return undefined;
     }
@@ -128,6 +130,7 @@ export class BundleScannerClient {
       sourceHint,
       isIOSAppOnMac,
       hasAppStoreEvidence: hasMasReceipt || hasAppStoreEvidence,
+      hasSafariWebExtension,
       sparkleFeedURL,
       iconDataURL: await this.appIconDataURL(appPath, iconResourcesPath, info)
     };
@@ -142,6 +145,7 @@ export class BundleScannerClient {
         isIOSAppOnMac:
           isIOSAppOnMacInfo(info) || (hasAppStoreEvidence && isUIKitMacAppStoreInfo(info)),
         hasAppStoreEvidence,
+        hasSafariWebExtension: await this.hasSafariWebExtension(appPath),
         iconResourcesPath: path.join(appPath, "Contents", "Resources")
       };
     }
@@ -166,6 +170,7 @@ export class BundleScannerClient {
             info,
             isIOSAppOnMac: true,
             hasAppStoreEvidence: await this.hasWrappedAppStoreEvidence(appPath, entry.name, info),
+            hasSafariWebExtension: false,
             iconResourcesPath: path.join(wrapperPath, entry.name)
           };
         }
@@ -184,6 +189,30 @@ export class BundleScannerClient {
     } catch {
       return false;
     }
+  }
+
+  private async hasSafariWebExtension(appPath: string): Promise<boolean> {
+    const pluginsPath = path.join(appPath, "Contents", "PlugIns");
+    try {
+      const entries = await readdir(pluginsPath, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory() || !entry.name.endsWith(".appex")) {
+          continue;
+        }
+        const info = await readInfoPlistAtPath(
+          path.join(pluginsPath, entry.name, "Contents", "Info.plist")
+        );
+        if (
+          stringValue(recordValue(info?.NSExtension)?.NSExtensionPointIdentifier) ===
+          "com.apple.Safari.web-extension"
+        ) {
+          return true;
+        }
+      }
+    } catch {
+      return false;
+    }
+    return false;
   }
 
   private async hasWrappedAppStoreEvidence(

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1056,7 +1056,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
             appRecord.localVersion,
             {
               includeIOSAppStoreSoftware:
-                appRecord.isIOSAppOnMac === true && appRecord.hasAppStoreEvidence === true
+                appRecord.isIOSAppOnMac === true && appRecord.hasAppStoreEvidence === true,
+              includeMacCapableAppStoreSoftware:
+                appRecord.isIOSAppOnMac !== true && appRecord.hasSafariWebExtension === true
             }
           );
           if (outcome.type === "completed" && outcome.value) {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -20,6 +20,7 @@ export type AppRecord = {
   sourceHint: UpdateSource;
   isIOSAppOnMac?: boolean;
   hasAppStoreEvidence?: boolean;
+  hasSafariWebExtension?: boolean;
   sparkleFeedURL?: string;
   iconDataURL?: string;
 };


### PR DESCRIPTION
## Summary
- Detect native Safari web extension apps during bundle scanning.
- Keep App Store `software` records as an opt-in fallback for Safari extension apps whose Mac lookup response is not labeled `mac-software`.
- Prevent ordinary native Mac App Store apps from using iOS-style `software` versions when the Mac App Store does not offer the update.

## Validation
- `npm test -- --run ElectronTests/clients.test.ts ElectronTests/bundleScanner.test.ts ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format -- --check`