### PR TITLE
Run cleanup after Homebrew updates and installs

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2630,6 +2630,35 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("runs Homebrew cleanup after successful direct formula updates", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "formula:managed",
+            token: "managed",
+            name: "managed",
+            kind: "formula",
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdate("formula:managed");
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "managed"],
+      ["cleanup"]
+    ]);
+  });
+
   it("keeps successful Homebrew updates when follow-up cleanup fails", async () => {
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
@@ -2917,6 +2946,41 @@ describe("update store helpers", () => {
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["install", "bat"],
       ["cleanup"]
+    ]);
+  });
+
+  it("keeps successful Homebrew Discover installs when follow-up cleanup fails", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => ({
+      success: command[0] !== "cleanup",
+      status: command[0] === "cleanup" ? 1 : 0,
+      output: command[0] === "cleanup" ? "Error: cleanup failed" : ""
+    }));
+    const store = await makeStore({ runBrewCommand });
+
+    await store.installHomebrewItem({
+      id: "formula:bat",
+      kind: "formula",
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    });
+
+    const snapshot = store.getSnapshot();
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["install", "bat"],
+      ["cleanup"]
+    ]);
+    expect(snapshot.refreshErrorMessage).toBeUndefined();
+    expect(snapshot.lastRefreshNoticeMessage).toContain("Homebrew cleanup did not complete");
+    expect(snapshot.profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewInstall",
+        targetID: "formula:bat",
+        displayName: "bat",
+        channel: "homebrew"
+      })
     ]);
   });
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2272,7 +2272,9 @@ describe("update store helpers", () => {
       bundleIdentifier: "com.example.homebrew",
       localVersion: version("1.0.0")
     });
