### PR TITLE
Compact long version labels on update cards

### DIFF
--- a/ElectronTests/rendererButtons.test.tsx
+++ b/ElectronTests/rendererButtons.test.tsx
@@ -2052,6 +2052,56 @@ describe("renderer button parity", () => {
     ]);
   });
 
+  it("shows only the new version on update cards when version labels are long", () => {
+    const longVersionApp: AppRecord = {
+      ...app,
+      id: "app:long-version",
+      displayName: "Long Version App",
+      bundleIdentifier: "com.example.long-version",
+      localVersion: version("2026.625.2148")
+    };
+    const longVersionUpdate: UpdateRecord = {
+      id: longVersionApp.id,
+      appID: longVersionApp.id,
+      source: "appStore",
+      supportLevel: "supported",
+      localVersion: version("2026.625.2148"),
+      remoteVersion: version("2026.628.2035"),
+      checkedAt: "2026-04-30T12:00:00.000Z"
+    };
+    const longVersionFormula: HomebrewManagedItem = {
+      id: "formula:long-version-tool",
+      token: "long-version-tool",
+      name: "Long Version Tool",
+      kind: "formula",
+      installedVersion: version("116.0.5845.179"),
+      latestVersion: version("117.0.5938.132"),
+      isOutdated: true
+    };
+    const { container } = render(
+      <Dashboard
+        compact={false}
+        onOpenSettings={() => undefined}
+        snapshot={snapshot({
+          apps: [longVersionApp],
+          updates: [longVersionUpdate],
+          homebrewItems: [longVersionFormula]
+        })}
+      />
+    );
+
+    const cards = Array.from(container.querySelectorAll(".update-card"));
+    const appCard = cards.find((card) => card.textContent?.includes(longVersionApp.displayName));
+    const homebrewCard = cards.find((card) => card.textContent?.includes(longVersionFormula.name));
+
+    expect(appCard).toHaveTextContent("2026.628.2035");
+    expect(appCard).not.toHaveTextContent("2026.625.2148");
+    expect(appCard).not.toHaveTextContent("→");
+    expect(homebrewCard).toHaveTextContent("117.0.5938.132");
+    expect(homebrewCard).not.toHaveTextContent("116.0.5845.179");
+    expect(homebrewCard).not.toHaveTextContent("→");
+  });
+
   it("shows updated aggregate state in the combined updates section", () => {
     const formula: HomebrewManagedItem = {
       id: "formula:ripgrep",

--- a/e2e/electron-smoke.spec.ts
+++ b/e2e/electron-smoke.spec.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { _electron as electron, expect, test } from "@playwright/test";
-import { access, mkdtemp } from "node:fs/promises";
+import { access, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { defaultPersistedSnapshot } from "../src/shared/domain";
+import { version } from "../src/shared/version";
 
 const expectedBaselineAPI = [
   "acknowledgeProfileStatsReset",
@@ -218,6 +220,88 @@ test("reopens settings after renderer-side back navigation", async () => {
     await window.baseline.showSettings();
   });
   await expect(page.locator("h1")).toContainText("General");
+
+  await closeApp(app);
+});
+
+test("renders long update versions inside Electron update cards", async () => {
+  const userData = await mkdtemp(path.join(os.tmpdir(), "baseline-e2e-"));
+  const longVersionApp = {
+    id: "app:long-version",
+    bundlePath: "/Applications/Long Version.app",
+    displayName: "Long Version App",
+    bundleIdentifier: "com.example.long-version",
+    localVersion: version("2026.625.2148"),
+    sourceHint: "unknown" as const
+  };
+  const longVersionFormula = {
+    id: "formula:long-version-tool",
+    token: "long-version-tool",
+    name: "Long Version Tool",
+    kind: "formula" as const,
+    installedVersion: version("116.0.5845.179"),
+    latestVersion: version("117.0.5938.132"),
+    isOutdated: true
+  };
+
+  await writeFile(
+    path.join(userData, "baseline-snapshot.json"),
+    `${JSON.stringify(
+      {
+        ...defaultPersistedSnapshot("2026-04-30T12:00:00.000Z"),
+        apps: [longVersionApp],
+        updates: [
+          {
+            id: longVersionApp.id,
+            appID: longVersionApp.id,
+            source: "appStore",
+            supportLevel: "supported",
+            localVersion: version("2026.625.2148"),
+            remoteVersion: version("2026.628.2035"),
+            checkedAt: "2026-04-30T12:00:00.000Z"
+          }
+        ],
+        homebrewItems: [longVersionFormula],
+        showMenuBarIcon: false
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const app = await launchBaseline({ userData });
+  const page = await app.firstWindow();
+  await expect(page.locator("h1")).toContainText("All");
+  await expect(page.locator(".update-card")).toHaveCount(2);
+
+  const appCard = page.locator(".update-card").filter({ hasText: longVersionApp.displayName });
+  const formulaCard = page.locator(".update-card").filter({ hasText: longVersionFormula.name });
+  await expect(appCard).toContainText("2026.628.2035");
+  await expect(appCard).not.toContainText("2026.625.2148");
+  await expect(appCard).not.toContainText("→");
+  await expect(formulaCard).toContainText("117.0.5938.132");
+  await expect(formulaCard).not.toContainText("116.0.5845.179");
+  await expect(formulaCard).not.toContainText("→");
+
+  const versionLineMetrics = await page
+    .locator(".update-card .item-card-main p")
+    .evaluateAll((nodes) =>
+      nodes.map((node) => ({
+        clientWidth: node.clientWidth,
+        scrollWidth: node.scrollWidth,
+        text: node.textContent?.trim()
+      }))
+    );
+  expect(versionLineMetrics).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ text: "2026.628.2035" }),
+      expect.objectContaining({ text: "117.0.5938.132" })
+    ])
+  );
+  expect(versionLineMetrics.every((metrics) => metrics.scrollWidth <= metrics.clientWidth)).toBe(
+    true
+  );
 
   await closeApp(app);
 });

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -90,6 +90,7 @@ type SettingsSectionID = "general" | "profile" | "appearance" | "diagnostics";
 const ActionConfirmationContext = React.createContext<RequestActionConfirmation>(() => {});
 const sidebarIconStrokeWidth = 1.5;
 const toolbarIconStrokeWidth = 1.5;
+const compactVersionLabelMaxLength = 9;
 const settingsSidebarItems: Array<{
   id: SettingsSectionID;
   label: string;
@@ -1473,6 +1474,7 @@ function AppUpdateCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineSn
             <VersionChange
               from={appUpdateVersionChange(update).from}
               to={appUpdateVersionChange(update).to}
+              collapseLong
             />
           ) : (
             app.localVersion.raw || "unknown"
@@ -1732,6 +1734,7 @@ function IgnoredAppCard({ app, snapshot }: { app: AppRecord; snapshot: BaselineS
             <VersionChange
               from={appUpdateVersionChange(update).from}
               to={appUpdateVersionChange(update).to}
+              collapseLong
             />
           ) : (
             app.localVersion.raw || "unknown"
@@ -2156,6 +2159,7 @@ function HomebrewUpdateCard({
             <VersionChange
               from={item.installedVersion.raw || "unknown"}
               to={item.latestVersion.raw}
+              collapseLong
             />
           ) : (
             item.installedVersion.raw || "unknown"
@@ -2345,6 +2349,7 @@ function IgnoredHomebrewCard({
             <VersionChange
               from={item.installedVersion.raw || "unknown"}
               to={item.latestVersion.raw}
+              collapseLong
             />
           ) : (
             item.installedVersion.raw || "unknown"
@@ -3708,7 +3713,23 @@ function Empty({ text }: { text: string }) {
   return <p className="empty">{text}</p>;
 }
 
-function VersionChange({ from, to }: { from: string; to: string }) {
+function VersionChange({
+  from,
+  to,
+  collapseLong = false
+}: {
+  from: string;
+  to: string;
+  collapseLong?: boolean;
+}) {
+  if (collapseLong && hasLongVersionLabel(from, to)) {
+    return (
+      <span className="version-token" title={`${from} → ${to}`}>
+        {to}
+      </span>
+    );
+  }
+
   return (
     <>
       <span className="version-token">{from}</span>
@@ -3716,6 +3737,10 @@ function VersionChange({ from, to }: { from: string; to: string }) {
       <span className="version-token">{to}</span>
     </>
   );
+}
+
+function hasLongVersionLabel(...labels: string[]): boolean {
+  return labels.some((label) => label.length > compactVersionLabelMaxLength);
 }
 
 function appUpdateVersionChange(update: UpdateRecord): { from: string; to: string } {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -927,7 +927,10 @@ button:disabled {
 }
 
 .item-card .row-main p {
+  overflow: hidden;
   margin-top: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 13px;
 }
 


### PR DESCRIPTION
## Summary
- Collapse update-card version changes to the target version when either version label exceeds nine characters, preserving the full old-to-new value in the element title.
- Apply the compact behavior to app and Homebrew update cards while keeping row displays unchanged.
- Add renderer and Electron smoke coverage for long app and Homebrew version labels staying inside cards.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm run test:electron`