### PR TITLE
Keep native macOS App Store apps on Mac lookup path

### DIFF
--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -265,6 +265,8 @@ describe("bundle scanner", () => {
         "  <string>macosx26.5</string>",
         "  <key>LSMinimumSystemVersion</key>",
         "  <string>26.0</string>",
+        "  <key>UIDesignRequiresCompatibility</key>",
+        "  <true/>",
         "  <key>UIApplicationSceneManifest</key>",
         "  <dict>",
         "    <key>UIApplicationSupportsMultipleScenes</key>",

--- a/ElectronTests/bundleScanner.test.ts
+++ b/ElectronTests/bundleScanner.test.ts
@@ -204,7 +204,7 @@ describe("bundle scanner", () => {
     });
   });
 
-  it("marks App Store UIKit Mac bundles as App Store software lookup eligible", async () => {
+  it("marks receipt-backed UIKit iPad bundles as App Store software lookup eligible", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
     tempDirs.push(root);
 
@@ -241,6 +241,53 @@ describe("bundle scanner", () => {
       bundleIdentifier: "com.example.uikit-mac",
       sourceHint: "appStore",
       isIOSAppOnMac: true,
+      hasAppStoreEvidence: true
+    });
+  });
+
+  it("does not enable iOS software lookup for native macOS UIKit App Store bundles", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "baseline-scan-"));
+    tempDirs.push(root);
+
+    const appPath = path.join(root, "Native UIKit Mac App.app");
+    await writeAppPlist(appPath, {
+      displayName: "Native UIKit Mac App",
+      bundleIdentifier: "com.example.native-uikit-mac",
+      version: "1.0.0",
+      extraKeys: [
+        "  <key>CFBundleSupportedPlatforms</key>",
+        "  <array>",
+        "    <string>MacOSX</string>",
+        "  </array>",
+        "  <key>DTPlatformName</key>",
+        "  <string>macosx</string>",
+        "  <key>DTSDKName</key>",
+        "  <string>macosx26.5</string>",
+        "  <key>LSMinimumSystemVersion</key>",
+        "  <string>26.0</string>",
+        "  <key>UIApplicationSceneManifest</key>",
+        "  <dict>",
+        "    <key>UIApplicationSupportsMultipleScenes</key>",
+        "    <false/>",
+        "  </dict>",
+        "  <key>UIDeviceFamily</key>",
+        "  <array>",
+        "    <integer>2</integer>",
+        "  </array>",
+        "  <key>UILaunchStoryboardName</key>",
+        "  <string>LaunchScreen</string>"
+      ].join("\n")
+    });
+    await mkdir(path.join(appPath, "Contents", "_MASReceipt"), { recursive: true });
+    await writeFile(path.join(appPath, "Contents", "_MASReceipt", "receipt"), "receipt");
+
+    const records = await new BundleScannerClient().scanApplications([root]);
+
+    expect(records[0]).toMatchObject({
+      bundlePath: appPath,
+      bundleIdentifier: "com.example.native-uikit-mac",
+      sourceHint: "appStore",
+      isIOSAppOnMac: false,
       hasAppStoreEvidence: true
     });
   });

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -357,6 +357,9 @@ function isIOSAppOnMacInfo(info: InfoPlist): boolean {
 }
 
 function isUIKitMacAppStoreInfo(info: InfoPlist): boolean {
+  if (hasNativeMacOSBuildMetadata(info)) {
+    return false;
+  }
   const deviceFamily = numberArrayValue(info.UIDeviceFamily);
   if (deviceFamily.includes(6)) {
     return false;
@@ -367,6 +370,12 @@ function isUIKitMacAppStoreInfo(info: InfoPlist): boolean {
     stringValue(info.UIMainStoryboardFile) !== undefined ||
     stringValue(info.UILaunchStoryboardName) !== undefined;
   return hasUIKitDeviceFamily && hasUIKitLifecycle;
+}
+
+function hasNativeMacOSBuildMetadata(info: InfoPlist): boolean {
+  const platformName = stringValue(info.DTPlatformName)?.toLowerCase();
+  const sdkName = stringValue(info.DTSDKName)?.toLowerCase();
+  return platformName === "macosx" || sdkName?.startsWith("macosx") === true;
 }
 
 function iconCandidatePaths(resourcesPath: string, info: InfoPlist): string[] {

--- a/src/main/bundleScanner.ts
+++ b/src/main/bundleScanner.ts
@@ -349,11 +349,13 @@ function numberArrayValue(value: unknown): number[] {
 }
 
 function isIOSAppOnMacInfo(info: InfoPlist): boolean {
-  return (
-    info.LSRequiresIPhoneOS === true ||
-    info.UIDesignRequiresCompatibility === true ||
-    stringArrayValue(info.CFBundleSupportedPlatforms).includes("iPhoneOS")
-  );
+  if (stringArrayValue(info.CFBundleSupportedPlatforms).includes("iPhoneOS")) {
+    return true;
+  }
+  if (hasNativeMacOSBuildMetadata(info)) {
+    return false;
+  }
+  return info.LSRequiresIPhoneOS === true || info.UIDesignRequiresCompatibility === true;
 }
 
 function isUIKitMacAppStoreInfo(info: InfoPlist): boolean {


### PR DESCRIPTION
## Summary
- Native macOS App Store bundles that include UIKit/iPad compatibility metadata could be classified as iOS-on-Mac, causing Baseline to accept iOS `software` catalog versions as updates for the Mac app.
- Treat native macOS build evidence such as `DTPlatformName=macosx` and `DTSDKName=macosx...` as a guard before `UIDesignRequiresCompatibility` or receipt-backed UIKit heuristics enable iOS lookup.
- Add scanner regression coverage for native macOS UIKit App Store bundles while preserving existing iOS-on-Mac lookup eligibility.

## Validation
- `npm test -- --run ElectronTests/bundleScanner.test.ts ElectronTests/clients.test.ts ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`