### PR TITLE
Add Profile privacy indicators

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1078,6 +1078,7 @@ describe("renderer button parity", () => {
     expect(screen.getByText("5 updates via Sparkle")).toBeInTheDocument();
     expect(screen.getByText("50%")).toBeInTheDocument();
     expect(screen.queryByText("Sparkle 45%")).not.toBeInTheDocument();
+    expect(screen.getAllByLabelText("Sparkle: 5 updates (50%)").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     expect(document.querySelector(".profile-start-panel-box")?.hasAttribute("title")).toBe(false);
     const sourceSegment = document.querySelector(".profile-source-segment") as HTMLElement;

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1025,6 +1025,24 @@ describe("renderer button parity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Profile" }));
 
     expect(screen.getAllByRole("heading", { name: "Profile" })).toHaveLength(1);
+    const profileIndicators = document.querySelector(".profile-topbar-indicators") as HTMLElement;
+    expect(profileIndicators).not.toBeNull();
+    expect(within(profileIndicators).getByText("Private")).toBeInTheDocument();
+    expect(
+      within(profileIndicators).getByLabelText(
+        "Private profile. Your profile is only visible to you and stays private on this Mac."
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(profileIndicators).getByText(
+        "Your profile is only visible to you and stays private on this Mac."
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(profileIndicators).getByText(
+        "Only updates and installs completed with Baseline are counted."
+      )
+    ).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Time with Baseline" })).not.toBeInTheDocument();
     expect(screen.getByText("with Baseline")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Stats" })).toBeInTheDocument();
@@ -1094,10 +1112,12 @@ describe("renderer button parity", () => {
     expect(screen.getByText("1 update · Formula")).toBeInTheDocument();
     expect([...topToolTiles].some((tile) => tile.textContent?.includes("Orion"))).toBe(false);
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Only updates and installs completed with Baseline are counted. Stats stay private on this Mac."
       )
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(document.querySelector(".profile-footer-panel")).toBeNull();
+    expect(document.querySelector(".profile-footer-row")).toBeNull();
     expect(screen.queryByText("Private stats")).not.toBeInTheDocument();
     expect(screen.queryByText("Verified")).not.toBeInTheDocument();
     expect(screen.queryByText("Stats were reset")).not.toBeInTheDocument();

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1059,7 +1059,8 @@ describe("renderer button parity", () => {
     ).toEqual(["10", "4", "1", "Sparkle"]);
     expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
     expect(screen.getByText("Favorite source")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Source mix" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Source mix" })).not.toBeInTheDocument();
+    expect(document.querySelector(".profile-source-section")).not.toBeNull();
     expect(screen.getByRole("heading", { name: "Most updated apps" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Most updated tools" })).toBeInTheDocument();
     expect(

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1072,7 +1072,7 @@ describe("renderer button parity", () => {
     expect(
       screen.queryByText("Tools you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Sparkle 5 events")).toBeInTheDocument();
+    expect(screen.getByText("5 updates via Sparkle")).toBeInTheDocument();
     expect(screen.getByText("45%")).toBeInTheDocument();
     expect(screen.queryByText("Sparkle 45%")).not.toBeInTheDocument();
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1067,13 +1067,16 @@ describe("renderer button parity", () => {
       screen.queryByText("Update or install something with Baseline to build a source history.")
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByText("Update something with Baseline to build a source history.")
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByText("Apps you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Tools you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
     expect(screen.getByText("5 updates via Sparkle")).toBeInTheDocument();
-    expect(screen.getByText("45%")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
     expect(screen.queryByText("Sparkle 45%")).not.toBeInTheDocument();
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     expect(document.querySelector(".profile-start-panel-box")?.hasAttribute("title")).toBe(false);
@@ -1145,7 +1148,7 @@ describe("renderer button parity", () => {
 
     expect(screen.getByText("No history")).toBeInTheDocument();
     expect(
-      screen.getByText("Update or install something with Baseline to build a source history.")
+      screen.getByText("Update something with Baseline to build a source history.")
     ).toBeInTheDocument();
     expect(screen.getByText("Apps you update with Baseline will appear here.")).toBeInTheDocument();
     expect(

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1072,7 +1072,9 @@ describe("renderer button parity", () => {
     expect(
       screen.queryByText("Tools you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
-    expect(screen.getAllByText("Sparkle 45%")).toHaveLength(1);
+    expect(screen.getByText("Sparkle 5 events")).toBeInTheDocument();
+    expect(screen.getByText("45%")).toBeInTheDocument();
+    expect(screen.queryByText("Sparkle 45%")).not.toBeInTheDocument();
     expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
     expect(document.querySelector(".profile-start-panel-box")?.hasAttribute("title")).toBe(false);
     const sourceSegment = document.querySelector(".profile-source-segment") as HTMLElement;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3290,7 +3290,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                       style={{ flexGrow: source.count }}
                     >
                       <span className="profile-source-tooltip" aria-hidden="true">
-                        {profileSourcePercentLabel(source, sourceMixTotal)}
+                        {profileSourceCountLabel(source)}
                       </span>
                     </span>
                   ))}
@@ -3307,7 +3307,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                         aria-hidden="true"
                       />
                       <span>{source.label}</span>
-                      <strong>{source.count}</strong>
+                      <strong>{profileSourcePercentLabel(source, sourceMixTotal)}</strong>
                     </div>
                   ))}
                 </div>
@@ -3782,9 +3782,13 @@ function profileSourcePercentLabel(
   total: number
 ): string {
   if (total <= 0) {
-    return `${source.label} 0%`;
+    return "0%";
   }
-  return `${source.label} ${Math.round((source.count / total) * 100)}%`;
+  return `${Math.round((source.count / total) * 100)}%`;
+}
+
+function profileSourceCountLabel(source: ProfileSummary["sourceMix"][number]): string {
+  return `${source.label} ${source.count} event${source.count === 1 ? "" : "s"}`;
 }
 
 function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sourceMix"] {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3273,7 +3273,6 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           </div>
         </section>
         <section className="panel settings-panel profile-source-section">
-          <PanelTitle title="Source mix" />
           <div className="settings-panel-box profile-source-panel-box">
             {activeSourceMix.length > 0 ? (
               <div className="profile-source-list">

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -20,7 +20,7 @@ import {
   FolderPlus,
   Info,
   Link2,
-  Lock,
+  LockKeyhole,
   Monitor,
   MoreHorizontal,
   Moon,
@@ -2990,7 +2990,7 @@ function ProfileTopbarIndicators() {
         tabIndex={0}
         aria-label="Private profile. Your profile is only visible to you and stays private on this Mac."
       >
-        <Lock size={13} strokeWidth={toolbarIconStrokeWidth} />
+        <LockKeyhole size={13} strokeWidth={toolbarIconStrokeWidth} />
         <span className="profile-topbar-indicator-label">Private</span>
         <span className="profile-topbar-tooltip" role="tooltip">
           Your profile is only visible to you and stays private on this Mac.

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3770,10 +3770,10 @@ function profileSourceShareLabel(
   total: number
 ): string {
   if (total <= 0) {
-    return `${source.label}: no recorded events`;
+    return `${source.label}: no recorded updates`;
   }
   const percent = Math.round((source.count / total) * 100);
-  return `${source.label}: ${source.count} event${source.count === 1 ? "" : "s"} (${percent}%)`;
+  return `${source.label}: ${source.count} update${source.count === 1 ? "" : "s"} (${percent}%)`;
 }
 
 function profileSourcePercentLabel(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3788,7 +3788,7 @@ function profileSourcePercentLabel(
 }
 
 function profileSourceCountLabel(source: ProfileSummary["sourceMix"][number]): string {
-  return `${source.label} ${source.count} event${source.count === 1 ? "" : "s"}`;
+  return `${source.count} update${source.count === 1 ? "" : "s"} via ${source.label}`;
 }
 
 function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sourceMix"] {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3314,7 +3314,7 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
               </div>
             ) : (
               <p className="profile-empty-state">
-                Update or install something with Baseline to build a source history.
+                Update something with Baseline to build a source history.
               </p>
             )}
           </div>
@@ -3729,7 +3729,8 @@ type ProfileSummary = {
 
 function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   const events = snapshot.profileStats.events;
-  const sourceMix = buildProfileSourceMix(events);
+  const updateEvents = events.filter(isProfileUpdateEvent);
+  const sourceMix = buildProfileSourceMix(updateEvents);
   const favorite = sourceMix.reduce((best, item) => (item.count > best.count ? item : best));
   const topApps = buildTopUpdatedApps(events, snapshot.apps);
   const topHomebrewItems = buildTopUpdatedHomebrewItems(
@@ -3738,9 +3739,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
     snapshot.apps,
     snapshot.updates
   );
-  const totalUpdates = events.filter(
-    (event) => event.type === "appUpdate" || event.type === "homebrewUpdate"
-  ).length;
+  const totalUpdates = updateEvents.length;
   const differentApps = new Set(
     events.filter((event) => event.type === "appUpdate").map((event) => event.targetID)
   ).size;
@@ -3789,6 +3788,10 @@ function profileSourcePercentLabel(
 
 function profileSourceCountLabel(source: ProfileSummary["sourceMix"][number]): string {
   return `${source.count} update${source.count === 1 ? "" : "s"} via ${source.label}`;
+}
+
+function isProfileUpdateEvent(event: ProfileStatsEvent): boolean {
+  return event.type === "appUpdate" || event.type === "homebrewUpdate";
 }
 
 function buildProfileSourceMix(events: ProfileStatsEvent[]): ProfileSummary["sourceMix"] {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -18,7 +18,9 @@ import {
   Eye,
   EyeOff,
   FolderPlus,
+  Info,
   Link2,
+  Lock,
   Monitor,
   MoreHorizontal,
   Moon,
@@ -2958,9 +2960,10 @@ export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
       <SettingsSidebar selectedSection={selectedSection} onSelectSection={setSelectedSection} />
       <section className="workspace">
         <header className="topbar">
-          <div>
+          <div className="topbar-title">
             <h1>{selectedItem?.label ?? "Settings"}</h1>
           </div>
+          {selectedSection === "profile" && <ProfileTopbarIndicators />}
         </header>
 
         <section className="content settings-content">
@@ -2976,6 +2979,34 @@ export function SettingsView({ snapshot }: { snapshot: BaselineSnapshot }) {
         </section>
       </section>
     </main>
+  );
+}
+
+function ProfileTopbarIndicators() {
+  return (
+    <div className="topbar-actions profile-topbar-indicators" aria-label="Profile privacy details">
+      <span
+        className="toolbar-button refresh-button profile-topbar-indicator private"
+        tabIndex={0}
+        aria-label="Private profile. Your profile is only visible to you and stays private on this Mac."
+      >
+        <Lock size={13} strokeWidth={toolbarIconStrokeWidth} />
+        <span className="profile-topbar-indicator-label">Private</span>
+        <span className="profile-topbar-tooltip" role="tooltip">
+          Your profile is only visible to you and stays private on this Mac.
+        </span>
+      </span>
+      <span
+        className="toolbar-button refresh-button profile-topbar-indicator icon-only"
+        tabIndex={0}
+        aria-label="Only updates and installs completed with Baseline are counted."
+      >
+        <Info size={15} strokeWidth={toolbarIconStrokeWidth} />
+        <span className="profile-topbar-tooltip" role="tooltip">
+          Only updates and installs completed with Baseline are counted.
+        </span>
+      </span>
+    </div>
   );
 }
 
@@ -3351,9 +3382,9 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
           </div>
         </section>
       </div>
-      <section className="panel settings-panel profile-footer-panel">
-        <div className="settings-panel-box">
-          {shouldShowResetWarning && (
+      {shouldShowResetWarning && (
+        <section className="panel settings-panel profile-footer-panel">
+          <div className="settings-panel-box">
             <div className="settings-row settings-row-action profile-warning-row">
               <SettingsRowText
                 label="Stats were reset"
@@ -3368,15 +3399,9 @@ function ProfileSection({ snapshot }: { snapshot: BaselineSnapshot }) {
                 <X size={15} />
               </button>
             </div>
-          )}
-          <div className="settings-row profile-footer-row">
-            <span className="profile-footer-text">
-              Only updates and installs completed with Baseline are counted. Stats stay private on
-              this Mac.
-            </span>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -262,6 +262,8 @@ button:disabled {
 .topbar,
 .popover-titlebar {
   display: flex;
+  position: relative;
+  z-index: 10;
   align-items: center;
   justify-content: space-between;
   gap: 14px;
@@ -297,6 +299,10 @@ button:disabled {
   font-size: 15px;
 }
 
+.topbar-title {
+  min-width: 0;
+}
+
 .topbar p,
 .popover-titlebar p {
   margin: 2px 0 0;
@@ -310,6 +316,72 @@ button:disabled {
   align-items: center;
   gap: 7px;
   -webkit-app-region: no-drag;
+}
+
+.profile-topbar-indicators {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.profile-topbar-indicator {
+  position: relative;
+  min-width: 0;
+  height: 28px;
+  min-height: 28px;
+  color: rgba(60, 60, 67, 0.78);
+  white-space: nowrap;
+  -webkit-app-region: no-drag;
+}
+
+.profile-topbar-indicator.private {
+  width: auto;
+  padding: 0 9px;
+}
+
+.profile-topbar-indicator.icon-only {
+  width: 28px;
+  padding: 0;
+}
+
+.profile-topbar-indicator svg {
+  flex: 0 0 auto;
+}
+
+.profile-topbar-tooltip {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  width: max-content;
+  max-width: min(260px, calc(100vw - 32px));
+  padding: 7px 9px;
+  border: 0.5px solid rgba(60, 60, 67, 0.16);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow:
+    0 10px 26px rgba(0, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  color: #1c1c1e;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.3;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition:
+    opacity 70ms ease,
+    transform 70ms ease;
+  white-space: normal;
+}
+
+.profile-topbar-indicator:hover .profile-topbar-tooltip,
+.profile-topbar-indicator:focus-visible .profile-topbar-tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.profile-topbar-indicator:focus-visible {
+  box-shadow: 0 0 0 3px rgba(var(--update-accent-rgb), 0.18);
 }
 
 .toolbar-search {
@@ -2289,20 +2361,6 @@ button:disabled {
   font-weight: 500;
 }
 
-.profile-footer-row {
-  background: rgba(60, 60, 67, 0.035);
-}
-
-.profile-footer-text {
-  color: rgba(60, 60, 67, 0.64);
-  font-size: 13px;
-  line-height: 1.45;
-}
-
-.profile-footer-row .settings-row-text > span:first-child {
-  color: rgba(60, 60, 67, 0.64);
-}
-
 .settings-number-input {
   width: 68px;
   height: 26px;
@@ -2441,6 +2499,22 @@ button:disabled {
   }
 }
 
+@media (max-width: 430px) {
+  .settings-shell .topbar {
+    gap: 10px;
+    padding-inline: 16px;
+  }
+
+  .profile-topbar-indicator-label {
+    display: none;
+  }
+
+  .profile-topbar-indicator:not(.icon-only) {
+    width: 28px;
+    padding: 0;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #fcfcfc;
@@ -2514,6 +2588,15 @@ button:disabled {
   .topbar {
     border-color: rgba(255, 255, 255, 0.1);
     background: rgba(25, 25, 25, 0.88);
+  }
+
+  .profile-topbar-tooltip {
+    border-color: rgba(235, 235, 245, 0.16);
+    background: #2c2c2e;
+    box-shadow:
+      0 10px 26px rgba(0, 0, 0, 0.42),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.88);
   }
 
   .topbar p,
@@ -2972,18 +3055,6 @@ button:disabled {
 
   .profile-warning-row .settings-row-text > span:first-child {
     color: #ff6961;
-  }
-
-  .profile-footer-row {
-    background: rgba(235, 235, 245, 0.018);
-  }
-
-  .profile-footer-text {
-    color: rgba(235, 235, 245, 0.44);
-  }
-
-  .profile-footer-row .settings-row-text > span:first-child {
-    color: rgba(235, 235, 245, 0.44);
   }
 
   .profile-footer-panel .settings-panel-box {


### PR DESCRIPTION
## Summary
- Moves Profile privacy and counting guidance into top-bar toolbar indicators with a keyhole-lock + Private control and an info control.
- Removes the duplicate Profile footer explainer and makes the tooltip surface opaque above Profile content.
- Removes the Source mix title and shows update-only source mix percentages in the legend while bar hover tooltips show raw update counts.

## Validation
- `npm test -- --run ElectronTests/rendererButtons.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run format`