### PR TITLE
Require installed cask ownership for app updates

### DIFF
--- a/ElectronTests/diagnostics.test.ts
+++ b/ElectronTests/diagnostics.test.ts
@@ -150,6 +150,9 @@ describe("diagnostics report", () => {
       "darwin"
     );
 
+    expect(report).toContain("- Scanned app bundles: 4");
+    expect(report).toContain("- App bundles linked to Homebrew casks: 1");
+    expect(report).toContain("- App bundles not linked to Homebrew casks: 3");
     expect(report).toContain(
       "- Source hints: App Store: 1, In-app updater: 1, Unknown: 1, Homebrew: 1"
     );
@@ -165,6 +168,7 @@ describe("diagnostics report", () => {
     expect(report).toContain("- Homebrew detected: Yes");
     expect(report).toContain("- Formulae: 1");
     expect(report).toContain("- Casks: 2");
+    expect(report).toContain("- Cask presentations: App Cask: 1, CLI Cask: 1");
     expect(report).toContain("- App-linked casks: 1");
   });
 

--- a/ElectronTests/diagnostics.test.ts
+++ b/ElectronTests/diagnostics.test.ts
@@ -84,7 +84,8 @@ describe("diagnostics report", () => {
     });
     const directDownloadApp = appRecord({
       id: "app:direct",
-      displayName: "Direct App"
+      displayName: "Direct App",
+      bundleIdentifier: "com.example.direct"
     });
     const homebrewApp = appRecord({
       id: "app:managed",
@@ -157,9 +158,48 @@ describe("diagnostics report", () => {
     expect(report).toContain("- Direct-download candidates without known feed: 1");
     expect(report).toContain("- Homebrew app updates with installed cask link: 1");
     expect(report).toContain("- Homebrew app updates without installed cask link: 1");
+    expect(report).toContain("- Listed: 1 of 1");
+    expect(report).toContain(
+      "- Direct App | bundle: com.example.direct | hint: Unknown | selected: Homebrew | action: Open app | linked cask: No | reason: Homebrew selected without installed cask link"
+    );
     expect(report).toContain("- Homebrew detected: Yes");
     expect(report).toContain("- Formulae: 1");
     expect(report).toContain("- Casks: 2");
     expect(report).toContain("- App-linked casks: 1");
+  });
+
+  it("caps route exception rows without including full app paths", () => {
+    const apps = Array.from({ length: 12 }, (_, index) =>
+      appRecord({
+        id: `app:route-exception-${index + 1}`,
+        bundlePath: `/Sensitive/Route Exception ${index + 1}.app`,
+        bundleIdentifier: `com.example.route-exception-${index + 1}`,
+        displayName: `Route Exception ${index + 1}`
+      })
+    );
+    const updates = apps.map((app, index) =>
+      appUpdate({
+        appID: app.id,
+        id: app.id,
+        source: "homebrew",
+        supportLevel: "limited",
+        homebrewToken: `route-exception-${index + 1}`,
+        updateURL: `https://formulae.brew.sh/cask/route-exception-${index + 1}`
+      })
+    );
+
+    const report = renderDiagnostics(
+      snapshot({
+        apps,
+        updates
+      }),
+      "0.2.0",
+      "darwin"
+    );
+
+    expect(report).toContain("- Listed: 10 of 12 (truncated)");
+    expect(report).toContain("Route Exception 10 | bundle: com.example.route-exception-10");
+    expect(report).not.toContain("Route Exception 11 | bundle: com.example.route-exception-11");
+    expect(report).not.toContain("/Sensitive/Route Exception");
   });
 });

--- a/ElectronTests/diagnostics.test.ts
+++ b/ElectronTests/diagnostics.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { describe, expect, it } from "vitest";
+import { renderDiagnostics } from "../src/shared/diagnostics";
+import type {
+  AppRecord,
+  BaselineSnapshot,
+  HomebrewManagedItem,
+  UpdateRecord
+} from "../src/shared/domain";
+import { defaultPersistedSnapshot } from "../src/shared/domain";
+import { version } from "../src/shared/version";
+
+function appRecord(patch: Partial<AppRecord>): AppRecord {
+  return {
+    id: "app:example",
+    bundlePath: "/Applications/Example.app",
+    displayName: "Example",
+    bundleIdentifier: "com.example.app",
+    localVersion: version("1.0.0"),
+    sourceHint: "unknown",
+    ...patch
+  };
+}
+
+function appUpdate(patch: Partial<UpdateRecord>): UpdateRecord {
+  return {
+    id: "app:example",
+    appID: "app:example",
+    source: "sparkle",
+    supportLevel: "limited",
+    localVersion: version("1.0.0"),
+    remoteVersion: version("2.0.0"),
+    checkedAt: "2026-06-28T12:00:00.000Z",
+    ...patch
+  };
+}
+
+function snapshot(patch: Partial<BaselineSnapshot> = {}): BaselineSnapshot {
+  return {
+    ...defaultPersistedSnapshot(),
+    isMasInstalled: false,
+    isHomebrewInstalled: false,
+    isChecking: false,
+    isRefreshing: false,
+    searchText: "",
+    isRunningHomebrewMaintenance: false,
+    isHomebrewCommandLocked: false,
+    appUpdatingIDs: [],
+    appUpdatedPendingRefreshIDs: [],
+    homebrewUpdatingItemIDs: [],
+    homebrewQueuedItemIDs: [],
+    homebrewUninstallingItemIDs: [],
+    homebrewUpdatedPendingRefreshItemIDs: [],
+    homebrewBatchProgressByItemID: {},
+    homebrewBatchFailedItemIDs: [],
+    homebrewFallbackProgressByAppID: {},
+    homebrewFallbackFailedAppIDs: [],
+    homebrewDiscoverItems: [],
+    homebrewDiscoverInstallingItemIDs: [],
+    homebrewDiscoverInstalledPendingRefreshItemIDs: [],
+    homebrewDiscoverFailedItemIDs: [],
+    homebrewDiscoverProgressByItemID: {},
+    laggingHomebrewCaskTokens: [],
+    defaultScanDirectories: ["/Applications"],
+    ...patch
+  };
+}
+
+describe("diagnostics report", () => {
+  it("includes update source routing evidence without treating Homebrew as ownership", () => {
+    const appStoreApp = appRecord({
+      id: "app:store",
+      displayName: "Store App",
+      sourceHint: "appStore",
+      hasAppStoreEvidence: true
+    });
+    const publisherUpdaterApp = appRecord({
+      id: "app:publisher",
+      displayName: "Publisher App",
+      sourceHint: "sparkle",
+      sparkleFeedURL: "https://updates.example.com/appcast.xml"
+    });
+    const directDownloadApp = appRecord({
+      id: "app:direct",
+      displayName: "Direct App"
+    });
+    const homebrewApp = appRecord({
+      id: "app:managed",
+      displayName: "Managed App",
+      sourceHint: "homebrew"
+    });
+    const linkedCask: HomebrewManagedItem = {
+      id: "cask:managed",
+      token: "managed",
+      name: "Managed App",
+      kind: "cask",
+      appID: homebrewApp.id,
+      presentation: "app",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    };
+    const standaloneCask: HomebrewManagedItem = {
+      id: "cask:standalone-tool",
+      token: "standalone-tool",
+      name: "standalone-tool",
+      kind: "cask",
+      presentation: "cli",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.0.0"),
+      isOutdated: false
+    };
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.1.0"),
+      isOutdated: true
+    };
+
+    const report = renderDiagnostics(
+      snapshot({
+        apps: [appStoreApp, publisherUpdaterApp, directDownloadApp, homebrewApp],
+        updates: [
+          appUpdate({ appID: publisherUpdaterApp.id, id: publisherUpdaterApp.id }),
+          appUpdate({
+            appID: homebrewApp.id,
+            id: homebrewApp.id,
+            source: "homebrew",
+            supportLevel: "supported",
+            homebrewToken: linkedCask.token
+          }),
+          appUpdate({
+            appID: directDownloadApp.id,
+            id: directDownloadApp.id,
+            source: "homebrew",
+            supportLevel: "limited",
+            homebrewToken: "direct-app"
+          })
+        ],
+        homebrewItems: [linkedCask, standaloneCask, formula],
+        isHomebrewInstalled: true
+      }),
+      { version: "0.2.0", buildNumber: "42" },
+      "darwin"
+    );
+
+    expect(report).toContain(
+      "- Source hints: App Store: 1, In-app updater: 1, Unknown: 1, Homebrew: 1"
+    );
+    expect(report).toContain("- Update sources: In-app updater: 1, Homebrew: 2");
+    expect(report).toContain("- Apps with publisher updater feed: 1");
+    expect(report).toContain("- Direct-download candidates without known feed: 1");
+    expect(report).toContain("- Homebrew app updates with installed cask link: 1");
+    expect(report).toContain("- Homebrew app updates without installed cask link: 1");
+    expect(report).toContain("- Homebrew detected: Yes");
+    expect(report).toContain("- Formulae: 1");
+    expect(report).toContain("- Casks: 2");
+    expect(report).toContain("- App-linked casks: 1");
+  });
+});

