### PR TITLE
Preserve build-only Homebrew cask updates

### DIFF
--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -270,6 +270,62 @@ describe("update store helpers", () => {
     expect(reconciled.find((item) => item.id === "cask:notion")?.isOutdated).toBe(false);
   });
 
+  it("keeps same-version cask updates when cask outdated detection is unreliable", () => {
+    const current = [
+      homebrewItem({
+        id: "cask:build-only-cask",
+        token: "build-only-cask",
+        name: "Build Only Cask",
+        kind: "cask",
+        installedVersion: version("1.0.0"),
+        isOutdated: false
+      }),
+      homebrewItem({
+        id: "formula:same-version-formula",
+        token: "same-version-formula",
+        name: "same-version-formula",
+        kind: "formula",
+        installedVersion: version("1.0.0"),
+        isOutdated: false
+      })
+    ];
+    const previous = [
+      homebrewItem({
+        id: "cask:build-only-cask",
+        token: "build-only-cask",
+        name: "Build Only Cask",
+        kind: "cask",
+        installedVersion: version("1.0.0"),
+        latestVersion: version("1.0.0"),
+        isOutdated: true,
+        releaseDate: "2026-06-01T12:00:00.000Z"
+      }),
+      homebrewItem({
+        id: "formula:same-version-formula",
+        token: "same-version-formula",
+        name: "same-version-formula",
+        kind: "formula",
+        installedVersion: version("1.0.0"),
+        latestVersion: version("1.0.0"),
+        isOutdated: true
+      })
+    ];
+
+    const reconciled = preservePreviousHomebrewOutdatedState(current, previous, {
+      formula: false,
+      cask: false
+    });
+
+    expect(reconciled.find((item) => item.id === "cask:build-only-cask")).toMatchObject({
+      latestVersion: version("1.0.0"),
+      isOutdated: true,
+      releaseDate: "2026-06-01T12:00:00.000Z"
+    });
+    const formula = reconciled.find((item) => item.id === "formula:same-version-formula");
+    expect(formula?.isOutdated).toBe(false);
+    expect(formula?.latestVersion).toBeUndefined();
+  });
+
   it("persists resolved additional scan directories", async () => {
     let userData = "";
     const store = await makeStore({

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -122,6 +122,48 @@ describe("update store helpers", () => {
     ]);
   });
 
+  it("records completed same-version cask updates as recently updated", () => {
+    const now = "2026-04-30T12:00:00.000Z";
+    const records = mergeHomebrewRecentlyUpdatedRecords(
+      [],
+      [
+        homebrewItem({
+          id: "cask:build-only-cask",
+          token: "build-only-cask",
+          name: "Build Only Cask",
+          kind: "cask",
+          installedVersion: version("1.0.0"),
+          latestVersion: version("1.0.0"),
+          isOutdated: true
+        })
+      ],
+      [
+        homebrewItem({
+          id: "cask:build-only-cask",
+          token: "build-only-cask",
+          name: "Build Only Cask",
+          kind: "cask",
+          installedVersion: version("1.0.0"),
+          isOutdated: false
+        })
+      ],
+      now,
+      {
+        completedItemIDs: ["cask:build-only-cask"],
+        currentDate: new Date("2026-05-01T12:00:00.000Z")
+      }
+    );
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        itemID: "cask:build-only-cask",
+        kind: "cask",
+        fromVersion: version("1.0.0"),
+        toVersion: version("1.0.0")
+      })
+    ]);
+  });
+
   it("keeps the newest Homebrew recent record per item", () => {
     const records = mergeHomebrewRecentlyUpdatedRecords(
       [
@@ -1543,7 +1585,7 @@ describe("update store helpers", () => {
   });
 
   it("preserves cask updates when only Homebrew build metadata changed", async () => {
-    const buildOnlyCask = homebrewItem({
+    const outdatedBuildOnlyCask = homebrewItem({
       id: "cask:build-only-cask",
       token: "build-only-cask",
       name: "Build Only Cask",
@@ -1552,6 +1594,11 @@ describe("update store helpers", () => {
       latestVersion: version("1.0.0"),
       isOutdated: true
     });
+    const currentBuildOnlyCask = homebrewItem({
+      ...outdatedBuildOnlyCask,
+      latestVersion: undefined,
+      isOutdated: false
+    });
     const runBrewCommand = vi.fn<
       NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
     >(async () => ({
@@ -1559,14 +1606,18 @@ describe("update store helpers", () => {
       status: 0,
       output: ""
     }));
+    let inventoryCalls = 0;
     const store = await makeStore({
       clients: {
         homebrewInventory: {
-          fetchInventory: async () => ({
-            items: [buildOnlyCask],
-            outdatedDetectionSucceeded: true,
-            outdatedDetectionSucceededByKind: { formula: true, cask: true }
-          })
+          fetchInventory: async () => {
+            inventoryCalls += 1;
+            return {
+              items: [inventoryCalls > 1 ? currentBuildOnlyCask : outdatedBuildOnlyCask],
+              outdatedDetectionSucceeded: true,
+              outdatedDetectionSucceededByKind: { formula: true, cask: true }
+            };
+          }
         }
       },
       runBrewCommand
@@ -1587,6 +1638,13 @@ describe("update store helpers", () => {
       ["upgrade", "--cask", "--greedy", "build-only-cask"],
       ["autoremove"],
       ["cleanup"]
+    ]);
+    expect(store.getSnapshot().homebrewRecentlyUpdated).toEqual([
+      expect.objectContaining({
+        itemID: "cask:build-only-cask",
+        fromVersion: version("1.0.0"),
+        toVersion: version("1.0.0")
+      })
     ]);
   });
 

--- a/ElectronTests/updateStore.test.ts
+++ b/ElectronTests/updateStore.test.ts
@@ -1486,6 +1486,54 @@ describe("update store helpers", () => {
     });
   });
 
+  it("preserves cask updates when only Homebrew build metadata changed", async () => {
+    const buildOnlyCask = homebrewItem({
+      id: "cask:build-only-cask",
+      token: "build-only-cask",
+      name: "Build Only Cask",
+      kind: "cask",
+      installedVersion: version("1.0.0"),
+      latestVersion: version("1.0.0"),
+      isOutdated: true
+    });
+    const runBrewCommand = vi.fn<
+      NonNullable<ConstructorParameters<typeof UpdateStore>[0]["runBrewCommand"]>
+    >(async () => ({
+      success: true,
+      status: 0,
+      output: ""
+    }));
+    const store = await makeStore({
+      clients: {
+        homebrewInventory: {
+          fetchInventory: async () => ({
+            items: [buildOnlyCask],
+            outdatedDetectionSucceeded: true,
+            outdatedDetectionSucceededByKind: { formula: true, cask: true }
+          })
+        }
+      },
+      runBrewCommand
+    });
+
+    await store.refresh(false);
+
+    expect(store.getSnapshot().homebrewItems[0]).toMatchObject({
+      id: "cask:build-only-cask",
+      latestVersion: version("1.0.0"),
+      isOutdated: true
+    });
+
+    await store.performHomebrewUpdateAll(["cask:build-only-cask"]);
+
+    expect(runBrewCommand.mock.calls.map(([command]) => command)).toEqual([
+      ["update"],
+      ["upgrade", "--cask", "--greedy", "build-only-cask"],
+      ["autoremove"],
+      ["cleanup"]
+    ]);
+  });
+
   it("does not use loose name matches to change cask installed versions", async () => {
     const sameNameApp = appRecord({
       bundlePath: "/Applications/Self Updating App.app",

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -2098,8 +2098,17 @@ function reconcileHomebrewInventory(
     const presentation: HomebrewManagedItem["presentation"] = appID
       ? "app"
       : (caskEntry?.presentation ?? previousItem?.presentation ?? item.presentation);
+    const latestVersionComparison = latestVersion
+      ? compareVersions(latestVersion, installedVersion)
+      : undefined;
+    const keepHomebrewReportedSameVersionUpdate =
+      latestVersion !== undefined &&
+      homebrewReportedSameVersionCaskUpdate(item, installedVersion, latestVersion);
 
-    if (!latestVersion || !isVersionGreater(latestVersion, installedVersion)) {
+    if (
+      !latestVersion ||
+      ((latestVersionComparison ?? 0) <= 0 && !keepHomebrewReportedSameVersionUpdate)
+    ) {
       return {
         ...item,
         appID,
@@ -2198,6 +2207,18 @@ function bestHomebrewCaskLatestVersion(
   }
   return candidates.reduce((latest, candidate) =>
     compareVersions(candidate, latest) > 0 ? candidate : latest
+  );
+}
+
+function homebrewReportedSameVersionCaskUpdate(
+  item: HomebrewManagedItem,
+  installedVersion: VersionValue,
+  latestVersion: VersionValue
+): boolean {
+  return (
+    item.isOutdated &&
+    compareVersions(latestVersion, installedVersion) === 0 &&
+    compareVersions(installedVersion, item.installedVersion) === 0
   );
 }
 

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -2004,9 +2004,17 @@ export function preservePreviousHomebrewOutdatedState(
     if (!previous?.isOutdated) {
       return item;
     }
+    const preserveSameVersionCaskUpdate =
+      previous.latestVersion !== undefined &&
+      homebrewReportedSameVersionCaskUpdate(
+        previous,
+        item.installedVersion,
+        previous.latestVersion
+      );
     if (
       previous.latestVersion &&
-      !isVersionGreater(previous.latestVersion, item.installedVersion)
+      !isVersionGreater(previous.latestVersion, item.installedVersion) &&
+      !preserveSameVersionCaskUpdate
     ) {
       return item;
     }
@@ -2216,6 +2224,7 @@ function homebrewReportedSameVersionCaskUpdate(
   latestVersion: VersionValue
 ): boolean {
   return (
+    item.kind === "cask" &&
     item.isOutdated &&
     compareVersions(latestVersion, installedVersion) === 0 &&
     compareVersions(installedVersion, item.installedVersion) === 0

--- a/src/main/updateStore.ts
+++ b/src/main/updateStore.ts
@@ -1214,7 +1214,8 @@ export class UpdateStore extends EventEmitter<StoreEvents> {
         this.state.homebrewRecentlyUpdated,
         previousHomebrewItems,
         reconciledHomebrewItems,
-        now
+        now,
+        { completedItemIDs: this.state.homebrewUpdatedPendingRefreshItemIDs }
       );
       const preserveHomebrewCommandState =
         this.isHomebrewCommandActive() && !options.allowHomebrewInventoryDuringActiveCommand;
@@ -2157,17 +2158,29 @@ export function mergeHomebrewRecentlyUpdatedRecords(
   previousItems: HomebrewManagedItem[],
   currentItems: HomebrewManagedItem[],
   now: string,
-  options: { currentDate?: Date } = {}
+  options: { completedItemIDs?: string[]; currentDate?: Date } = {}
 ): HomebrewRecentlyUpdatedRecord[] {
   const records = [...existingRecords];
   const previousByID = new Map(previousItems.map((item) => [item.id, item]));
+  const completedItemIDs = new Set(options.completedItemIDs ?? []);
 
   for (const currentItem of currentItems) {
     const previousItem = previousByID.get(currentItem.id);
     if (!previousItem) {
       continue;
     }
-    if (compareVersions(currentItem.installedVersion, previousItem.installedVersion) <= 0) {
+    const versionComparison = compareVersions(
+      currentItem.installedVersion,
+      previousItem.installedVersion
+    );
+    const completedSameVersionCaskUpdate =
+      versionComparison === 0 &&
+      currentItem.kind === "cask" &&
+      previousItem.kind === "cask" &&
+      previousItem.isOutdated &&
+      !currentItem.isOutdated &&
+      completedItemIDs.has(currentItem.id);
+    if (versionComparison < 0 || (versionComparison === 0 && !completedSameVersionCaskUpdate)) {
       continue;
     }
     records.unshift({


### PR DESCRIPTION
Fixes #185

## Summary

- Preserve Homebrew-reported cask updates when the normalized installed and latest versions compare equal, covering comma-suffixed build metadata changes.
- Keep stale app-linked cask updates suppressed when the scanned app version has already advanced beyond Homebrew inventory.
- Record completed same-version cask upgrades in Recently Updated after the follow-up inventory refresh reports them current.
- Add update-store regression coverage that verifies same-version cask updates remain visible, eligible for `Update Brews`, and retained in recent history after completion.

## Validation

- `npm test -- --run ElectronTests/updateStore.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format`