### PR TITLE
Ease Homebrew progress ring animation

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -312,7 +312,7 @@ describe("renderer button parity", () => {
   it("eases active Homebrew update progress from the queued marker", () => {
     vi.useFakeTimers();
     try {
-      const { container } = render(
+      const { container, rerender } = render(
         <UpdateActionButton
           state={{
             type: "updating",
@@ -333,17 +333,31 @@ describe("renderer button parity", () => {
       expect(easedProgress).toBeGreaterThan(initialProgress);
       expect(easedProgress).toBeLessThan(0.28);
 
+      rerender(
+        <UpdateActionButton
+          state={{
+            type: "updating",
+            progress: HomebrewMaintenanceProgressStage.downloading
+          }}
+          onAction={() => undefined}
+        />
+      );
+      expect(progressRingValue(container)).toBeCloseTo(easedProgress);
+      expect(progressRingValue(container)).toBeLessThan(
+        HomebrewMaintenanceProgressStage.downloading
+      );
+
       act(() => {
         vi.advanceTimersByTime(60_000);
       });
 
-      expect(progressRingValue(container)).toBeCloseTo(0.28, 2);
+      expect(progressRingValue(container)).toBeCloseTo(0.58, 2);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("resets easing from the next Homebrew progress stage", () => {
+  it("continues easing toward the next Homebrew progress stage without jumping", () => {
     vi.useFakeTimers();
     try {
       const { container, rerender } = render(
@@ -360,6 +374,7 @@ describe("renderer button parity", () => {
         vi.advanceTimersByTime(60_000);
       });
       expect(progressRingValue(container)).toBeCloseTo(0.58, 2);
+      const downloadingCapProgress = progressRingValue(container);
 
       rerender(
         <UpdateActionButton
@@ -370,7 +385,10 @@ describe("renderer button parity", () => {
           onAction={() => undefined}
         />
       );
-      expect(progressRingValue(container)).toBeCloseTo(HomebrewMaintenanceProgressStage.installing);
+      expect(progressRingValue(container)).toBeCloseTo(downloadingCapProgress);
+      expect(progressRingValue(container)).toBeLessThan(
+        HomebrewMaintenanceProgressStage.installing
+      );
 
       act(() => {
         vi.advanceTimersByTime(60_000);

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -309,6 +309,40 @@ describe("renderer button parity", () => {
     }
   });
 
+  it("eases active Homebrew update progress from the queued marker", () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <UpdateActionButton
+          state={{
+            type: "updating",
+            progress: HomebrewMaintenanceProgressStage.queued
+          }}
+          onAction={() => undefined}
+        />
+      );
+
+      const initialProgress = progressRingValue(container);
+      expect(initialProgress).toBeCloseTo(HomebrewMaintenanceProgressStage.queued);
+
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+
+      const easedProgress = progressRingValue(container);
+      expect(easedProgress).toBeGreaterThan(initialProgress);
+      expect(easedProgress).toBeLessThan(0.28);
+
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+
+      expect(progressRingValue(container)).toBeCloseTo(0.28, 2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("resets easing from the next Homebrew progress stage", () => {
     vi.useFakeTimers();
     try {

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ActionConfirmationContext,
@@ -11,7 +11,8 @@ import {
   DiscoverRow,
   HomebrewRow,
   HomebrewSection,
-  SettingsView
+  SettingsView,
+  UpdateActionButton
 } from "../src/renderer/main";
 import type {
   AppRecord,
@@ -21,6 +22,7 @@ import type {
   UpdateRecord
 } from "../src/shared/domain";
 import { defaultPersistedSnapshot, profileStatsSignatureVersion } from "../src/shared/domain";
+import { HomebrewMaintenanceProgressStage } from "../src/shared/homebrewProgress";
 import { version } from "../src/shared/version";
 
 const app: AppRecord = {
@@ -128,6 +130,15 @@ function toolbarButtonLabels(container: HTMLElement): Array<string | null> {
   return within(container.querySelector(".topbar-actions") as HTMLElement)
     .getAllByRole("button")
     .map((button) => button.getAttribute("aria-label") ?? button.getAttribute("title"));
+}
+
+function progressRingValue(container: HTMLElement): number {
+  const radius = 6;
+  const circumference = 2 * Math.PI * radius;
+  const progressRing = container.querySelector(".progress-ring-value");
+  expect(progressRing).not.toBeNull();
+  const offset = Number(progressRing?.getAttribute("stroke-dashoffset"));
+  return 1 - offset / circumference;
 }
 
 function domRect({
@@ -262,6 +273,78 @@ describe("renderer button parity", () => {
 
     expect(screen.queryByRole("button", { name: "Updating" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Updated" })).toBeInTheDocument();
+  });
+
+  it("eases Homebrew update progress within the current stage", () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <UpdateActionButton
+          state={{
+            type: "updating",
+            progress: HomebrewMaintenanceProgressStage.downloading
+          }}
+          onAction={() => undefined}
+        />
+      );
+
+      const initialProgress = progressRingValue(container);
+      expect(initialProgress).toBeCloseTo(HomebrewMaintenanceProgressStage.downloading);
+
+      act(() => {
+        vi.advanceTimersByTime(4500);
+      });
+
+      const easedProgress = progressRingValue(container);
+      expect(easedProgress).toBeGreaterThan(initialProgress);
+      expect(easedProgress).toBeLessThan(0.58);
+
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+
+      expect(progressRingValue(container)).toBeCloseTo(0.58, 2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets easing from the next Homebrew progress stage", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <UpdateActionButton
+          state={{
+            type: "updating",
+            progress: HomebrewMaintenanceProgressStage.downloading
+          }}
+          onAction={() => undefined}
+        />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(progressRingValue(container)).toBeCloseTo(0.58, 2);
+
+      rerender(
+        <UpdateActionButton
+          state={{
+            type: "updating",
+            progress: HomebrewMaintenanceProgressStage.installing
+          }}
+          onAction={() => undefined}
+        />
+      );
+      expect(progressRingValue(container)).toBeCloseTo(HomebrewMaintenanceProgressStage.installing);
+
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(progressRingValue(container)).toBeCloseTo(0.84, 2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps Homebrew app updates clickable during active Homebrew commands", () => {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -61,6 +61,7 @@ import {
   isCask,
   normalizedHomebrewAppName
 } from "../shared/homebrewAppLinking";
+import { HomebrewMaintenanceProgressStage } from "../shared/homebrewProgress";
 import { compareVersions } from "../shared/version";
 import "./styles.css";
 
@@ -2768,10 +2769,89 @@ function rowActionMenuEstimatedHeight(
   return itemCount * 28 + 10;
 }
 
+type SyntheticProgressRange = {
+  floor: number;
+  cap: number;
+  speedMs: number;
+};
+
+const syntheticProgressRanges = {
+  starting: { cap: 0.28, speedMs: 5000 },
+  downloading: { cap: 0.58, speedMs: 9000 },
+  installing: { cap: 0.84, speedMs: 6500 },
+  finalizing: { cap: 0.96, speedMs: 3500 }
+} as const;
+
+function syntheticProgressRange(value: number): SyntheticProgressRange {
+  const clamped = clampProgress(value);
+  if (clamped >= HomebrewMaintenanceProgressStage.completed) {
+    return { floor: HomebrewMaintenanceProgressStage.completed, cap: 1, speedMs: 1 };
+  }
+  if (clamped >= HomebrewMaintenanceProgressStage.finalizing) {
+    return {
+      floor: Math.max(clamped, HomebrewMaintenanceProgressStage.finalizing),
+      ...syntheticProgressRanges.finalizing
+    };
+  }
+  if (clamped >= HomebrewMaintenanceProgressStage.installing) {
+    return {
+      floor: Math.max(clamped, HomebrewMaintenanceProgressStage.installing),
+      ...syntheticProgressRanges.installing
+    };
+  }
+  if (clamped >= HomebrewMaintenanceProgressStage.downloading) {
+    return {
+      floor: Math.max(clamped, HomebrewMaintenanceProgressStage.downloading),
+      ...syntheticProgressRanges.downloading
+    };
+  }
+  if (clamped > HomebrewMaintenanceProgressStage.queued) {
+    return {
+      floor: clamped,
+      ...syntheticProgressRanges.starting
+    };
+  }
+  return { floor: HomebrewMaintenanceProgressStage.queued, cap: 0, speedMs: 1 };
+}
+
+function clampProgress(value: number): number {
+  return Math.max(0, Math.min(value, 1));
+}
+
+function easedProgress(range: SyntheticProgressRange, elapsedMs: number): number {
+  if (range.cap <= range.floor) {
+    return range.floor;
+  }
+  return range.floor + (range.cap - range.floor) * (1 - Math.exp(-elapsedMs / range.speedMs));
+}
+
+function useSyntheticProgress(value: number): number {
+  const range = syntheticProgressRange(value);
+  const [renderedProgress, setRenderedProgress] = useState(range.floor);
+
+  useEffect(() => {
+    setRenderedProgress(range.floor);
+    if (range.cap <= range.floor) {
+      return;
+    }
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      const nextProgress = easedProgress(range, Date.now() - startedAt);
+      setRenderedProgress(nextProgress);
+      if (range.cap - nextProgress < 0.001) {
+        window.clearInterval(timer);
+      }
+    }, 120);
+    return () => window.clearInterval(timer);
+  }, [range.floor, range.cap, range.speedMs]);
+
+  return Math.min(Math.max(renderedProgress, range.floor), range.cap);
+}
+
 function ProgressRing({ value }: { value: number }) {
   const radius = 6;
   const circumference = 2 * Math.PI * radius;
-  const clamped = Math.max(0, Math.min(value, 1));
+  const progress = useSyntheticProgress(value);
   return (
     <svg className="progress-ring" viewBox="0 0 16 16" aria-hidden="true">
       <circle className="progress-ring-track" cx="8" cy="8" r={radius} />
@@ -2781,7 +2861,7 @@ function ProgressRing({ value }: { value: number }) {
         cy="8"
         r={radius}
         strokeDasharray={circumference}
-        strokeDashoffset={circumference * (1 - clamped)}
+        strokeDashoffset={circumference * (1 - progress)}
       />
     </svg>
   );

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2769,8 +2769,7 @@ function rowActionMenuEstimatedHeight(
   return itemCount * 28 + 10;
 }
 
-type SyntheticProgressRange = {
-  floor: number;
+type SyntheticProgressTarget = {
   cap: number;
   speedMs: number;
 };
@@ -2782,73 +2781,61 @@ const syntheticProgressRanges = {
   finalizing: { cap: 0.96, speedMs: 3500 }
 } as const;
 
-function syntheticProgressRange(value: number): SyntheticProgressRange {
+function syntheticProgressTarget(value: number): SyntheticProgressTarget {
   const clamped = clampProgress(value);
   if (clamped >= HomebrewMaintenanceProgressStage.completed) {
-    return { floor: HomebrewMaintenanceProgressStage.completed, cap: 1, speedMs: 1 };
+    return { cap: 1, speedMs: 1 };
   }
   if (clamped >= HomebrewMaintenanceProgressStage.finalizing) {
-    return {
-      floor: Math.max(clamped, HomebrewMaintenanceProgressStage.finalizing),
-      ...syntheticProgressRanges.finalizing
-    };
+    return syntheticProgressRanges.finalizing;
   }
   if (clamped >= HomebrewMaintenanceProgressStage.installing) {
-    return {
-      floor: Math.max(clamped, HomebrewMaintenanceProgressStage.installing),
-      ...syntheticProgressRanges.installing
-    };
+    return syntheticProgressRanges.installing;
   }
   if (clamped >= HomebrewMaintenanceProgressStage.downloading) {
-    return {
-      floor: Math.max(clamped, HomebrewMaintenanceProgressStage.downloading),
-      ...syntheticProgressRanges.downloading
-    };
+    return syntheticProgressRanges.downloading;
   }
-  if (clamped > HomebrewMaintenanceProgressStage.queued) {
-    return {
-      floor: clamped,
-      ...syntheticProgressRanges.starting
-    };
-  }
-  return {
-    floor: HomebrewMaintenanceProgressStage.queued,
-    ...syntheticProgressRanges.starting
-  };
+  return syntheticProgressRanges.starting;
 }
 
 function clampProgress(value: number): number {
   return Math.max(0, Math.min(value, 1));
 }
 
-function easedProgress(range: SyntheticProgressRange, elapsedMs: number): number {
-  if (range.cap <= range.floor) {
-    return range.floor;
+function easedProgress(start: number, target: SyntheticProgressTarget, elapsedMs: number): number {
+  if (target.cap <= start) {
+    return start;
   }
-  return range.floor + (range.cap - range.floor) * (1 - Math.exp(-elapsedMs / range.speedMs));
+  return start + (target.cap - start) * (1 - Math.exp(-elapsedMs / target.speedMs));
 }
 
 function useSyntheticProgress(value: number): number {
-  const range = syntheticProgressRange(value);
-  const [renderedProgress, setRenderedProgress] = useState(range.floor);
+  const initialProgress = Math.min(clampProgress(value), syntheticProgressTarget(value).cap);
+  const [renderedProgress, setRenderedProgress] = useState(initialProgress);
+  const renderedProgressRef = useRef(renderedProgress);
 
   useEffect(() => {
-    setRenderedProgress(range.floor);
-    if (range.cap <= range.floor) {
+    renderedProgressRef.current = renderedProgress;
+  }, [renderedProgress]);
+
+  const target = syntheticProgressTarget(value);
+  useEffect(() => {
+    const start = renderedProgressRef.current;
+    if (target.cap <= start) {
       return;
     }
     const startedAt = Date.now();
     const timer = window.setInterval(() => {
-      const nextProgress = easedProgress(range, Date.now() - startedAt);
+      const nextProgress = easedProgress(start, target, Date.now() - startedAt);
       setRenderedProgress(nextProgress);
-      if (range.cap - nextProgress < 0.001) {
+      if (target.cap - nextProgress < 0.001) {
         window.clearInterval(timer);
       }
     }, 120);
     return () => window.clearInterval(timer);
-  }, [range.floor, range.cap, range.speedMs]);
+  }, [target.cap, target.speedMs]);
 
-  return Math.min(Math.max(renderedProgress, range.floor), range.cap);
+  return Math.min(renderedProgress, target.cap);
 }
 
 function ProgressRing({ value }: { value: number }) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2811,7 +2811,10 @@ function syntheticProgressRange(value: number): SyntheticProgressRange {
       ...syntheticProgressRanges.starting
     };
   }
-  return { floor: HomebrewMaintenanceProgressStage.queued, cap: 0, speedMs: 1 };
+  return {
+    floor: HomebrewMaintenanceProgressStage.queued,
+    ...syntheticProgressRanges.starting
+  };
 }
 
 function clampProgress(value: number): number {


### PR DESCRIPTION
## Summary
- Add renderer-only synthetic easing for Homebrew progress rings so each real Homebrew stage advances gradually toward a stage cap instead of sitting on a fixed value.
- Keep Homebrew output as the source of truth for stage transitions and completion while preserving existing update button labels and action states.
- Cover progress easing and stage reset behavior in renderer button tests.

## Validation
- `npm test`
- `npm test -- --run ElectronTests/rendererButtons.test.tsx ElectronTests/homebrewProgress.test.ts ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`