-    const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
     const store = await makeStore({
       persisted: {
         ...defaultPersistedSnapshot(),
@@ -2306,10 +2308,10 @@ describe("update store helpers", () => {
 
     await store.performAppUpdate(app.id);
 
-    expect(runBrewCommand).toHaveBeenCalledWith(
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["upgrade", "--cask", "--greedy", "homebrew-managed"],
-      expect.any(Function)
-    );
+      ["cleanup"]
+    ]);
     expect(store.getSnapshot().profileStats.events).toEqual([
       expect.objectContaining({
         type: "appUpdate",
@@ -2327,7 +2329,9 @@ describe("update store helpers", () => {
       bundleIdentifier: "com.example.homebrew",
       localVersion: version("1.0.0")
     });
-    const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
     const store = await makeStore({
       persisted: {
         ...defaultPersistedSnapshot(),
@@ -2361,10 +2365,10 @@ describe("update store helpers", () => {
 
     await store.performAppUpdate(app.id);
 
-    expect(runBrewCommand).toHaveBeenCalledWith(
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["upgrade", "--cask", "--greedy", "homebrew-managed"],
-      expect.any(Function)
-    );
+      ["cleanup"]
+    ]);
   });
 
   it("uses external fallback for unmanaged Homebrew-backed app updates", async () => {
@@ -2479,7 +2483,9 @@ describe("update store helpers", () => {
     expect(openExternalURL).not.toHaveBeenCalled();
     expect(openAppBundle).toHaveBeenCalledWith(app.bundlePath);
 
-    const linkedBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const linkedBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
     const linkedStore = await makeStore({
       persisted: {
         ...persisted,
@@ -2490,10 +2496,10 @@ describe("update store helpers", () => {
 
     await linkedStore.performAppUpdate(app.id);
 
-    expect(linkedBrewCommand).toHaveBeenCalledWith(
+    expect(linkedBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["upgrade", "--cask", "--greedy", "sparkle-managed"],
-      expect.any(Function)
-    );
+      ["cleanup"]
+    ]);
   });
 
   it("derives external fallback URLs for persisted Homebrew-backed app updates without URLs", async () => {
@@ -2593,6 +2599,79 @@ describe("update store helpers", () => {
     await store.performHomebrewUpdate("cask:unsafe");
 
     expect(runBrewCommand).not.toHaveBeenCalled();
+  });
+
+  it("runs Homebrew cleanup after successful direct cask updates", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:managed",
+            token: "managed",
+            name: "Managed",
+            kind: "cask",
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdate("cask:managed");
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "--cask", "--greedy", "managed"],
+      ["cleanup"]
+    ]);
+  });
+
+  it("keeps successful Homebrew updates when follow-up cleanup fails", async () => {
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => ({
+      success: command[0] !== "cleanup",
+      status: command[0] === "cleanup" ? 1 : 0,
+      output: command[0] === "cleanup" ? "Error: cleanup failed" : ""
+    }));
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: "cask:managed",
+            token: "managed",
+            name: "Managed",
+            kind: "cask",
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    await store.performHomebrewUpdate("cask:managed");
+
+    const snapshot = store.getSnapshot();
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "--cask", "--greedy", "managed"],
+      ["cleanup"]
+    ]);
+    expect(snapshot.refreshErrorMessage).toBeUndefined();
+    expect(snapshot.lastRefreshNoticeMessage).toContain("Homebrew cleanup did not complete");
+    expect(snapshot.profileStats.events).toEqual([
+      expect.objectContaining({
+        type: "homebrewUpdate",
+        targetID: "cask:managed",
+        displayName: "Managed",
+        channel: "homebrew"
+      })
+    ]);
   });
 
   it("rejects Homebrew uninstall for formula and unsafe cask tokens", async () => {
@@ -2814,7 +2893,10 @@ describe("update store helpers", () => {
   });
 
   it("records profile stats for successful Homebrew Discover installs", async () => {
-    const store = await makeStore();
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({ success: true, status: 0, output: "" }));
+    const store = await makeStore({ runBrewCommand });
 
     await store.installHomebrewItem({
       id: "formula:bat",
@@ -2831,6 +2913,10 @@ describe("update store helpers", () => {
         displayName: "bat",
         channel: "homebrew"
       })
+    ]);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["install", "bat"],
+      ["cleanup"]
     ]);
   });
 
@@ -3130,12 +3216,14 @@ describe("update store helpers", () => {
     let resolveCommand!: (result: { success: boolean; status: number; output: string }) => void;
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
-    >(
-      async () =>
-        await new Promise((resolve) => {
-          resolveCommand = resolve;
-        })
-    );
+    >(async (command) => {
+      if (command[0] === "cleanup") {
+        return { success: true, status: 0, output: "" };
+      }
+      return await new Promise((resolve) => {
+        resolveCommand = resolve;
+      });
+    });
     const store = await makeStore({ runBrewCommand });
 
     const firstInstall = store.installHomebrewItem(item);
@@ -3147,7 +3235,10 @@ describe("update store helpers", () => {
     resolveCommand({ success: true, status: 0, output: "" });
     await Promise.all([firstInstall, secondInstall]);
 
-    expect(runBrewCommand).toHaveBeenCalledOnce();
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["install", "ripgrep"],
+      ["cleanup"]
+    ]);
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
   });
 
@@ -3176,6 +3267,9 @@ describe("update store helpers", () => {
         return await new Promise((resolve) => {
           resolveAvailability = resolve;
         });
+      }
+      if (command[0] === "cleanup") {
+        return { success: true, status: 0, output: "" };
       }
       return await new Promise((resolve) => {
         resolveInstall = resolve;
@@ -3207,6 +3301,12 @@ describe("update store helpers", () => {
     resolveInstall({ success: true, status: 0, output: "" });
     await Promise.all([firstInstall, secondInstall]);
 
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["--version"],
+      ["--version"],
+      ["install", "ripgrep"],
+      ["cleanup"]
+    ]);
     expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).not.toContain(item.id);
   });
 
@@ -3224,6 +3324,9 @@ describe("update store helpers", () => {
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
     >(async (command) => {
       if (command[0] === "--version") {
+        return { success: true, status: 0, output: "" };
+      }
+      if (command[0] === "cleanup") {
         return { success: true, status: 0, output: "" };
       }
       return await new Promise((resolve) => {
@@ -3256,6 +3359,12 @@ describe("update store helpers", () => {
 
     resolveInstall({ success: true, status: 0, output: "" });
     await install;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["--version"],
+      ["install", "fd"],
+      ["cleanup"]
+    ]);
   });
 
   it("blocks Discover installs while a tool-status Homebrew check is active", async () => {
@@ -3390,8 +3499,10 @@ describe("update store helpers", () => {
 
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["install", "fd"],
+      ["cleanup"],
       ["upgrade", "ripgrep"],
-      ["upgrade", "--cask", "--greedy", "raycast"]
+      ["upgrade", "--cask", "--greedy", "raycast"],
+      ["cleanup"]
     ]);
   });
 
@@ -3474,8 +3585,10 @@ describe("update store helpers", () => {
     await vi.waitFor(() => {
       expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
         ["install", "fd"],
+        ["cleanup"],
         ["upgrade", "ripgrep"],
-        ["upgrade", "--cask", "--greedy", "raycast"]
+        ["upgrade", "--cask", "--greedy", "raycast"],
+        ["cleanup"]
       ]);
     });
     expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual([]);
@@ -3555,8 +3668,10 @@ describe("update store helpers", () => {
 
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["upgrade", "ripgrep"],
+      ["cleanup"],
       ["upgrade", "bat"],
-      ["upgrade", "--cask", "--greedy", "raycast"]
+      ["upgrade", "--cask", "--greedy", "raycast"],
+      ["cleanup"]
     ]);
     expect(store.getSnapshot().homebrewQueuedItemIDs).toEqual([]);
     expect(store.getSnapshot().homebrewUpdatingItemIDs).toEqual([]);
@@ -3850,7 +3965,10 @@ describe("update store helpers", () => {
     await refresh;
     await update;
 
-    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "ripgrep"],
+      ["cleanup"]
+    ]);
     expect(store.getSnapshot().isHomebrewCommandLocked).toBe(false);
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
   });
@@ -3923,7 +4041,10 @@ describe("update store helpers", () => {
     });
     await Promise.all([staleRefresh, winningRefresh, update]);
 
-    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([["upgrade", "ripgrep"]]);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "ripgrep"],
+      ["cleanup"]
+    ]);
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(item.id);
   });
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1817,7 +1817,7 @@ describe("update store helpers", () => {
     ]);
   });
 
-  it("records profile stats for batch upgrades completed before maintenance fails", async () => {
+  it("keeps successful batch upgrades when follow-up cleanup fails", async () => {
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
     >(async (command) => ({
@@ -1861,7 +1861,10 @@ describe("update store helpers", () => {
       ["autoremove"],
       ["cleanup"]
     ]);
-    expect(store.getSnapshot().profileStats.events).toEqual([
+    const snapshot = store.getSnapshot();
+    expect(snapshot.refreshErrorMessage).toBeUndefined();
+    expect(snapshot.lastRefreshNoticeMessage).toContain("Homebrew cleanup did not complete");
+    expect(snapshot.profileStats.events).toEqual([
       expect.objectContaining({
         type: "homebrewUpdate",
         targetID: "formula:ripgrep",
@@ -1874,6 +1877,75 @@ describe("update store helpers", () => {
         displayName: "Visual Studio Code",
         channel: "homebrew"
       })
+    ]);
+  });
+
+  it("keeps bulk Homebrew updates finalizing until cleanup completes", async () => {
+    let resolveCleanup!: (result: { success: boolean; status: number; output: string }) => void;
+    let cleanupStarted!: () => void;
+    const cleanupStartedPromise = new Promise<void>((resolve) => {
+      cleanupStarted = resolve;
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "cleanup") {
+        cleanupStarted();
+        return await new Promise((resolve) => {
+          resolveCleanup = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const formula = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("14.0.0"),
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const cask = homebrewItem({
+      id: "cask:visual-studio-code",
+      token: "visual-studio-code",
+      name: "Visual Studio Code",
+      kind: "cask",
+      installedVersion: version("1.99.0"),
+      latestVersion: version("1.100.0"),
+      isOutdated: true
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [formula, cask]
+      },
+      runBrewCommand
+    });
+
+    const update = store.performHomebrewUpdateAll();
+    await cleanupStartedPromise;
+
+    const cleanupSnapshot = store.getSnapshot();
+    expect(cleanupSnapshot.isRunningHomebrewMaintenance).toBe(true);
+    expect(cleanupSnapshot.homebrewBatchProgressByItemID[formula.id]).toBe(
+      HomebrewMaintenanceProgressStage.finalizing
+    );
+    expect(cleanupSnapshot.homebrewBatchProgressByItemID[cask.id]).toBe(
+      HomebrewMaintenanceProgressStage.finalizing
+    );
+    expect(cleanupSnapshot.homebrewUpdatedPendingRefreshItemIDs).not.toContain(formula.id);
+    expect(cleanupSnapshot.homebrewUpdatedPendingRefreshItemIDs).not.toContain(cask.id);
+
+    resolveCleanup({ success: true, status: 0, output: "" });
+    await update;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "ripgrep"],
+      ["upgrade", "--cask", "--greedy", "visual-studio-code"],
+      ["autoremove"],
+      ["cleanup"]
     ]);
   });
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -18,6 +18,7 @@ import {
   preservePreviousHomebrewOutdatedState,
   UpdateStore
 } from "../src/main/updateStore";
+import { HomebrewMaintenanceProgressStage } from "../src/shared/homebrewProgress";
 import type {
   AppRecord,
   HomebrewCaskIndex,
@@ -2659,6 +2660,59 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("keeps direct Homebrew updates finalizing until cleanup completes", async () => {
+    let resolveCleanup!: (result: { success: boolean; status: number; output: string }) => void;
+    let cleanupStarted!: () => void;
+    const cleanupStartedPromise = new Promise<void>((resolve) => {
+      cleanupStarted = resolve;
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "cleanup") {
+        cleanupStarted();
+        return await new Promise((resolve) => {
+          resolveCleanup = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const itemID = "cask:managed";
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [
+          homebrewItem({
+            id: itemID,
+            token: "managed",
+            name: "Managed",
+            kind: "cask",
+            latestVersion: version("2.0.0"),
+            isOutdated: true
+          })
+        ]
+      },
+      runBrewCommand
+    });
+
+    const update = store.performHomebrewUpdate(itemID);
+    await cleanupStartedPromise;
+
+    const cleanupSnapshot = store.getSnapshot();
+    expect(cleanupSnapshot.homebrewBatchProgressByItemID[itemID]).toBe(
+      HomebrewMaintenanceProgressStage.finalizing
+    );
+    expect(cleanupSnapshot.homebrewUpdatedPendingRefreshItemIDs).not.toContain(itemID);
+
+    resolveCleanup({ success: true, status: 0, output: "" });
+    await update;
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["upgrade", "--cask", "--greedy", "managed"],
+      ["cleanup"]
+    ]);
+  });
+
   it("keeps successful Homebrew updates when follow-up cleanup fails", async () => {
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
@@ -2943,6 +2997,51 @@ describe("update store helpers", () => {
         channel: "homebrew"
       })
     ]);
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["install", "bat"],
+      ["cleanup"]
+    ]);
+  });
+
+  it("keeps Homebrew Discover installs finalizing until cleanup completes", async () => {
+    let resolveCleanup!: (result: { success: boolean; status: number; output: string }) => void;
+    let cleanupStarted!: () => void;
+    const cleanupStartedPromise = new Promise<void>((resolve) => {
+      cleanupStarted = resolve;
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "cleanup") {
+        cleanupStarted();
+        return await new Promise((resolve) => {
+          resolveCleanup = resolve;
+        });
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({ runBrewCommand });
+    const item = {
+      id: "formula:bat",
+      kind: "formula" as const,
+      token: "bat",
+      displayName: "bat",
+      version: version("1.0.0")
+    };
+
+    const install = store.installHomebrewItem(item);
+    await cleanupStartedPromise;
+
+    const cleanupSnapshot = store.getSnapshot();
+    expect(cleanupSnapshot.homebrewDiscoverInstallingItemIDs).toContain(item.id);
+    expect(cleanupSnapshot.homebrewDiscoverInstalledPendingRefreshItemIDs).not.toContain(item.id);
+    expect(cleanupSnapshot.homebrewDiscoverProgressByItemID[item.id]).toBe(
+      HomebrewMaintenanceProgressStage.finalizing
+    );
+
+    resolveCleanup({ success: true, status: 0, output: "" });
+    await install;
+
     expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
       ["install", "bat"],
       ["cleanup"]

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -3669,6 +3669,110 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("keeps successful queued Homebrew batches finalizing until cleanup completes", async () => {
+    const discoverItem = {
+      id: "formula:fd",
+      kind: "formula" as const,
+      token: "fd",
+      displayName: "fd",
+      presentation: "formula" as const,
+      version: version("10.0.0")
+    };
+    const formula = homebrewItem({
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      latestVersion: version("14.1.0"),
+      isOutdated: true
+    });
+    const cask = homebrewItem({
+      id: "cask:raycast",
+      token: "raycast",
+      name: "Raycast",
+      kind: "cask",
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    });
+    let resolveInstall!: (result: { success: boolean; status: number; output: string }) => void;
+    let resolveQueuedCleanup!: (result: {
+      success: boolean;
+      status: number;
+      output: string;
+    }) => void;
+    let cleanupCount = 0;
+    let queuedCleanupStarted!: () => void;
+    const queuedCleanupStartedPromise = new Promise<void>((resolve) => {
+      queuedCleanupStarted = resolve;
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async (command) => {
+      if (command[0] === "install") {
+        return await new Promise((resolve) => {
+          resolveInstall = resolve;
+        });
+      }
+      if (command[0] === "cleanup") {
+        cleanupCount += 1;
+        if (cleanupCount === 2) {
+          queuedCleanupStarted();
+          return await new Promise((resolve) => {
+            resolveQueuedCleanup = resolve;
+          });
+        }
+      }
+      return { success: true, status: 0, output: "" };
+    });
+    const store = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        homebrewItems: [formula, cask]
+      },
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [formula, cask],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
+      runBrewCommand
+    });
+
+    const install = store.installHomebrewItem(discoverItem);
+    expect(store.getSnapshot().homebrewDiscoverInstallingItemIDs).toContain(discoverItem.id);
+
+    const queuedFormulaUpdate = store.performHomebrewUpdate(formula.id);
+    const queuedCaskUpdate = store.performHomebrewUpdate(cask.id);
+
+    resolveInstall({ success: true, status: 0, output: "" });
+    await install;
+    await queuedCleanupStartedPromise;
+
+    const cleanupSnapshot = store.getSnapshot();
+    expect(cleanupSnapshot.homebrewBatchProgressByItemID[formula.id]).toBe(
+      HomebrewMaintenanceProgressStage.finalizing
+    );
+    expect(cleanupSnapshot.homebrewBatchProgressByItemID[cask.id]).toBe(
+      HomebrewMaintenanceProgressStage.finalizing
+    );
+    expect(cleanupSnapshot.homebrewUpdatedPendingRefreshItemIDs).not.toContain(formula.id);
+    expect(cleanupSnapshot.homebrewUpdatedPendingRefreshItemIDs).not.toContain(cask.id);
+
+    resolveQueuedCleanup({ success: true, status: 0, output: "" });
+    await Promise.all([queuedFormulaUpdate, queuedCaskUpdate]);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["install", "fd"],
+      ["cleanup"],
+      ["upgrade", "ripgrep"],
+      ["upgrade", "--cask", "--greedy", "raycast"],
+      ["cleanup"]
+    ]);
+  });
+
   it("queues visible Homebrew batch updates during an active Discover install", async () => {
     const discoverItem = {
       id: "formula:fd",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -509,7 +509,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         profileStatsEvent ??
           homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
       ]);
+      const cleanupNotice = await this.runPostSuccessHomebrewCleanup();
       await this.holdSuccessfulUpdate();
+      await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+      this.applyHomebrewCleanupNotice(cleanupNotice);
     } else {
       this.patch({
         refreshErrorMessage: `Homebrew update failed for ${item.name}.`,
@@ -520,8 +523,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         }
       });
       this.scheduleHomebrewBatchFailureClear([itemID]);
+      await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
     }
-    await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
   }
 
   private async runHomebrewQueuedUpdates(entries: HomebrewUpdateQueueEntry[]): Promise<void> {
@@ -627,6 +630,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     if (!success) {
       this.scheduleHomebrewBatchFailureClear(failedIDs);
     }
+    let cleanupNotice: string | undefined;
     if (completedIDs.length > 0) {
       const occurredAt = new Date().toISOString();
       await this.recordProfileStatsEvents(
@@ -637,9 +641,11 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
               entry.profileStatsEvent ?? homebrewUpdateProfileStatsEvent({ item, occurredAt })
           )
       );
+      cleanupNotice = await this.runPostSuccessHomebrewCleanup();
       await this.holdSuccessfulUpdate();
     }
     await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+    this.applyHomebrewCleanupNotice(cleanupNotice);
   }
 
   async performHomebrewUpdateAll(itemIDs?: string[]): Promise<void> {
@@ -873,8 +879,10 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         this.hasCheckedHomebrewAvailability = true;
         this.patch({ isHomebrewInstalled: true });
         await this.recordProfileStatsEvents([homebrewInstallProfileStatsEvent(item)]);
+        const cleanupNotice = await this.runPostSuccessHomebrewCleanup();
         await this.holdSuccessfulUpdate();
         await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+        this.applyHomebrewCleanupNotice(cleanupNotice);
       } else {
         this.scheduleHomebrewDiscoverFailureClear(itemID);
       }
@@ -1362,6 +1370,24 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     this.emit("homebrewCommand", finished);
     onEvent(finished);
     return result;
+  }
+
+  private async runPostSuccessHomebrewCleanup(): Promise<string | undefined> {
+    const result = await this.runBrewWithResultEvents(["cleanup"], () => undefined);
+    return result.success
+      ? undefined
+      : "Homebrew cleanup did not complete after the Homebrew operation. Old downloads may still be retained.";
+  }
+
+  private applyHomebrewCleanupNotice(message: string | undefined): void {
+    if (!message) {
+      return;
+    }
+    this.patch({
+      lastRefreshNoticeMessage: this.state.lastRefreshNoticeMessage
+        ? `${this.state.lastRefreshNoticeMessage} ${message}`
+        : message
+    });
   }
 
   private applyHomebrewProgressEvent(

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -496,6 +496,17 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       this.patch({
         refreshErrorMessage: undefined,
         homebrewBatchFailedItemIDs: removeFromArray(this.state.homebrewBatchFailedItemIDs, itemID),
+        homebrewBatchProgressByItemID: {
+          ...this.state.homebrewBatchProgressByItemID,
+          [itemID]: HomebrewMaintenanceProgressStage.finalizing
+        }
+      });
+      await this.recordProfileStatsEvents([
+        profileStatsEvent ??
+          homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
+      ]);
+      const cleanupNotice = await this.runPostSuccessHomebrewCleanup();
+      this.patch({
         homebrewUpdatedPendingRefreshItemIDs: addToArray(
           this.state.homebrewUpdatedPendingRefreshItemIDs,
           itemID
@@ -505,11 +516,6 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           [itemID]: 1
         }
       });
-      await this.recordProfileStatsEvents([
-        profileStatsEvent ??
-          homebrewUpdateProfileStatsEvent({ item, occurredAt: new Date().toISOString() })
-      ]);
-      const cleanupNotice = await this.runPostSuccessHomebrewCleanup();
       await this.holdSuccessfulUpdate();
       await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
       this.applyHomebrewCleanupNotice(cleanupNotice);
@@ -618,13 +624,12 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
               )
             ])
           ],