--- a/ElectronTests/homebrewAppLinking.test.ts
+++ b/ElectronTests/homebrewAppLinking.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import { homebrewItemHasAppRepresentation } from "../src/shared/homebrewAppLinking";
-import type { AppRecord, HomebrewManagedItem, UpdateRecord } from "../src/shared/domain";
+import type { AppRecord, HomebrewManagedItem } from "../src/shared/domain";
 import { version } from "../src/shared/version";
 
 const app: AppRecord = {
@@ -26,58 +26,27 @@ const codeCask: HomebrewManagedItem = {
 };
 
 describe("Homebrew app linking", () => {
-  it("matches casks to app updates by Homebrew token", () => {
-    const update: UpdateRecord = {
-      id: app.id,
-      appID: app.id,
-      source: "homebrew",
-      supportLevel: "supported",
-      localVersion: version("1.0.0"),
-      remoteVersion: version("2.0.0"),
-      homebrewToken: "visual-studio-code",
-      checkedAt: "2026-04-30T12:00:00.000Z"
-    };
-
-    expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map([[app.id, update]]))).toBe(
-      true
-    );
+  it("does not use token-only Homebrew updates as app-backed proof", () => {
+    expect(homebrewItemHasAppRepresentation(codeCask, [app])).toBe(false);
   });
 
   it("matches casks to ignored apps by explicit app link", () => {
-    expect(homebrewItemHasAppRepresentation({ ...codeCask, appID: app.id }, [app], new Map())).toBe(
-      true
-    );
+    expect(homebrewItemHasAppRepresentation({ ...codeCask, appID: app.id }, [app])).toBe(true);
   });
 
   it("does not use app bundle names alone as app-backed proof", () => {
-    expect(homebrewItemHasAppRepresentation(codeCask, [app], new Map())).toBe(false);
+    expect(homebrewItemHasAppRepresentation(codeCask, [app])).toBe(false);
   });
 
-  it("does not use token-only Homebrew updates as app-backed proof for Sparkle-origin apps", () => {
+  it("still keeps explicitly linked Sparkle-origin casks represented by app rows", () => {
     const sparkleApp = {
       ...app,
       sourceHint: "sparkle" as const
     };
-    const update: UpdateRecord = {
-      id: sparkleApp.id,
-      appID: sparkleApp.id,
-      source: "homebrew",
-      supportLevel: "limited",
-      localVersion: version("1.0.0"),
-      remoteVersion: version("2.0.0"),
-      homebrewToken: "visual-studio-code",
-      checkedAt: "2026-04-30T12:00:00.000Z"
-    };
 
+    expect(homebrewItemHasAppRepresentation(codeCask, [sparkleApp])).toBe(false);
     expect(
-      homebrewItemHasAppRepresentation(codeCask, [sparkleApp], new Map([[sparkleApp.id, update]]))
-    ).toBe(false);
-    expect(
-      homebrewItemHasAppRepresentation(
-        { ...codeCask, appID: sparkleApp.id },
-        [sparkleApp],
-        new Map([[sparkleApp.id, update]])
-      )
+      homebrewItemHasAppRepresentation({ ...codeCask, appID: sparkleApp.id }, [sparkleApp])
     ).toBe(true);
   });
 
@@ -92,6 +61,6 @@ describe("Homebrew app linking", () => {
       isOutdated: true
     };
 
-    expect(homebrewItemHasAppRepresentation(formula, [app], new Map())).toBe(false);
+    expect(homebrewItemHasAppRepresentation(formula, [app])).toBe(false);
   });
 });

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -223,6 +223,7 @@ describe("renderer button parity", () => {
 
     expect(screen.getByText("1.0 (100)")).toBeInTheDocument();
     expect(screen.getByText("1.0 (101)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open updater" })).toBeInTheDocument();
   });
 
   it("shows matched Homebrew cask progress on app update buttons", () => {
@@ -429,9 +430,12 @@ describe("renderer button parity", () => {
       />
     );
 
-    const updateButton = screen.getByRole("button", { name: "Update" });
+    const updateButton = screen
+      .getAllByRole("button", { name: "Open app" })
+      .find((button) => button.classList.contains("update-action-button"));
+    expect(updateButton).toBeDefined();
     expect(updateButton).toBeEnabled();
-    fireEvent.click(updateButton);
+    fireEvent.click(updateButton as HTMLButtonElement);
     expect(window.baseline.performAppUpdate).toHaveBeenCalledWith(sparkleBackedApp.id);
   });
 
@@ -936,7 +940,7 @@ describe("renderer button parity", () => {
 
     expect(screen.getByText("Example")).toBeInTheDocument();
     expect(screen.getByText("example-cask")).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Open app" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Open app" })).toHaveLength(2);
   });
 
   it("shows settings sections as sidebar tabs without search-filtered badges", () => {
@@ -989,6 +993,33 @@ describe("renderer button parity", () => {
     expect(screen.queryByRole("button", { name: "All" })).not.toBeInTheDocument();
     expect(screen.queryByText("Stable App")).not.toBeInTheDocument();
     expect(screen.queryByText("ripgrep")).not.toBeInTheDocument();
+  });
+
+  it("shows when Homebrew is installed but has no installed casks", () => {
+    const formula: HomebrewManagedItem = {
+      id: "formula:ripgrep",
+      token: "ripgrep",
+      name: "ripgrep",
+      kind: "formula",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.1.0"),
+      isOutdated: true
+    };
+
+    render(
+      <SettingsView
+        snapshot={snapshot({
+          homebrewItems: [formula],
+          isHomebrewInstalled: true
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "Homebrew detected with 0 installed casks and 1 formula; app updates will not use Homebrew unless a matching cask is installed."
+      )
+    ).toBeInTheDocument();
   });
 
   it("shows local profile stats in a settings tab below general", () => {
@@ -1193,7 +1224,7 @@ describe("renderer button parity", () => {
     ).toEqual(["Total updates", "Unique apps", "Homebrew Installs", "Favorite source"]);
     expect(
       [...document.querySelectorAll(".profile-metric strong")].map((metric) => metric.textContent)
-    ).toEqual(["10", "4", "1", "Sparkle"]);
+    ).toEqual(["10", "4", "1", "In-app updater"]);
     expect(screen.queryByText("Favorite channel")).not.toBeInTheDocument();
     expect(screen.getByText("Favorite source")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Source mix" })).not.toBeInTheDocument();
@@ -1212,11 +1243,11 @@ describe("renderer button parity", () => {
     expect(
       screen.queryByText("Tools you update with Baseline will appear here.")
     ).not.toBeInTheDocument();
-    expect(screen.getByText("5 updates via Sparkle")).toBeInTheDocument();
+    expect(screen.getByText("5 updates via In-app updater")).toBeInTheDocument();
     expect(screen.getByText("50%")).toBeInTheDocument();
-    expect(screen.queryByText("Sparkle 45%")).not.toBeInTheDocument();
-    expect(screen.getAllByLabelText("Sparkle: 5 updates (50%)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Sparkle").length).toBeGreaterThan(0);
+    expect(screen.queryByText("In-app updater 45%")).not.toBeInTheDocument();
+    expect(screen.getAllByLabelText("In-app updater: 5 updates (50%)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("In-app updater").length).toBeGreaterThan(0);
     expect(document.querySelector(".profile-start-panel-box")?.hasAttribute("title")).toBe(false);
     const sourceSegment = document.querySelector(".profile-source-segment") as HTMLElement;
     expect(sourceSegment).not.toBeNull();
@@ -2669,7 +2700,7 @@ describe("renderer button parity", () => {
     );
 
     expect(
-      within(container.querySelector(".recent-card") as HTMLElement).getByText("Sparkle")
+      within(container.querySelector(".recent-card") as HTMLElement).getByText("In-app updater")
     ).toBeInTheDocument();
 
     rerender(

--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -39,6 +39,7 @@ const cask: HomebrewManagedItem = {
   token: "example",
   name: "Example",
   kind: "cask",
+  appID: app.id,
   installedVersion: version("1.0.0"),
   latestVersion: version("2.0.0"),
   isOutdated: true
@@ -916,6 +917,7 @@ describe("renderer button parity", () => {
     };
     const fallbackCask: HomebrewManagedItem = {
       ...cask,
+      appID: undefined,
       name: "example-cask",
       presentation: "app"
     };
@@ -2182,7 +2184,7 @@ describe("renderer button parity", () => {
           searchText: "cli",
           ignoredIDs: [app.id],
           updates: [{ ...update, homebrewToken: searchCask.token }],
-          homebrewItems: [searchCask, formula]
+          homebrewItems: [{ ...searchCask, appID: app.id }, formula]
         })}
       />
     );
@@ -2490,6 +2492,7 @@ describe("renderer button parity", () => {
     };
     const standaloneCask: HomebrewManagedItem = {
       ...cask,
+      appID: undefined,
       id: "cask:standalone",
       token: "standalone",
       name: "Standalone",
@@ -2840,7 +2843,8 @@ describe("renderer button parity", () => {
       ...cask,
       id: "cask:long-token-name",
       token: "long-token-name",
-      name: "Long Token Name"
+      name: "Long Token Name",
+      appID: shortNamedApp.id
     };
 
     render(
@@ -2979,6 +2983,7 @@ describe("renderer button parity", () => {
     };
     const nonAppCask: HomebrewManagedItem = {
       ...cask,
+      appID: undefined,
       id: "cask:managed",
       token: "managed",
       name: "managed",

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -725,15 +725,43 @@ describe("update store helpers", () => {
       sparkleFeedURL: "https://updates.example.com/appcast.xml",
       localVersion: version("1.0.0")
     });
+    const precedenceCaskEntry = {
+      token: "precedence",
+      version: version("2.0.0"),
+      presentation: "app" as const,
+      bundleIdentifiers: ["com.example.precedence"],
+      appBundleNames: ["precedence.app"]
+    };
     const clients = {
       scanner: { scanApplications: async () => [precedenceApp] },
       homebrew: {
-        fetchIndex: async () => emptyHomebrewCaskIndex,
+        fetchIndex: async () => ({
+          byToken: { precedence: precedenceCaskEntry },
+          byBundleIdentifier: { "com.example.precedence": precedenceCaskEntry },
+          byAppBundleName: { "precedence.app": [precedenceCaskEntry] }
+        }),
         lookupUpdate: () => ({
           remoteVersion: version("2.0.0"),
           token: "precedence"
         }),
         searchCasks: () => []
+      },
+      homebrewInventory: {
+        fetchInventory: async () => ({
+          items: [
+            homebrewItem({
+              id: "cask:precedence",
+              token: "precedence",
+              name: "Precedence",
+              kind: "cask",
+              installedVersion: version("1.0.0"),
+              latestVersion: version("2.0.0"),
+              isOutdated: true
+            })
+          ],
+          outdatedDetectionSucceeded: true,
+          outdatedDetectionSucceededByKind: { formula: true, cask: true }
+        })
       }
     };
     const storeWithAppStore = await makeStore({
@@ -2370,6 +2398,7 @@ describe("update store helpers", () => {
             token: "homebrew-managed",
             name: "Homebrew Managed",
             kind: "cask",
+            appID: app.id,
             installedVersion: version("1.0.0"),
             latestVersion: version("2.0.0"),
             isOutdated: true
@@ -2428,6 +2457,7 @@ describe("update store helpers", () => {
             token: "homebrew-managed",
             name: "Homebrew Managed",
             kind: "cask",
+            appID: app.id,
             installedVersion: version("1.0.0"),
             isOutdated: false
           })
@@ -2444,7 +2474,7 @@ describe("update store helpers", () => {
     ]);
   });
 
-  it("uses external fallback for unmanaged Homebrew-backed app updates", async () => {
+  it("does not create Homebrew app updates without installed cask ownership", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Manual Homebrew Match.app",
       displayName: "Manual Homebrew Match",
@@ -2455,6 +2485,14 @@ describe("update store helpers", () => {
     const openExternalURL = vi.fn(async () => true);
     const openAppBundle = vi.fn(async () => undefined);
     const runBrewCommand = vi.fn(async () => ({ success: true, status: 0, output: "" }));
+    const caskEntry = {
+      token: "manual-homebrew-match",
+      version: version("2.0.0"),
+      homepageURL: fallbackURL,
+      presentation: "app" as const,
+      bundleIdentifiers: ["com.example.manual-homebrew-match"],
+      appBundleNames: ["manual homebrew match.app"]
+    };
     const store = await makeStore({
       openExternalURL,
       openAppBundle,
@@ -2462,7 +2500,11 @@ describe("update store helpers", () => {
       clients: {
         scanner: { scanApplications: async () => [app] },
         homebrew: {
-          fetchIndex: async () => emptyHomebrewCaskIndex,
+          fetchIndex: async () => ({
+            byToken: { "manual-homebrew-match": caskEntry },
+            byBundleIdentifier: { "com.example.manual-homebrew-match": caskEntry },
+            byAppBundleName: { "manual homebrew match.app": [caskEntry] }
+          }),
           lookupUpdate: () => ({
             remoteVersion: version("2.0.0"),
             token: "manual-homebrew-match",
@@ -2472,17 +2514,7 @@ describe("update store helpers", () => {
         },
         homebrewInventory: {
           fetchInventory: async () => ({
-            items: [
-              homebrewItem({
-                id: "formula:manual-homebrew-match",
-                token: "manual-homebrew-match",
-                name: "manual-homebrew-match",
-                kind: "formula",
-                installedVersion: version("1.0.0"),
-                latestVersion: version("2.0.0"),
-                isOutdated: true
-              })
-            ],
+            items: [],
             outdatedDetectionSucceeded: true,
             outdatedDetectionSucceededByKind: { formula: true, cask: true }
           })
@@ -2491,16 +2523,10 @@ describe("update store helpers", () => {
     });
 
     await store.refresh(false);
-    expect(store.getSnapshot().updates[0]).toMatchObject({
-      source: "homebrew",
-      homebrewToken: "manual-homebrew-match",
-      updateURL: fallbackURL
-    });
 
-    await store.performAppUpdate(app.id);
-
+    expect(store.getSnapshot().updates).toEqual([]);
     expect(runBrewCommand).not.toHaveBeenCalled();
-    expect(openExternalURL).toHaveBeenCalledWith(fallbackURL);
+    expect(openExternalURL).not.toHaveBeenCalled();
     expect(openAppBundle).not.toHaveBeenCalled();
   });
 
@@ -2575,7 +2601,7 @@ describe("update store helpers", () => {
     ]);
   });
 
-  it("derives external fallback URLs for persisted Homebrew-backed app updates without URLs", async () => {
+  it("opens the app for persisted Homebrew-backed app updates without cask ownership", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Persisted Homebrew Match.app",
       displayName: "Persisted Homebrew Match",
@@ -2610,10 +2636,8 @@ describe("update store helpers", () => {
     await store.performAppUpdate(app.id);
 
     expect(runBrewCommand).not.toHaveBeenCalled();
-    expect(openExternalURL).toHaveBeenCalledWith(
-      "https://formulae.brew.sh/cask/persisted-homebrew-match"
-    );
-    expect(openAppBundle).not.toHaveBeenCalled();
+    expect(openExternalURL).not.toHaveBeenCalled();
+    expect(openAppBundle).toHaveBeenCalledWith(app.bundlePath);
   });
 
   it("rejects unsafe Homebrew-backed app update tokens", async () => {
@@ -4715,6 +4739,7 @@ describe("update store helpers", () => {
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
     >(async () => ({ success: true, status: 0, output: "" }));
     const openExternalURL = vi.fn(async () => true);
+    const openAppBundle = vi.fn(async () => undefined);
     const store = await makeStore({
       persisted: {
         ...defaultPersistedSnapshot(),
@@ -4734,13 +4759,15 @@ describe("update store helpers", () => {
         homebrewItems: [currentItem]
       },
       runBrewCommand,
-      openExternalURL
+      openExternalURL,
+      openAppBundle
     });
 
     await store.performAppUpdate(app.id);
 
     expect(runBrewCommand).not.toHaveBeenCalled();
-    expect(openExternalURL).toHaveBeenCalledWith("https://formulae.brew.sh/cask/example");
+    expect(openExternalURL).not.toHaveBeenCalled();
+    expect(openAppBundle).toHaveBeenCalledWith(app.bundlePath);
     expect(store.getSnapshot().homebrewUpdatingItemIDs).not.toContain(currentItem.id);
     expect(store.getSnapshot().homebrewQueuedItemIDs).not.toContain(currentItem.id);
   });

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -2601,6 +2601,56 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("removes persisted Homebrew app updates without installed cask ownership before refresh", async () => {
+    const app = appRecord({
+      bundlePath: "/Applications/Persisted Token Match.app",
+      displayName: "Persisted Token Match",
+      bundleIdentifier: "com.example.persisted-token-match",
+      localVersion: version("1.0.0")
+    });
+    const staleUpdate: UpdateRecord = {
+      id: app.id,
+      appID: app.id,
+      source: "homebrew",
+      supportLevel: "limited",
+      localVersion: version("1.0.0"),
+      remoteVersion: version("2.0.0"),
+      homebrewToken: "persisted-token-match",
+      updateURL: "https://formulae.brew.sh/cask/persisted-token-match",
+      checkedAt: "2026-05-20T12:00:00.000Z"
+    };
+    const tokenOnlyCask = homebrewItem({
+      id: "cask:persisted-token-match",
+      token: "persisted-token-match",
+      name: "Persisted Token Match",
+      kind: "cask",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("2.0.0"),
+      isOutdated: true
+    });
+    const staleStore = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [staleUpdate],
+        homebrewItems: [tokenOnlyCask]
+      }
+    });
+
+    expect(staleStore.getSnapshot().updates).toEqual([]);
+
+    const linkedStore = await makeStore({
+      persisted: {
+        ...defaultPersistedSnapshot(),
+        apps: [app],
+        updates: [staleUpdate],
+        homebrewItems: [{ ...tokenOnlyCask, appID: app.id }]
+      }
+    });
+
+    expect(linkedStore.getSnapshot().updates).toEqual([staleUpdate]);
+  });
+
   it("opens the app for persisted Homebrew-backed app updates without cask ownership", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Persisted Homebrew Match.app",
@@ -2640,7 +2690,7 @@ describe("update store helpers", () => {
     expect(openAppBundle).toHaveBeenCalledWith(app.bundlePath);
   });
 
-  it("rejects unsafe Homebrew-backed app update tokens", async () => {
+  it("removes unsafe persisted Homebrew-backed app update tokens before use", async () => {
     const app = appRecord({
       bundlePath: "/Applications/Unsafe Managed.app",
       displayName: "Unsafe Managed",
@@ -2668,10 +2718,12 @@ describe("update store helpers", () => {
       runBrewCommand
     });
 
+    expect(store.getSnapshot().updates).toEqual([]);
+
     await store.performAppUpdate(app.id);
 
     expect(runBrewCommand).not.toHaveBeenCalled();
-    expect(store.getSnapshot().refreshErrorMessage).toContain("Blocked unsafe Homebrew token");
+    expect(store.getSnapshot().refreshErrorMessage).toBeUndefined();
   });
 
   it("rejects unsafe direct Homebrew update tokens", async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -365,12 +365,11 @@ function trayUpdateTitle(snapshot: BaselineSnapshot): string {
   const appsRepresentedOutsideHomebrew = snapshot.apps.filter(
     (app) => visibleAppUpdateIDs.has(app.id) || ignored.has(app.id)
   );
-  const updatesByAppID = new Map(snapshot.updates.map((update) => [update.appID, update]));
   const visibleHomebrewUpdates = snapshot.homebrewItems.filter(
     (item) =>
       item.isOutdated &&
       !ignoredHomebrew.has(item.id) &&
-      !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
+      !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew)
   );
   const visibleUpdates = visibleAppUpdates.length + visibleHomebrewUpdates.length;
   if (visibleUpdates === 0) {

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -157,8 +157,9 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
     this.profileStatsIntegrity =
       options.profileStatsIntegrity ?? new KeychainProfileStatsIntegrity();
     this.successRefreshDelayMS = options.successRefreshDelayMS ?? successfulUpdateHoldMs;
+    const persisted = sanitizePersistedSnapshotForRuntime(options.persisted);
     this.state = {
-      ...options.persisted,
+      ...persisted,
       isMasInstalled: false,
       isHomebrewInstalled: false,
       isChecking: false,
@@ -1785,6 +1786,46 @@ function snapshotForPersistence(snapshot: BaselineSnapshot): PersistedSnapshot {
     profileStatsResetAcknowledgedID: snapshot.profileStatsResetAcknowledgedID,
     lastRefreshDate: snapshot.lastRefreshDate
   };
+}
+
+function sanitizePersistedSnapshotForRuntime(snapshot: PersistedSnapshot): PersistedSnapshot {
+  const updates = snapshot.updates.filter((update) =>
+    persistedUpdateHasValidRuntimeRoute(update, snapshot)
+  );
+
+  if (updates.length === snapshot.updates.length) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    updates
+  };
+}
+
+function persistedUpdateHasValidRuntimeRoute(
+  update: UpdateRecord,
+  snapshot: PersistedSnapshot
+): boolean {
+  if (update.source !== "homebrew") {
+    return true;
+  }
+
+  const token = update.homebrewToken?.toLowerCase();
+  if (!token || !isValidHomebrewToken(token)) {
+    return false;
+  }
+  if (!snapshot.apps.some((app) => app.id === update.appID)) {
+    return false;
+  }
+
+  return snapshot.homebrewItems.some(
+    (item) =>
+      item.kind === "cask" &&
+      item.appID === update.appID &&
+      item.token.toLowerCase() === token &&
+      isValidHomebrewToken(item.token)
+  );
 }
 
 function appUpdateProfileStatsEvent({

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -34,11 +34,7 @@ import {
 } from "../shared/homebrewProgress";
 import { homebrewItemHasAppRepresentation } from "../shared/homebrewAppLinking";
 import type { PreferencePatch } from "../shared/ipc";
-import {
-  isAllowedExternalURL,
-  isValidHomebrewToken,
-  sanitizeExternalURL
-} from "../shared/security";
+import { isAllowedExternalURL, isValidHomebrewToken } from "../shared/security";
 import {
   compareVersions,
   isVersionEmpty,
@@ -396,14 +392,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         });
         return;
       }
-      if (requiresHomebrewOwnershipProof(appRecord)) {
-        await this.routeExternalUpdate(appRecord, { ...update, updateURL: undefined });
-        return;
-      }
-      await this.routeExternalUpdate(appRecord, {
-        ...update,
-        updateURL: update.updateURL ?? homebrewCaskPageURL(update.homebrewToken)
-      });
+      await this.routeExternalUpdate(appRecord, { ...update, updateURL: undefined });
       return;
     }
 
@@ -824,8 +813,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         isValidHomebrewToken(item.token) &&
         !homebrewItemHasAppRepresentation(
           item,
-          requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew,
-          updatesByAppID
+          requestedItemIDs ? ignoredApps : appsRepresentedOutsideHomebrew
         )
     );
   }
@@ -1539,12 +1527,7 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
       (item) =>
         item.kind === "cask" &&
         item.token.toLowerCase() === token &&
-        (!requiresHomebrewOwnershipProof(appRecord) ||
-          homebrewCaskItemProvesAppOwnership(
-            item,
-            appRecord,
-            this.latestHomebrewIndex.byToken[token]
-          ))
+        homebrewCaskItemProvesAppOwnership(item, appRecord, this.latestHomebrewIndex.byToken[token])
     );
   }
 
@@ -1883,10 +1866,6 @@ function profileStatsChannel(
   return "unknown";
 }
 
-function homebrewCaskPageURL(token: string): string | undefined {
-  return sanitizeExternalURL(`https://formulae.brew.sh/cask/${token}`);
-}
-
 function toggleSet(set: Set<string>, value: string): void {
   if (set.has(value)) {
     set.delete(value);
@@ -2006,9 +1985,6 @@ function canUseHomebrewAppUpdate(
   homebrewItems: HomebrewManagedItem[],
   caskIndex: HomebrewCaskIndex
 ): boolean {
-  if (!requiresHomebrewOwnershipProof(appRecord)) {
-    return true;
-  }
   const token = homebrewToken.toLowerCase();
   return homebrewItems.some(
     (item) =>
@@ -2020,10 +1996,6 @@ function canUseHomebrewAppUpdate(
 
 function homebrewItemCanRunAppUpdate(item: HomebrewManagedItem, update: UpdateRecord): boolean {
   return item.isOutdated || isVersionGreater(update.remoteVersion, item.installedVersion);
-}
-
-function requiresHomebrewOwnershipProof(appRecord: AppRecord): boolean {
-  return appRecord.sourceHint === "sparkle";
 }
 
 function homebrewCaskItemProvesAppOwnership(

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -56,10 +56,8 @@ import {
 } from "../shared/domain";
 import {
   homebrewItemHasAppRepresentation,
-  homebrewItemIdentifiers,
   homebrewItemMatchesApp,
-  isCask,
-  normalizedHomebrewAppName
+  isCask
 } from "../shared/homebrewAppLinking";
 import { HomebrewMaintenanceProgressStage } from "../shared/homebrewProgress";
 import { compareVersions } from "../shared/version";
@@ -3806,8 +3804,7 @@ function buildProfileSummary(snapshot: BaselineSnapshot): ProfileSummary {
   const topHomebrewItems = buildTopUpdatedHomebrewItems(
     events,
     snapshot.homebrewItems,
-    snapshot.apps,
-    snapshot.updates
+    snapshot.apps
   );
   const totalUpdates = updateEvents.length;
   const differentApps = new Set(
@@ -3914,11 +3911,9 @@ function buildTopUpdatedApps(
 function buildTopUpdatedHomebrewItems(
   events: ProfileStatsEvent[],
   homebrewItems: HomebrewManagedItem[],
-  apps: AppRecord[],
-  updates: UpdateRecord[]
+  apps: AppRecord[]
 ): ProfileSummary["topHomebrewItems"] {
   const itemsByID = new Map(homebrewItems.map((item) => [item.id, item]));
-  const updatesByAppID = new Map(updates.map((update) => [update.appID, update]));
   const counts = new Map<
     string,
     {
@@ -3934,7 +3929,7 @@ function buildTopUpdatedHomebrewItems(
       continue;
     }
     const item = itemsByID.get(event.targetID);
-    if (!isProfileHomebrewToolEvent(event, item, apps, updatesByAppID)) {
+    if (!isProfileHomebrewToolEvent(event, item, apps)) {
       continue;
     }
     const current = counts.get(event.targetID);
@@ -3958,8 +3953,7 @@ function buildTopUpdatedHomebrewItems(
 function isProfileHomebrewToolEvent(
   event: ProfileStatsEvent,
   item: HomebrewManagedItem | undefined,
-  apps: AppRecord[],
-  updatesByAppID: Map<string, UpdateRecord>
+  apps: AppRecord[]
 ): boolean {
   if (item?.kind === "formula" || event.targetID.startsWith("formula:")) {
     return true;
@@ -3967,7 +3961,7 @@ function isProfileHomebrewToolEvent(
   if (!item) {
     return false;
   }
-  if (homebrewItemHasAppRepresentation(item, apps, updatesByAppID)) {
+  if (homebrewItemHasAppRepresentation(item, apps)) {
     return false;
   }
   if (item.presentation === "app") {
@@ -4190,8 +4184,7 @@ function deriveSections(snapshot: BaselineSnapshot) {
         (app) => updatesByAppID.has(app.id) || snapshot.ignoredIDs.includes(app.id)
       );
   const allHomebrewOutdated = homebrewOutdated.filter(
-    (item) =>
-      !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew, updatesByAppID)
+    (item) => !homebrewItemHasAppRepresentation(item, appsRepresentedOutsideHomebrew)
   );
   const homebrewInstalled = snapshot.homebrewItems
     .filter((item) => !item.isOutdated && !snapshot.ignoredHomebrewItemIDs.includes(item.id))
@@ -4235,22 +4228,7 @@ function matchingAppForHomebrewItem(
     return appFromExplicitLink;
   }
 
-  const identifiers = homebrewItemIdentifiers(item);
-  const matchingUpdate = snapshot.updates.find(
-    (update) =>
-      update.homebrewToken && identifiers.has(normalizedHomebrewAppName(update.homebrewToken))
-  );
-  const appFromUpdate = matchingUpdate
-    ? snapshot.apps.find((app) => app.id === matchingUpdate.appID)
-    : undefined;
-  if (appFromUpdate?.sourceHint === "sparkle") {
-    return undefined;
-  }
-  if (appFromUpdate?.iconDataURL) {
-    return appFromUpdate;
-  }
-
-  return appFromUpdate;
+  return undefined;
 }
 
 function uninstallableHomebrewItemForApp(
@@ -4262,20 +4240,6 @@ function uninstallableHomebrewItemForApp(
   );
   if (matchedByExplicitLink) {
     return matchedByExplicitLink;
-  }
-  if (app.sourceHint === "sparkle") {
-    return undefined;
-  }
-
-  const update = snapshot.updates.find((candidate) => candidate.appID === app.id);
-  if (update?.homebrewToken) {
-    const token = normalizedHomebrewAppName(update.homebrewToken);
-    const matchedByUpdate = snapshot.homebrewItems.find(
-      (item) => item.kind === "cask" && normalizedHomebrewAppName(item.token) === token
-    );
-    if (matchedByUpdate) {
-      return matchedByUpdate;
-    }
   }
 
   return undefined;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -77,6 +77,7 @@ type RequestActionConfirmation = (confirmation: ActionConfirmation) => void;
 type RowUpdateMenuAction = {
   state: ActionState;
   disabled?: boolean;
+  readyLabel?: string;
   onAction: () => void;
 };
 type RowActionMenuPlacement = "below" | "above" | "floating";
@@ -1443,6 +1444,7 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
             <UpdateActionButton
               state={actionState}
               disabled={isUninstalling}
+              readyLabel={appUpdateReadyLabel(app, snapshot, update)}
               onAction={() => void window.baseline.performAppUpdate(app.id)}
             />
           )}
@@ -1643,6 +1645,7 @@ function RecentAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
             <UpdateActionButton
               state={actionState}
               disabled={isUninstalling}
+              readyLabel={appUpdateReadyLabel(app, snapshot, update)}
               onAction={() => void window.baseline.performAppUpdate(app.id)}
             />
           )}
@@ -1702,6 +1705,7 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
                 ? {
                     state: actionState,
                     disabled: isUninstalling,
+                    readyLabel: appUpdateReadyLabel(app, snapshot, update),
                     onAction: () => void window.baseline.performAppUpdate(app.id)
                   }
                 : undefined
@@ -1789,6 +1793,7 @@ export function AppRow({
           <UpdateActionButton
             state={actionState}
             disabled={isUninstalling}
+            readyLabel={appUpdateReadyLabel(app, snapshot, update)}
             onAction={() => void window.baseline.performAppUpdate(app.id)}
           />
         )}
@@ -2696,7 +2701,9 @@ function RowMoreActionButton({
             <span className="failure-glyph">!</span>
           )}
           <span>
-            {updateAction.state.type === "ready" ? "Update" : actionStateLabel(updateAction.state)}
+            {updateAction.state.type === "ready"
+              ? (updateAction.readyLabel ?? "Update")
+              : actionStateLabel(updateAction.state)}
           </span>
         </button>
       )}
@@ -3159,6 +3166,7 @@ function SettingsPane({
                 description="Find updates for installed casks and formulae."
                 missingDetail="Homebrew is not detected on this Mac. Install Homebrew to enable this source."
                 ready={snapshot.isHomebrewInstalled}
+                readyDetail={homebrewReadyDetail(snapshot)}
               />
               <ToolStatus
                 label="mas"
@@ -3743,17 +3751,19 @@ function ToolStatus({
   description,
   missingDetail,
   ready,
+  readyDetail,
   enabled = true
 }: {
   label: string;
   description: string;
   missingDetail: string;
   ready: boolean;
+  readyDetail?: string;
   enabled?: boolean;
 }) {
   const active = ready && enabled;
   const statusLabel = ready ? (enabled ? "Enabled" : "Not used") : "Not detected";
-  const detail = ready ? description : `${description} ${missingDetail}`;
+  const detail = ready ? (readyDetail ?? description) : `${description} ${missingDetail}`;
   return (
     <div className="settings-row settings-row-status">
       <SettingsRowText label={label} description={detail} />
@@ -3763,6 +3773,35 @@ function ToolStatus({
       </span>
     </div>
   );
+}
+
+function homebrewReadyDetail(snapshot: BaselineSnapshot): string {
+  const caskCount = snapshot.homebrewItems.filter((item) => item.kind === "cask").length;
+  const formulaCount = snapshot.homebrewItems.filter((item) => item.kind === "formula").length;
+  const appLinkedCaskCount = snapshot.homebrewItems.filter(
+    (item) => item.kind === "cask" && item.appID
+  ).length;
+
+  if (caskCount === 0) {
+    return `Homebrew detected with 0 installed casks and ${countLabel(
+      formulaCount,
+      "formula",
+      "formulae"
+    )}; app updates will not use Homebrew unless a matching cask is installed.`;
+  }
+
+  return `Homebrew detected with ${countLabel(
+    caskCount,
+    "installed cask"
+  )}, ${countLabel(appLinkedCaskCount, "app-linked cask")}, and ${countLabel(
+    formulaCount,
+    "formula",
+    "formulae"
+  )}.`;
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 
 type ProfileSummary = {
@@ -4015,9 +4054,24 @@ function startedUsingSummary(createdAt: string): ProfileSummary["startedUsing"] 
 }
 
 function sourceLabel(update: UpdateRecord): string {
-  if (update.source === "appStore") return "App Store";
-  if (update.source === "sparkle") return "Sparkle";
-  if (update.source === "homebrew") return "Homebrew";
+  if (update.source === "unknown") return "Update";
+  return sourceDisplayName(update.source);
+}
+
+function appUpdateReadyLabel(
+  app: AppRecord,
+  snapshot: BaselineSnapshot,
+  update: UpdateRecord
+): string {
+  if (update.source === "homebrew" && !uninstallableHomebrewItemForApp(app, snapshot)) {
+    return "Open app";
+  }
+  if (update.source === "sparkle") {
+    return "Open updater";
+  }
+  if (update.source === "web") {
+    return "Open website";
+  }
   return "Update";
 }
 

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -5,6 +5,8 @@ import type { BaselineSnapshot, UpdateSource } from "./domain";
 import { sourceDisplayName } from "./domain";
 import { formatAppDisplayVersion, type AppMetadata } from "./appMetadata";
 
+const routeExceptionLimit = 10;
+
 export function renderDiagnostics(
   snapshot: BaselineSnapshot,
   appMetadata: Pick<AppMetadata, "version" | "buildNumber"> | string = "Unknown",
@@ -32,6 +34,7 @@ export function renderDiagnostics(
       app.hasAppStoreEvidence !== true &&
       !snapshot.homebrewItems.some((item) => item.kind === "cask" && item.appID === app.id)
   );
+  const routeExceptions = routeExceptionRows(snapshot, routeExceptionLimit);
 
   const safeLastMessage = (snapshot.refreshErrorMessage ?? snapshot.lastRefreshNoticeMessage)
     ?.split(/\r?\n/u)[0]
@@ -69,6 +72,14 @@ export function renderDiagnostics(
     `- Homebrew app updates without installed cask link: ${
       homebrewAppUpdates.length - homebrewAppUpdatesWithInstalledCask.length
     }`,
+    "",
+    "Route Exceptions",
+    routeExceptions.total === 0
+      ? "- None"
+      : `- Listed: ${routeExceptions.rows.length} of ${routeExceptions.total}${
+          routeExceptions.truncated ? " (truncated)" : ""
+        }`,
+    ...routeExceptions.rows.map((row) => `- ${formatRouteException(row)}`),
     "",
     "Homebrew",
     `- Homebrew detected: ${yesNo(snapshot.isHomebrewInstalled)}`,
@@ -119,6 +130,121 @@ function formatSourceCounts(counts: Map<UpdateSource, number>): string {
     .map(([source, count]) => `${sourceDisplayName(source)}: ${count}`)
     .join(", ");
   return formatted || "None";
+}
+
+type RouteExceptionRow = {
+  actionRoute: string;
+  bundleIdentifier: string;
+  displayName: string;
+  linkedCask: boolean;
+  reason: string;
+  selectedSource: UpdateSource;
+  sourceHint: UpdateSource;
+};
+
+function routeExceptionRows(
+  snapshot: BaselineSnapshot,
+  limit: number
+): { rows: RouteExceptionRow[]; total: number; truncated: boolean } {
+  const appByID = new Map(snapshot.apps.map((app) => [app.id, app]));
+  const rows = snapshot.updates.flatMap((update) => {
+    if (update.source !== "homebrew") {
+      return [];
+    }
+    const app = appByID.get(update.appID);
+    if (!app) {
+      return [];
+    }
+    const linkedCask = linkedHomebrewCaskForUpdate(snapshot, update);
+    if (linkedCask) {
+      return [];
+    }
+    return [
+      {
+        actionRoute: actionRouteForUpdate(snapshot, update),
+        bundleIdentifier: diagnosticField(app.bundleIdentifier, "Not reported"),
+        displayName: diagnosticField(app.displayName, "Unknown app"),
+        linkedCask: false,
+        reason: "Homebrew selected without installed cask link",
+        selectedSource: update.source,
+        sourceHint: app.sourceHint
+      }
+    ];
+  });
+
+  return {
+    rows: rows.slice(0, limit),
+    total: rows.length,
+    truncated: rows.length > limit
+  };
+}
+
+function linkedHomebrewCaskForUpdate(
+  snapshot: BaselineSnapshot,
+  update: { appID: string; homebrewToken?: string }
+) {
+  return snapshot.homebrewItems.find(
+    (item) =>
+      item.kind === "cask" &&
+      item.appID === update.appID &&
+      (!update.homebrewToken || item.token.toLowerCase() === update.homebrewToken.toLowerCase())
+  );
+}
+
+function actionRouteForUpdate(
+  snapshot: BaselineSnapshot,
+  update: {
+    appID: string;
+    source: UpdateSource;
+    appStoreItemID?: number;
+    homebrewToken?: string;
+    updateURL?: string;
+  }
+): string {
+  if (update.source === "homebrew") {
+    return linkedHomebrewCaskForUpdate(snapshot, update)
+      ? "Homebrew cask update"
+      : update.homebrewToken
+        ? "Open app"
+        : externalOrAppRoute(update);
+  }
+  if (update.source === "appStore" && snapshot.useMasForAppStoreUpdates && update.appStoreItemID) {
+    return "App Store helper";
+  }
+  return externalOrAppRoute(update);
+}
+
+function externalOrAppRoute(update: { source: UpdateSource; updateURL?: string }): string {
+  if (!update.updateURL) {
+    return "Open app";
+  }
+  if (update.source === "appStore") {
+    return "Open App Store URL";
+  }
+  if (update.source === "sparkle") {
+    return "Open publisher updater URL";
+  }
+  if (update.source === "web") {
+    return "Open publisher website";
+  }
+  return "Open external URL";
+}
+
+function formatRouteException(row: RouteExceptionRow): string {
+  return [
+    row.displayName,
+    `bundle: ${row.bundleIdentifier}`,
+    `hint: ${sourceDisplayName(row.sourceHint)}`,
+    `selected: ${sourceDisplayName(row.selectedSource)}`,
+    `action: ${row.actionRoute}`,
+    `linked cask: ${yesNo(row.linkedCask)}`,
+    `reason: ${row.reason}`
+  ].join(" | ");
+}
+
+function diagnosticField(value: string | undefined, fallback: string): string {
+  const normalized = value?.replace(/\s+/gu, " ").replace(/\|/gu, "/").trim();
+  return normalized || fallback;
 }
 
 function appearanceLabel(value: BaselineSnapshot["appearancePreference"]): string {

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { BaselineSnapshot, UpdateSource } from "./domain";
-import { sourceDisplayName } from "./domain";
+import { homebrewPresentationLabel, sourceDisplayName } from "./domain";
+import { homebrewItemHasAppRepresentation } from "./homebrewAppLinking";
 import { formatAppDisplayVersion, type AppMetadata } from "./appMetadata";
 
 const routeExceptionLimit = 10;
@@ -16,7 +17,13 @@ export function renderDiagnostics(
   const appHintCounts = sourceCounts(snapshot.apps.map((app) => app.sourceHint));
   const homebrewFormulas = snapshot.homebrewItems.filter((item) => item.kind === "formula");
   const homebrewCasks = snapshot.homebrewItems.filter((item) => item.kind === "cask");
-  const appLinkedCasks = homebrewCasks.filter((item) => Boolean(item.appID));
+  const appLinkedCasks = homebrewCasks.filter((item) =>
+    homebrewItemHasAppRepresentation(item, snapshot.apps)
+  );
+  const appLinkedCaskIDs = new Set(appLinkedCasks.map((item) => item.appID).filter(Boolean));
+  const appsLinkedToHomebrewCasks = snapshot.apps.filter((app) => appLinkedCaskIDs.has(app.id));
+  const appsNotLinkedToHomebrewCasks = snapshot.apps.length - appsLinkedToHomebrewCasks.length;
+  const casksByPresentation = formatCaskPresentationCounts(homebrewCasks);
   const homebrewAppUpdates = snapshot.updates.filter((update) => update.source === "homebrew");
   const homebrewAppUpdatesWithInstalledCask = homebrewAppUpdates.filter((update) =>
     snapshot.homebrewItems.some(
@@ -61,7 +68,9 @@ export function renderDiagnostics(
   lines.push(
     "",
     "Apps",
-    `- Scanned apps: ${snapshot.apps.length}`,
+    `- Scanned app bundles: ${snapshot.apps.length}`,
+    `- App bundles linked to Homebrew casks: ${appsLinkedToHomebrewCasks.length}`,
+    `- App bundles not linked to Homebrew casks: ${appsNotLinkedToHomebrewCasks}`,
     `- Available updates: ${snapshot.updates.length}`,
     `- Ignored: ${snapshot.ignoredIDs.length}`,
     `- Source hints: ${formatSourceCounts(appHintCounts)}`,
@@ -86,6 +95,7 @@ export function renderDiagnostics(
     `- Items: ${snapshot.homebrewItems.length}`,
     `- Formulae: ${homebrewFormulas.length}`,
     `- Casks: ${homebrewCasks.length}`,
+    `- Cask presentations: ${casksByPresentation}`,
     `- App-linked casks: ${appLinkedCasks.length}`,
     `- Outdated: ${snapshot.homebrewItems.filter((item) => item.isOutdated).length}`,
     `- Installed/current: ${snapshot.homebrewItems.filter((item) => !item.isOutdated).length}`,
@@ -128,6 +138,21 @@ function formatSourceCounts(counts: Map<UpdateSource, number>): string {
   const formatted = [...counts.entries()]
     .filter(([, count]) => count > 0)
     .map(([source, count]) => `${sourceDisplayName(source)}: ${count}`)
+    .join(", ");
+  return formatted || "None";
+}
+
+function formatCaskPresentationCounts(
+  casks: Array<Pick<BaselineSnapshot["homebrewItems"][number], "kind" | "presentation">>
+): string {
+  const counts = new Map<string, number>();
+  for (const cask of casks) {
+    const label = homebrewPresentationLabel(cask.kind, cask.presentation);
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  const formatted = [...counts.entries()]
+    .filter(([, count]) => count > 0)
+    .map(([label, count]) => `${label}: ${count}`)
     .join(", ");
   return formatted || "None";
 }

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -10,15 +10,28 @@ export function renderDiagnostics(
   appMetadata: Pick<AppMetadata, "version" | "buildNumber"> | string = "Unknown",
   platform = process.platform
 ): string {
-  const updatesBySource = new Map<UpdateSource, number>();
-  for (const update of snapshot.updates) {
-    updatesBySource.set(update.source, (updatesBySource.get(update.source) ?? 0) + 1);
-  }
-
-  const sourceCounts = [...updatesBySource.entries()]
-    .filter(([, count]) => count > 0)
-    .map(([source, count]) => `${sourceDisplayName(source)}: ${count}`)
-    .join(", ");
+  const updateSourceCounts = sourceCounts(snapshot.updates.map((update) => update.source));
+  const appHintCounts = sourceCounts(snapshot.apps.map((app) => app.sourceHint));
+  const homebrewFormulas = snapshot.homebrewItems.filter((item) => item.kind === "formula");
+  const homebrewCasks = snapshot.homebrewItems.filter((item) => item.kind === "cask");
+  const appLinkedCasks = homebrewCasks.filter((item) => Boolean(item.appID));
+  const homebrewAppUpdates = snapshot.updates.filter((update) => update.source === "homebrew");
+  const homebrewAppUpdatesWithInstalledCask = homebrewAppUpdates.filter((update) =>
+    snapshot.homebrewItems.some(
+      (item) =>
+        item.kind === "cask" &&
+        item.appID === update.appID &&
+        (!update.homebrewToken || item.token.toLowerCase() === update.homebrewToken.toLowerCase())
+    )
+  );
+  const publisherUpdaterApps = snapshot.apps.filter((app) => Boolean(app.sparkleFeedURL));
+  const directDownloadCandidates = snapshot.apps.filter(
+    (app) =>
+      app.sourceHint === "unknown" &&
+      !app.sparkleFeedURL &&
+      app.hasAppStoreEvidence !== true &&
+      !snapshot.homebrewItems.some((item) => item.kind === "cask" && item.appID === app.id)
+  );
 
   const safeLastMessage = (snapshot.refreshErrorMessage ?? snapshot.lastRefreshNoticeMessage)
     ?.split(/\r?\n/u)[0]
@@ -48,15 +61,25 @@ export function renderDiagnostics(
     `- Scanned apps: ${snapshot.apps.length}`,
     `- Available updates: ${snapshot.updates.length}`,
     `- Ignored: ${snapshot.ignoredIDs.length}`,
-    `- Sources: ${sourceCounts || "None"}`,
+    `- Source hints: ${formatSourceCounts(appHintCounts)}`,
+    `- Update sources: ${formatSourceCounts(updateSourceCounts)}`,
+    `- Apps with publisher updater feed: ${publisherUpdaterApps.length}`,
+    `- Direct-download candidates without known feed: ${directDownloadCandidates.length}`,
+    `- Homebrew app updates with installed cask link: ${homebrewAppUpdatesWithInstalledCask.length}`,
+    `- Homebrew app updates without installed cask link: ${
+      homebrewAppUpdates.length - homebrewAppUpdatesWithInstalledCask.length
+    }`,
     "",
     "Homebrew",
+    `- Homebrew detected: ${yesNo(snapshot.isHomebrewInstalled)}`,
     `- Items: ${snapshot.homebrewItems.length}`,
+    `- Formulae: ${homebrewFormulas.length}`,
+    `- Casks: ${homebrewCasks.length}`,
+    `- App-linked casks: ${appLinkedCasks.length}`,
     `- Outdated: ${snapshot.homebrewItems.filter((item) => item.isOutdated).length}`,
     `- Installed/current: ${snapshot.homebrewItems.filter((item) => !item.isOutdated).length}`,
     `- Recently updated: ${snapshot.homebrewRecentlyUpdated.length}`,
     `- Ignored: ${snapshot.ignoredHomebrewItemIDs.length}`,
-    `- Homebrew available for helper install: ${yesNo(snapshot.isHomebrewInstalled)}`,
     "",
     "Optional Tools",
     `- mas installed: ${yesNo(snapshot.isMasInstalled)}`,
@@ -80,6 +103,22 @@ function diagnosticsAppVersion(
 
 function yesNo(value: boolean): string {
   return value ? "Yes" : "No";
+}
+
+function sourceCounts(sources: UpdateSource[]): Map<UpdateSource, number> {
+  const counts = new Map<UpdateSource, number>();
+  for (const source of sources) {
+    counts.set(source, (counts.get(source) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function formatSourceCounts(counts: Map<UpdateSource, number>): string {
+  const formatted = [...counts.entries()]
+    .filter(([, count]) => count > 0)
+    .map(([source, count]) => `${sourceDisplayName(source)}: ${count}`)
+    .join(", ");
+  return formatted || "None";
 }
 
 function appearanceLabel(value: BaselineSnapshot["appearancePreference"]): string {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -317,9 +317,9 @@ export function homebrewDiscoverID(kind: HomebrewManagedItemKind, token: string)
 export function sourceDisplayName(source: UpdateSource): string {
   return {
     appStore: "App Store",
-    sparkle: "Sparkle",
+    sparkle: "In-app updater",
     homebrew: "Homebrew",
-    web: "Web",
+    web: "Publisher website",
     unknown: "Unknown"
   }[source];
 }

--- a/src/shared/homebrewAppLinking.ts
+++ b/src/shared/homebrewAppLinking.ts
@@ -1,20 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Arshia Ghaffarian
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type {
-  AppRecord,
-  HomebrewCaskDiscoveryItem,
-  HomebrewManagedItem,
-  UpdateRecord
-} from "./domain";
+import type { AppRecord, HomebrewCaskDiscoveryItem, HomebrewManagedItem } from "./domain";
 
 export function homebrewItemHasAppRepresentation(
   item: Pick<HomebrewManagedItem, "kind" | "token"> &
     Partial<
       Pick<HomebrewManagedItem, "appID" | "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">
     >,
-  apps: AppRecord[],
-  updatesByAppID: Map<string, UpdateRecord>
+  apps: AppRecord[]
 ): boolean {
   if (!isCask(item.kind)) {
     return false;
@@ -23,17 +17,7 @@ export function homebrewItemHasAppRepresentation(
     return true;
   }
 
-  const identifiers = homebrewItemIdentifiers(item);
-  return apps.some((app) => {
-    const update = updatesByAppID.get(app.id);
-    if (app.sourceHint === "sparkle") {
-      return false;
-    }
-    if (update?.homebrewToken && identifiers.has(normalizedHomebrewAppName(update.homebrewToken))) {
-      return true;
-    }
-    return false;
-  });
+  return false;
 }
 
 export function homebrewItemMatchesApp(
@@ -51,21 +35,6 @@ export function homebrewItemMatchesApp(
   }
 
   return false;
-}
-
-export function homebrewItemIdentifiers(
-  item: Pick<HomebrewManagedItem, "token"> &
-    Partial<Pick<HomebrewManagedItem, "name"> & Pick<HomebrewCaskDiscoveryItem, "displayName">>
-): Set<string> {
-  return new Set(
-    [item.token, item.name, item.displayName]
-      .filter((value): value is string => Boolean(value))
-      .map(normalizedHomebrewAppName)
-  );
-}
-
-export function normalizedHomebrewAppName(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
 }
 
 export function isCask(kind: string): boolean {


### PR DESCRIPTION
## Summary
- Baseline could treat Homebrew cask catalog matches as app update routes even when the cask was not installed, so direct-download or self-updating apps on Macs with Homebrew could open Homebrew update URLs.
- Require installed Homebrew cask ownership before creating, displaying, running, or de-duping Homebrew-backed app updates; unowned or stale persisted Homebrew app update rows fall back to opening the installed app or are discarded before display.
- Clarify update source wording for publisher/in-app update paths and Homebrew Settings status so users can tell when Homebrew exists but does not manage GUI apps.
- Expand diagnostics with app-bundle/Homebrew overlap counts, Homebrew app route exceptions, cask presentation counts, and route evidence for remote support debugging without dumping full app paths.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`
- `npm audit --omit=dev --audit-level=high`