-      homebrewUpdatedPendingRefreshItemIDs:
-        completedIDs.length > 0
-          ? [...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...completedIDs])]
-          : this.state.homebrewUpdatedPendingRefreshItemIDs,
       homebrewBatchProgressByItemID: {
         ...this.state.homebrewBatchProgressByItemID,
-        ...Object.fromEntries(affectedIDs.map((id) => [id, 1]))
+        ...Object.fromEntries(
+          completedIDs.map((id) => [id, HomebrewMaintenanceProgressStage.finalizing])
+        ),
+        ...Object.fromEntries(failedIDs.map((id) => [id, 1]))
       }
     });
     if (!success) {
@@ -642,6 +647,15 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
           )
       );
       cleanupNotice = await this.runPostSuccessHomebrewCleanup();
+      this.patch({
+        homebrewUpdatedPendingRefreshItemIDs: [
+          ...new Set([...this.state.homebrewUpdatedPendingRefreshItemIDs, ...completedIDs])
+        ],
+        homebrewBatchProgressByItemID: {
+          ...this.state.homebrewBatchProgressByItemID,
+          ...Object.fromEntries(completedIDs.map((id) => [id, 1]))
+        }
+      });
       await this.holdSuccessfulUpdate();
     }
     await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
@@ -861,16 +875,20 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         this.applyDiscoverInstallEvent(event, parser, itemID, item.token.toLowerCase());
       });
       this.patch({
-        homebrewDiscoverInstallingItemIDs: removeFromArray(
-          this.state.homebrewDiscoverInstallingItemIDs,
-          itemID
-        ),
-        homebrewDiscoverInstalledPendingRefreshItemIDs: success
-          ? addToArray(this.state.homebrewDiscoverInstalledPendingRefreshItemIDs, itemID)
-          : this.state.homebrewDiscoverInstalledPendingRefreshItemIDs,
+        homebrewDiscoverInstallingItemIDs: success
+          ? this.state.homebrewDiscoverInstallingItemIDs
+          : removeFromArray(this.state.homebrewDiscoverInstallingItemIDs, itemID),
+        homebrewDiscoverInstalledPendingRefreshItemIDs:
+          this.state.homebrewDiscoverInstalledPendingRefreshItemIDs,
         homebrewDiscoverFailedItemIDs: success
           ? removeFromArray(this.state.homebrewDiscoverFailedItemIDs, itemID)
           : addToArray(this.state.homebrewDiscoverFailedItemIDs, itemID),
+        homebrewDiscoverProgressByItemID: success
+          ? {
+              ...this.state.homebrewDiscoverProgressByItemID,
+              [itemID]: HomebrewMaintenanceProgressStage.finalizing
+            }
+          : this.state.homebrewDiscoverProgressByItemID,
         refreshErrorMessage: success
           ? undefined
           : `Homebrew install failed for ${item.displayName}.`
@@ -880,6 +898,20 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         this.patch({ isHomebrewInstalled: true });
         await this.recordProfileStatsEvents([homebrewInstallProfileStatsEvent(item)]);
         const cleanupNotice = await this.runPostSuccessHomebrewCleanup();
+        this.patch({
+          homebrewDiscoverInstallingItemIDs: removeFromArray(
+            this.state.homebrewDiscoverInstallingItemIDs,
+            itemID
+          ),
+          homebrewDiscoverInstalledPendingRefreshItemIDs: addToArray(
+            this.state.homebrewDiscoverInstalledPendingRefreshItemIDs,
+            itemID
+          ),
+          homebrewDiscoverProgressByItemID: {
+            ...this.state.homebrewDiscoverProgressByItemID,
+            [itemID]: 1
+          }
+        });
         await this.holdSuccessfulUpdate();
         await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
         this.applyHomebrewCleanupNotice(cleanupNotice);

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -721,8 +721,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         ["update"],
         ...(formulaTokens.length > 0 ? [["upgrade", ...formulaTokens]] : []),
         ...(caskTokens.length > 0 ? [["upgrade", "--cask", "--greedy", ...caskTokens]] : []),
-        ["autoremove"],
-        ["cleanup"]
+        ["autoremove"]
       ];
       const completedItemIDs = new Set<string>();
       let success = true;
@@ -753,6 +752,19 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         ? affectedIDs
         : affectedIDs.filter((id) => completedItemIDs.has(id));
       const failedIDs = affectedIDs.filter((id) => !completedItemIDs.has(id));
+      let cleanupNotice: string | undefined;
+
+      if (success) {
+        this.patch({
+          homebrewBatchProgressByItemID: {
+            ...this.state.homebrewBatchProgressByItemID,
+            ...Object.fromEntries(
+              completedIDs.map((id) => [id, HomebrewMaintenanceProgressStage.finalizing])
+            )
+          }
+        });
+        cleanupNotice = await this.runPostSuccessHomebrewCleanup();
+      }
 
       this.patch({
         isRunningHomebrewMaintenance: false,
@@ -790,6 +802,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         await this.holdSuccessfulUpdate();
       }
       await this.refresh(false, { allowHomebrewInventoryDuringActiveCommand: true });
+      this.applyHomebrewCleanupNotice(cleanupNotice);
     } finally {
       releaseHomebrewCommandLock();
     }

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -611,7 +611,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     const completedIDs = success
       ? affectedIDs
       : affectedIDs.filter((id) => completedItemIDs.has(id));
-    const failedIDs = affectedIDs.filter((id) => !completedItemIDs.has(id));
+    const failedIDs = success ? [] : affectedIDs.filter((id) => !completedItemIDs.has(id));
     this.patch({
       refreshErrorMessage: success ? undefined : "Homebrew update failed.",
       homebrewBatchFailedItemIDs: success

--- a/src/shared/homebrewProgress.ts
+++ b/src/shared/homebrewProgress.ts
@@ -10,8 +10,8 @@ export type HomebrewMaintenanceRunEvent =
 
 export const HomebrewMaintenanceProgressStage = {
   queued: 0.0,
-  downloading: 0.78,
-  installing: 0.83,
+  downloading: 0.32,
+  installing: 0.72,
   finalizing: 0.92,
   completed: 1.0
 } as const;


### PR DESCRIPTION
## Summary
- Run a conservative `brew cleanup` after successful direct Homebrew item updates, queued update batches, and Discover installs.
- Keep cleanup failures secondary so completed updates and installs remain successful, while surfacing a non-blocking notice that retained downloads may remain.
- Cover direct cask updates, Homebrew-backed app updates, queued updates, Discover installs, and cleanup-failure behavior in update-store tests.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`
- `npm run build` (exited 0 locally; no packaged app was generated)
- `npm run test:electron` (4/5 passed locally; packaged-app smoke could not run because the packaged app was not generated)